### PR TITLE
Restore to use type for hover objects ignoreList

### DIFF
--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -140,9 +140,9 @@ export class ThreeService {
 
     // Export ignore list
     this.ignoreList = [
-      THREE.AmbientLight.name,
-      THREE.DirectionalLight.name,
-      THREE.AxesHelper.name
+      new THREE.AmbientLight().type,
+      new THREE.DirectionalLight().type,
+      new THREE.AxesHelper().type
     ];
     // Object Collections
     this.objects = [];


### PR DESCRIPTION
Hi,

I made a little mistake in #70 for the ignoreList. I changed to get each of their's static property 'name' and only checked for `THREE.AmbientLight` and `THREE.DirectionalLight` which gave the right result but since `THREE.AxesHelper` is derived for `THREE.LineSegments` the type gives `LineSegments` while the name gives `AxesHelper`.

This restores the ignoreList back to how it was. :)

Thanks. 