### PR TITLE
Show/hide all geometries not working for geometries loaded from GLTF

### DIFF
--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -206,9 +206,8 @@ export class ThreeService {
    * @param sceneUrl Path to the geometry.
    */
   public loadGLTFGeometry(sceneUrl: any, name: string) {
-    const callback = (geometry: Object3D) => {
-      this.sceneManager.getScene().add(geometry);
-    };
+    const geometries = this.sceneManager.getGeometries();
+    const callback = (geometry: Object3D) => geometries.add(geometry);
     this.importManager.loadGLTFGeometry(sceneUrl, name, callback);
   }
 

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -22,7 +22,6 @@ export class UIService {
     geometries: undefined
   };
   private geomFolder: any;
-  private geomNames: any = [];
   private controlsFolder: any;
   private eventFolder: any;
   private viewFolder: any;
@@ -97,7 +96,6 @@ export class UIService {
   }
 
   public addGeometry(name: string, colour) {
-    this.geomNames.push(name);
     if (this.geomFolder == null) {
       this.addGeomFolder();
     }


### PR DESCRIPTION
Hi,

Since a group with identifier `SceneManager.GEOMETRIES_ID` is being used to group all detector geometries, geometries loaded from gltf should also be a part of this group.
The `Geometries` folder `Show` checkbox wasn't working because of this.

Thanks. :)