### PR TITLE
Toggle for changing event data depthTest

### DIFF
--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -1065,7 +1065,7 @@ export class ThreeService {
   /**
    * Update all children's depthTest and renderOrder.
    * @param object Object group whose depthTest is to be changed.
-   * @param value Value of depthTest to be true or false.
+   * @param value A boolean to specify if depthTest is to be enabled or disabled.
    */
   private updateChildrenDepthTest(object: any, value: boolean) {
     // Changing renderOrder to make event data render on top of geometry

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -1050,6 +1050,41 @@ export class ThreeService {
     }
   }
 
+  /**
+   * Set event data depthTest to enable/disable if event data should show on top of geometry.
+   * @param value A boolean to specify if depthTest is to be enabled or disabled.
+   */
+  public eventDataDepthTest(value: boolean) {
+    const object = this.scene.getObjectByName('EventData');
+
+    if (object !== null) {
+      this.updateChildrenDepthTest(object, value);
+    }
+  }
+  
+  /**
+   * Update all children's depthTest and renderOrder.
+   * @param object Object group whose depthTest is to be changed.
+   * @param value Value of depthTest to be true or false.
+   */
+  private updateChildrenDepthTest(object: any, value: boolean) {
+    // Changing renderOrder to make event data render on top of geometry
+    // Arbitrarily setting a high value of 999 
+    value ? object.renderOrder = 0 : object.renderOrder = 999;
+
+    // Traversing all event data objects to change material's depthTest
+    object.children.forEach((objectChild: any) => {
+      if (!(objectChild instanceof THREE.Group)) {
+        if (objectChild.material) {
+          objectChild.material.depthTest = value;
+        }
+      } else {
+        // Calling the function again if the object is a group
+        this.updateChildrenDepthTest(objectChild, value);
+      }
+    });
+  }
+
   public getObjectPosition(name: string): Vector3 {
     const object = this.objects.find(o => o.name === name);
     if (object) {

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -155,7 +155,7 @@ export class UIService {
     // A boolean toggle for showing/hiding the event data is added to the 'Event Data' folder.
     const menu = this.eventFolder.add(this.guiParameters.eventData, 'show').name('Show').listen();
     menu.onChange((value) => this.three.objectVisibility('EventData', value));
-    // A boolean toggle for enabling disabling depthTest of event data.
+    // A boolean toggle for enabling/disabling depthTest of event data.
     const depthTestMenu = this.eventFolder.add(this.guiParameters.eventData, 'depthTest').name('Depth Test').listen();
     depthTestMenu.onChange((value) => this.three.eventDataDepthTest(value));
   }

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -151,10 +151,13 @@ export class UIService {
     }
     // A new folder for the Event Data is added to the GUI.
     this.eventFolder = this.gui.addFolder('Event Data');
-    this.guiParameters.eventData = { show: true };
+    this.guiParameters.eventData = { show: true, depthTest: true };
     // A boolean toggle for showing/hiding the event data is added to the 'Event Data' folder.
     const menu = this.eventFolder.add(this.guiParameters.eventData, 'show').name('Show').listen();
     menu.onChange((value) => this.three.objectVisibility('EventData', value));
+    // A boolean toggle for enabling disabling depthTest of event data.
+    const depthTestMenu = this.eventFolder.add(this.guiParameters.eventData, 'depthTest').name('Depth Test').listen();
+    depthTestMenu.onChange((value) => this.three.eventDataDepthTest(value));
   }
 
   public addEventDataTypeFolder(objectType: string) {


### PR DESCRIPTION
Hi,

Added a toggle to change the depthTest of event data. This helps in toggling to show event data on top of detector geometry. It actually works equally well for all experiments. We can see both the geometry and the complete event at the same time. :)

Here is how it looks:

![depthTest-toggle](https://user-images.githubusercontent.com/36920441/78227691-1366e800-74e7-11ea-9f1d-22c6869c135b.gif)
