### PR TITLE
General improvements and fixes

### DIFF
--- a/src/app/services/eventdisplay.service.ts
+++ b/src/app/services/eventdisplay.service.ts
@@ -77,13 +77,9 @@ export class EventdisplayService {
    */
   public loadEventsFromJSON(eventsData: any): string[] {
     this.eventsData = eventsData;
-    const eventKeys = [];
-    for (const ev of Object.keys(eventsData)) {
-      if (eventsData[ev] != null) {
-        eventKeys.push(ev);
-      }
-    }
+    const eventKeys = this.configuration.getEventDataLoader().buildEventsList(eventsData);
     this.loadEvent(eventKeys[0]);
+
     return eventKeys;
   }
 
@@ -93,7 +89,12 @@ export class EventdisplayService {
    * @param eventKey string that represents the event in the eventsData object.
    */
   public loadEvent(eventKey: any) {
-    const event = this.eventsData[eventKey];
+    let event = this.eventsData[eventKey];
+
+    if(Array.isArray(event)){
+      event = event[0];
+    }
+
     if (event) {
       this.buildEventDataFromJSON(event);
     }
@@ -105,6 +106,11 @@ export class EventdisplayService {
    * @param eventData object containing the event data.
    */
   public buildEventDataFromJSON(eventData: any) {
+    // Creating UI folder
+    this.ui.addEventDataFolder();
+    // Clearing existing event data
+    this.graphicsLibrary.clearEventData();
+    // Build data and add to scene
     this.configuration.getEventDataLoader().buildEventData(eventData, this.graphicsLibrary, this.ui);
   }
 
@@ -136,15 +142,19 @@ export class EventdisplayService {
 
   public loadDisplay(input: any) {
     const phoenixScene = JSON.parse(input);
+    
     if (phoenixScene.sceneConfiguration && phoenixScene.scene) {
+      // Creating UI folder
+      this.ui.addEventDataFolder();
+      // Clearing existing event data
+      this.graphicsLibrary.clearEventData();
+      // Add to scene
       this.loadSceneConfiguration(phoenixScene.sceneConfiguration);
       this.graphicsLibrary.loadScene(phoenixScene.scene);
     }
   }
 
   private loadSceneConfiguration(sceneConfiguration: { eventData: {}; geometries: [] }) {
-    this.ui.addEventDataFolder();
-    this.graphicsLibrary.clearEventData();
     for (const objectType of Object.keys(sceneConfiguration.eventData)) {
       const typeFolder = this.ui.addEventDataTypeFolder(objectType);
       const collections = sceneConfiguration.eventData[objectType];

--- a/src/app/services/loaders/event-data-loader.ts
+++ b/src/app/services/loaders/event-data-loader.ts
@@ -2,6 +2,7 @@ import {ThreeService} from '../three.service';
 import {UIService} from '../ui.service';
 
 export interface EventDataLoader {
+  buildEventsList(eventsData: any): string[];
   buildEventData(eventData: any, graphicsLibrary: ThreeService, ui: UIService): void;
 
   getCollection(value: string): any;

--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -10,102 +10,137 @@ export class PhoenixLoader implements EventDataLoader {
   private ui: UIService;
   private eventData: any;
 
+
+  public buildEventsList(eventsData: any): string[]{
+    const eventsList: string[] = [];
+
+    for (const eventName of Object.keys(eventsData)) {
+      if (eventsData[eventName] !== null) eventsList.push(eventName);
+    }
+
+    return eventsList;
+  }
+
+  public buildCollectionsList(object: any): string[]{
+    const collectionsList: string[] = [];
+
+    for (const collectionName of Object.keys(object)) {
+      if(object[collectionName] !== null) collectionsList.push(collectionName);
+    }
+
+    return collectionsList;
+  }
+
+
   public buildEventData(eventData: any, graphicsLibrary: ThreeService, ui: UIService): void {
     this.graphicsLibrary = graphicsLibrary;
     this.ui = ui;
     this.eventData = eventData;
-    // Creating UI folder
-    this.ui.addEventDataFolder();
-    // Clearing existing event data
-    this.graphicsLibrary.clearEventData();
+
+    // initiate load
     this.loadObjectTypes(eventData);
   }
 
   private loadObjectTypes(eventData: any) {
     if (eventData.Tracks) {
-      const cuts = [
+      const cuts: Cut[] = [
         new Cut('chi2', 0, 50),
-        new Cut('dof', 0, 100)];
-      this.addEventCollections(eventData.Tracks, this.addTrack, 'Tracks', cuts);
+        new Cut('dof', 0, 100),
+        new Cut('mementum', 0, 500)
+      ];
+
+      this.addObject(eventData.Tracks, this.addTrack, 'Tracks', cuts);
     }
+
     if (eventData.Jets) {
       const cuts = [
         new Cut('phi', -Math.PI, Math.PI),
         new Cut('eta', 0, 100),
-        new Cut('energy', 2000, 10000)];
-      this.addEventCollections(eventData.Jets, this.addJet, 'Jets', cuts);
+        new Cut('energy', 2000, 10000)
+      ];
+
+      this.addObject(eventData.Jets, this.addJet, 'Jets', cuts);
     }
+
     if (eventData.Hits) {
-      this.addEventCollections(eventData.Hits, this.addHits, 'Hits');
+      this.addObject(eventData.Hits, this.addHits, 'Hits');
     }
+
     if (eventData.CaloClusters) {
       const cuts = [
         new Cut('phi', -Math.PI, Math.PI),
         new Cut('eta', 0, 100),
-        new Cut('energy', 2000, 10000)];
-      this.addEventCollections(eventData.CaloClusters, this.addCluster, 'CaloClusters', cuts);
+        new Cut('energy', 2000, 10000)
+      ];
+
+      this.addObject(eventData.CaloClusters, this.addCluster, 'CaloClusters', cuts);
     }
+
     if (eventData.Muons) {
-      this.addEventCollections(eventData.Muons, this.addMuon, 'Muons');
+      this.addObject(eventData.Muons, this.addMuon, 'Muons');
     }
   }
 
-  private addEventCollections(collections: any, addObject: any, objectType: string, cuts?: Cut[]) {
+  private addObject(object: any, addObject: any, objectType: string, cuts?: Cut[]) {
+
     const typeFolder = this.ui.addEventDataTypeFolder(objectType);
-    const typeGroup = this.graphicsLibrary.addEventDataTypeGroup(objectType);
-    for (const collname of Object.keys(collections)) {
-      const collection = collections[collname];
-      if (collection != null) {
-        this.addCollection(collection, collname, addObject, typeGroup);
-        this.ui.addCollection(typeFolder, collname, cuts);
-      }
+    const objectGroup = this.graphicsLibrary.addEventDataTypeGroup(objectType);
+
+    const collectionsList: string[] = this.buildCollectionsList(object);
+
+
+    for (const collectionName of collectionsList) {
+      const objectCollection = object[collectionName];
+
+      this.addCollection(objectCollection, collectionName, addObject, objectGroup);
+      this.ui.addCollection(typeFolder, collectionName, cuts);
     }
   }
 
-  private addCollection(collection: any, collname: string, addObject: (object: any, scene: any) => void, typeGroup: Group) {
+  private addCollection(objectCollection: any, collectionName: string, addObject: (object: any, scene: Object3D) => void, objectGroup: Group) {
     const collscene = new THREE.Group();
-    collscene.name = collname;
-    for (const object of collection) {
+    collscene.name = collectionName;
+
+    for (const object of objectCollection) {
       addObject.bind(this)(object, collscene);
     }
-    typeGroup.add(collscene);
+
+    objectGroup.add(collscene);
   }
 
-  protected addTrack(track: any, scene: Object3D): Object3D {
-    // Track with no points
-    if (!track.pos) {
-      return;
-    }
-
-    const length = 100;
-    let colour = 0xff0000;
-    if (track.color) {
-      colour = parseInt(track.color, 16);
-    }
-
+  protected addTrack(track: any, scene: Object3D): void {
     const positions = track.pos;
-    const numPoints = positions.length;
-    if (numPoints < 3) {
-      // Track with too few points
+    // Track with no points
+    if (!positions) {
       return;
     }
+
+    const numPoints = positions.length;
+    // Track with too few points
+    if (numPoints < 3) {
+      return;
+    }
+
     // Now sort these.
     positions.sort((a, b) => {
       const distA = a[0] * a[0] + a[1] * a[1] + a[2] * a[2];
       const distB = b[0] * b[0] + b[1] * b[1] + b[2] * b[2];
-      if (distA < distB) {
-        return -1;
-      }
-      if (distA > distB) {
-        return -1;
-      }
-      return 0;
+      
+      return distA - distB;
     });
 
+    //const length = 100;
+    let color;
+    if (track.color) {
+      color = parseInt(track.color, 16);
+    }else{
+      color = 0xff0000
+    }
+
     // Apply pT cut TODO - make this configurable.
-    if (track.hasOwnProperty('mom')) {
-      const mom = track.mom;
-      if (mom[0] * mom[0] + mom[1] * mom[1] + mom[2] * mom[2] < 0.25) {
+    const momentum = track.mom;
+    if (momentum) {
+      if (momentum[0] * momentum[0] + momentum[1] * momentum[1] + momentum[2] * momentum[2] < 0.25) {
         // console.log('Track mom<0.5 GeV. Skipping. Positions are: ' + positions + ' particle_id: ' + track.particle_id);
         return;
       }
@@ -117,19 +152,23 @@ export class PhoenixLoader implements EventDataLoader {
       points.push(new THREE.Vector3(positions[i][0], positions[i][1], positions[i][2]));
     }
 
+    // attributes
     const curve = new THREE.CatmullRomCurve3(points);
     const vertices = curve.getPoints(50);
+    // geometry
     const geometry = new THREE.BufferGeometry().setFromPoints(vertices);
-    const material = new THREE.LineBasicMaterial({color: colour});
+    // material
+    const material = new THREE.LineBasicMaterial({color: color});
     material.linewidth = 2;
+    // object
     const splineObject = new THREE.Line(geometry, material);
     splineObject.userData = track;
     splineObject.name = 'Track';
+    // add to scene
     scene.add(splineObject);
-    return splineObject;
   }
 
-  protected addJet(jet: any, scene: Object3D): Object3D {
+  protected addJet(jet: any, scene: Object3D): void {
     const eta = jet.eta;
     const phi = jet.phi;
     const theta = 2 * Math.atan(Math.pow(Math.E, eta));
@@ -161,10 +200,10 @@ export class PhoenixLoader implements EventDataLoader {
     mesh.userData = jet;
     mesh.name = 'Jet';
     scene.add(mesh);
-    return mesh;
   }
 
-  protected addHits(hits: any, scene: Object3D): Object3D {
+  protected addHits(hits: any, scene: Object3D): void {
+    // attributes
     const pointPos = new Float32Array(hits.length * 3);
     let i = 0;
     for (const hit of hits) {
@@ -173,24 +212,31 @@ export class PhoenixLoader implements EventDataLoader {
       pointPos[i + 2] = hit[2];
       i += 3;
     }
+
+    // geometry
     const geometry = new THREE.BufferGeometry();
     geometry.addAttribute('position', new THREE.BufferAttribute(pointPos, 3));
     geometry.computeBoundingSphere();
+    // material
     const material = new THREE.PointsMaterial({size: 10});
     material.color.set('#ff0000');
+    // object
     const pointsObj = new THREE.Points(geometry, material);
     pointsObj.userData = hits;
     pointsObj.name = 'Hit';
+    // add to scene
     scene.add(pointsObj);
-    return pointsObj;
   }
 
-  protected addCluster(cluster: any, scene: Object3D): Object3D {
+  protected addCluster(cluster: any, scene: Object3D): void {
     const maxR = 1100.0;
     const maxZ = 3200.0;
     const length = cluster.energy * 0.003;
+    // geometry
     const geometry = new THREE.BoxGeometry(30, 30, length);
-    const material = new THREE.MeshPhongMaterial({color: Math.random() * 0xffffff});
+    // material
+    const material = new THREE.MeshBasicMaterial({color: Math.random() * 0xffffff});
+    // object
     const cube = new THREE.Mesh(geometry, material);
     const theta = 2 * Math.atan(Math.pow(Math.E, cluster.eta));
     const pos = new THREE.Vector3(4000.0 * Math.cos(cluster.phi) * Math.sin(theta),
@@ -206,15 +252,17 @@ export class PhoenixLoader implements EventDataLoader {
     cube.lookAt(new THREE.Vector3(0, 0, 0));
     cube.userData = cluster;
     cube.name = 'Cluster';
+    // add to scene
     scene.add(cube);
-    return cube;
   }
 
-  protected addMuon(muon: any, scene: Scene) {
+  protected addMuon(muon: any, scene: Scene): void {
     const muonScene = new Group();
+
     for (const clusterID of muon.LinkedClusters) {
       const clusterColl = clusterID.split(':')[0];
       const clusterIndex = clusterID.split(':')[1];
+
       if (clusterColl && clusterIndex && this.eventData.CaloClusters && this.eventData.CaloClusters[clusterColl]) {
         const cluster = this.eventData.CaloClusters[clusterColl][clusterIndex];
         if (cluster) {
@@ -222,9 +270,11 @@ export class PhoenixLoader implements EventDataLoader {
         }
       }
     }
+
     for (const trackID of muon.LinkedTracks) {
       const trackColl = trackID.split(':')[0];
       const trackIndex = trackID.split(':')[1];
+
       if (trackColl && trackIndex && this.eventData.Tracks && this.eventData.Tracks[trackColl]) {
         const track = this.eventData.Tracks[trackColl][trackIndex];
         if (track) {
@@ -232,10 +282,13 @@ export class PhoenixLoader implements EventDataLoader {
         }
       }
     }
+    // add to scene
     scene.add(muonScene);
   }
 
   getCollections(): string[] {
+    if(!this.eventData) return null;
+
     const collections = [];
     for (const objectType of Object.keys(this.eventData)) {
       for (const collection of Object.keys(this.eventData[objectType])) {
@@ -246,6 +299,8 @@ export class PhoenixLoader implements EventDataLoader {
   }
 
   getCollection(collectionName: string): any {
+    if(!this.eventData) return null;
+
     for (const objectType of Object.keys(this.eventData)) {
       for (const collection of Object.keys(this.eventData[objectType])) {
         if (collection === collectionName) {

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -780,15 +780,21 @@ export class ThreeService {
 
   public collectionColor(collectionName: string, value: any) {
     const collection = this.scene.getObjectByName(collectionName);
+
     for (const child of Object.values(collection.children)) {
-      let color;
-      // For jets and tracks
-      if (child instanceof Line || child instanceof Mesh) {
-        if (child.material instanceof LineBasicMaterial || child.material instanceof MeshBasicMaterial) {
-          color = child.material.color;
+
+      child.traverse(
+        function(object: THREE.Object3D){
+
+          // For jets and tracks
+          if (object instanceof Line || object instanceof Mesh) {
+            if (object.material instanceof LineBasicMaterial || object.material instanceof MeshBasicMaterial) {
+              object.material.color.set(value);
+            }
+          }
         }
-      }
-      color.set(value);
+      );
+
     }
   }
 

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -387,7 +387,11 @@ export class ThreeService {
     const sceneString = JSON.stringify(scene, null, 2);
     // @ts-ignore
     loader.parse(sceneString, '', (gltf) => {
+      const eventData = this.getEventData();
       this.scene = gltf.scene;
+
+      eventData.children = gltf.scene.getObjectByName('EventData').children;
+      
       this.setLights();
       this.darkBackground(false);
 

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -483,14 +483,46 @@ export class ThreeService {
     this.scene.background = new THREE.Color(background);
   }
 
-  public setCameraPos(cameraPos: number[]) {
-    return () => {
-      new TWEEN.Tween(this.controlsManager.activeCamera.position).to({
-        x: cameraPos[0],
-        y: cameraPos[1],
-        z: cameraPos[2]
-      }, 1000).start();
-    };
+  /**
+   * Animates camera transform.
+   * @param {number[]} cameraPosition End position.
+   * @param {number[]} cameraTarget End target.
+   * @param {number} duration Duration of an animation in seconds.
+   * @private
+   */
+  public animateCameraTransform(cameraPosition: number[], cameraTarget: number[], duration: number): void {
+      this.animateCameraPosition(cameraPosition, duration);
+      this.animateCameraTarget(cameraTarget, duration);
+  }
+  /**
+   * Animates camera position.
+   * @param {number[]} cameraPosition End position.
+   * @param {number} duration Duration of an animation in seconds.
+   * @private
+   */
+  public animateCameraPosition(cameraPosition: number[], duration: number): void{
+    const posAnimation = new TWEEN.Tween(this.controlsManager.activeCamera.position);
+    posAnimation.to({
+      x: cameraPosition[0],
+      y: cameraPosition[1],
+      z: cameraPosition[2]
+    }, duration);
+    posAnimation.start();
+  }
+   /**
+   * Animates camera target.
+   * @param {number[]} cameraTarget End target.
+   * @param {number} duration Duration of an animation in seconds.
+   * @private
+   */
+  public animateCameraTarget(cameraTarget: number[], duration: number): void{
+    const rotAnimation = new TWEEN.Tween(this.controlsManager.activeControls.target);
+    rotAnimation.to({
+      x: cameraTarget[0],
+      y: cameraTarget[1],
+      z: cameraTarget[2]
+    }, duration);
+    rotAnimation.start();
   }
 
   /**
@@ -545,22 +577,26 @@ export class ThreeService {
    * @param targetlookAtVector Vector to align camera to.
    */
   private alignCameraWithVector(targetlookAtVector: THREE.Vector3): void {
-    const activeLookAtVector = new THREE.Vector3(0, 0, -1);
+    const activeLookAtVector: THREE.Vector3  = new THREE.Vector3(0, 0, -1);
     activeLookAtVector.applyQuaternion(this.controlsManager.mainCamera.quaternion);
 
-    const orbitTargetVector = new THREE.Vector3();
+    const orbitTargetVector: THREE.Vector3  = new THREE.Vector3();
     orbitTargetVector.subVectors(this.controlsManager.mainControls.target, this.controlsManager.mainCamera.position);
 
-    const direction = orbitTargetVector.dot(targetlookAtVector);
+    const direction: number = orbitTargetVector.dot(targetlookAtVector);
     targetlookAtVector.normalize().multiplyScalar(orbitTargetVector.length());
     if (direction < 0) {
       targetlookAtVector.multiplyScalar(-1);
     }
 
-    const newLookAtPoint = targetlookAtVector.add(this.controlsManager.mainCamera.position);
-    this.controlsManager.mainControls.target = newLookAtPoint;
+    const newLookAtPoint: THREE.Vector3 = targetlookAtVector.add(this.controlsManager.mainCamera.position);
 
-    this.updateControls();
+    //instant change
+    //this.controlsManager.mainControls.target = newLookAtPoint;
+    //this.updateControls();
+
+    //animated change
+    this.animateCameraTarget(newLookAtPoint.toArray(), 1000);
   }
 
   private enableSelecting() {

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -113,14 +113,20 @@ export class UIService {
     const presetViewFolder = this.viewFolder.addFolder('Preset Views');
     const presetIconsUl = document.createElement('div');
     presetIconsUl.className = 'preset-views';
+
+    const scope = this;
     presetViews.forEach((view) => {
+      // Animation
+      const animationFunction = function(){
+        scope.three.animateCameraTransform(view.cameraPos, [0, 0, 0], 1000);
+      };
       // For menu
-      view.setView = this.three.setCameraPos(view.cameraPos);
+      view.setView = animationFunction;
       presetViewFolder.add(view, 'setView').name(view.name);
       // For icons
       const viewElement = document.createElement('img');
       viewElement.setAttribute('src', view.getIconURL());
-      viewElement.addEventListener('click', this.three.setCameraPos(view.cameraPos));
+      viewElement.addEventListener('click', animationFunction);
       presetIconsUl.append(viewElement);
     });
     const element = document.getElementById('optionsPanel');


### PR DESCRIPTION
- Improved export and import 
Here I tackle odd behavior while exporting and importing a scene. I introduce list of object to not export, since they are not well supported in current GLTF versions. The objects that are excluded are considered a defaults and are loaded at scene initialization.

- Fixed views animation to work on arbitrary transform 
Views animation did not seem to work in arbitrary position and rotation. Adding both animations fixed the problem. I also added animation to other align view options.

- Fixed muons color property
There was an error while tiring to change a muon color. Since muons are compound objects, changing the depth of material color assignment solved this issue. 

-  Formatting and fixing event data loading
Changed event data loading to a more consistent format. Please note that I also changed a sorting function of track positions (file: phoenix-loader.ts, lines: 125 - 130). I think there was an error in the sorting function, but it may be intentionally that way.
Maybe we should exclude a sort completely since sorting might corrupt a correct order of track positions. Trajectory of a particle may bend in such a way that it loops back to collision source and sorting would give incorrect order of track positions. This seems unlikely but the probability is still there.

- Fixing selecting items on reimported scene
Alternative solution to enable selection on object in a scene. Solved by adding an even data at scene load.