### PR TITLE
Fix momentum cuts not working

### DIFF
--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -72,7 +72,7 @@ export class PhoenixLoader implements EventDataLoader {
       const cuts: Cut[] = [
         new Cut('chi2', 0, 50),
         new Cut('dof', 0, 100),
-        new Cut('momentum', 0, 500)
+        new Cut('mom', 0, 500)
       ];
 
       this.addObjectType(eventData.Tracks, PhoenixObjects.getTrack, 'Tracks', cuts);


### PR DESCRIPTION
Fixes #56

The code uses Object keys to get the cuts. Since the key for momentum being used in the code was `momentum`, the code wasn't picking `mom` which is the actual momentum property of tracks in events.