### PR TITLE
Restrict movement of draggable components

### DIFF
--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -1,5 +1,5 @@
 <!-- Show objects -->
-<div class="info-box" *ngIf="showObjectsInfo" cdkDrag>
+<div class="info-box" *ngIf="showObjectsInfo" cdkDrag cdkDragBoundary="body">
     <div class="boxHeader" *ngIf="collections!=null">
         <span>Choose a collection: </span>
         <div class="eventSelector">

--- a/src/app/components/ui-menu/object-selection/object-selection-overlay/object-selection-overlay.component.html
+++ b/src/app/components/ui-menu/object-selection/object-selection-overlay/object-selection-overlay.component.html
@@ -1,4 +1,4 @@
-<div class="infoPanelWrapper" cdkDrag *ngIf="selectedObject">
+<div class="infoPanelWrapper" cdkDrag cdkDragBoundary="body" *ngIf="selectedObject">
     <div id="selectedObjectPanel" [ngClass]="{'hidden' : hiddenSelectedInfo}">
         <div class="selectedObjectPanelHeader">
             <div></div>

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -237,6 +237,8 @@ export class ThreeService {
     // Add listener
     const offset: { x: number; y: number } = { x: 0, y: 0 };
     let mouseDown = false;
+    // Padding limit for element dragging
+    let sidePadding = 3;
 
     canvas.addEventListener(
       'mousedown',
@@ -261,8 +263,19 @@ export class ThreeService {
       (event) => {
         event.preventDefault();
         if (mouseDown) {
-          canvas.style.left = event.clientX - offset.x + 'px';
-          canvas.style.top = event.clientY - offset.y + 'px';
+          let posX = event.clientX - offset.x;
+          let posY = event.clientY - offset.y;
+          let rightLimit = window.innerWidth - canvas.clientWidth - sidePadding;
+          let bottomLimit = window.innerHeight - canvas.clientHeight - sidePadding;
+
+          // If the position is inside the window width AND the position is not less than the left padding
+          if ((posX < rightLimit) && (posX > sidePadding)) {
+            canvas.style.left = posX + 'px';
+          }
+          // If the position is inside the window height AND the position is not less than the top padding
+          if ((posY < bottomLimit) && (posY > sidePadding)) {
+            canvas.style.top = posY + 'px';
+          }
         }
       },
       true


### PR DESCRIPTION
Hi,

Some draggable components can be dragged outside the browser window view and can become impossible to fetch again.
This fix limits their movement so they can't go out of the browser window.

The changes effect and limit drag movements of **Overlay view**, **Object selection**, and **Event data collections info**.