### PR TITLE
Close sections created by clipping

### DIFF
--- a/src/app/services/three/import-manager.ts
+++ b/src/app/services/three/import-manager.ts
@@ -120,6 +120,10 @@ export class ImportManager {
                     child.material.clippingPlanes = this.clipPlanes;
                     child.material.clipIntersection = true;
                     child.material.clipShadows = false;
+                    child.material.side = DoubleSide;
+                    child.material.onBeforeCompile = (shader) => {
+                        shader.fragmentShader = shader.fragmentShader.replace('gl_FragColor = vec4( outgoingLight, diffuseColor.a );', 'if ( gl_FrontFacing ) { gl_FragColor = vec4( outgoingLight, diffuseColor.a ); } else { gl_FragColor = diffuseColor; }');
+                    };
                 }
             }
         });

--- a/src/app/services/three/import-manager.ts
+++ b/src/app/services/three/import-manager.ts
@@ -66,9 +66,6 @@ export class ImportManager {
         material2.wireframe = false;
         if (doubleSided) {
             material2.side = DoubleSide;
-            material2.onBeforeCompile = (shader) => {
-                shader.fragmentShader = shader.fragmentShader.replace('gl_FragColor = vec4( outgoingLight, diffuseColor.a );', 'if ( gl_FrontFacing ) { gl_FragColor = vec4( outgoingLight, diffuseColor.a ); } else { gl_FragColor = diffuseColor; }');
-            };
         }
 
         object3d.traverse(child => {
@@ -120,10 +117,6 @@ export class ImportManager {
                     child.material.clippingPlanes = this.clipPlanes;
                     child.material.clipIntersection = true;
                     child.material.clipShadows = false;
-                    child.material.side = DoubleSide;
-                    child.material.onBeforeCompile = (shader) => {
-                        shader.fragmentShader = shader.fragmentShader.replace('gl_FragColor = vec4( outgoingLight, diffuseColor.a );', 'if ( gl_FrontFacing ) { gl_FragColor = vec4( outgoingLight, diffuseColor.a ); } else { gl_FragColor = diffuseColor; }');
-                    };
                 }
             }
         });

--- a/src/app/services/three/import-manager.ts
+++ b/src/app/services/three/import-manager.ts
@@ -66,6 +66,9 @@ export class ImportManager {
         material2.wireframe = false;
         if (doubleSided) {
             material2.side = DoubleSide;
+            material2.onBeforeCompile = (shader) => {
+                shader.fragmentShader = shader.fragmentShader.replace('gl_FragColor = vec4( outgoingLight, diffuseColor.a );', 'if ( gl_FrontFacing ) { gl_FragColor = vec4( outgoingLight, diffuseColor.a ); } else { gl_FragColor = diffuseColor; }');
+            };
         }
 
         object3d.traverse(child => {

--- a/src/app/services/three/scene-manager.ts
+++ b/src/app/services/three/scene-manager.ts
@@ -1,4 +1,4 @@
-import { Scene, Object3D, Color, LineSegments, Mesh, MeshPhongMaterial, LineBasicMaterial, Vector3, Group, AxesHelper, AmbientLight, DirectionalLight, Line, MeshBasicMaterial, Material, Points, PointsMaterial } from 'three';
+import { Scene, Object3D, Color, LineSegments, Mesh, MeshPhongMaterial, LineBasicMaterial, Vector3, Group, AxesHelper, AmbientLight, DirectionalLight, Line, MeshBasicMaterial, Material, Points, PointsMaterial, DoubleSide } from 'three';
 import { Cut } from '../extras/cut.model';
 
 
@@ -317,6 +317,27 @@ export class SceneManager {
             } else {
                 // Calling the function again if the object is a group
                 this.updateChildrenDepthTest(objectChild, value);
+            }
+        });
+    }
+
+    /**
+     * Toggle for closing sections created by clipping.
+     * @param value A boolean to specify if clipped sections of geometries should be closed.
+     */
+    public closeClippedGeometries(value: boolean) {
+        const objects = this.scene.getObjectByName(SceneManager.GEOMETRIES_ID);
+        
+        objects.traverse((child) => {
+            if (child instanceof Mesh) {
+                if (child.material instanceof Material && child.material.side === DoubleSide) {
+                    child.material.onBeforeCompile = (shader) => {
+                        if (value) {
+                            shader.fragmentShader = shader.fragmentShader.replace('gl_FragColor = vec4( outgoingLight, diffuseColor.a );', 'if ( gl_FrontFacing ) { gl_FragColor = vec4( outgoingLight, diffuseColor.a ); } else { gl_FragColor = diffuseColor; }');
+                        }
+                    }
+                    child.material.needsUpdate = true;
+                }
             }
         });
     }

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -87,11 +87,16 @@ export class UIService {
     if (this.geomFolder == null) {
       this.geomFolder = this.gui.addFolder(SceneManager.GEOMETRIES_ID);
     }
-    this.guiParameters.geometries = { show: true };
+    this.guiParameters.geometries = { show: true, closeClippedGeometries: false };
     // A boolean toggle for showing/hiding the geometries is added to the 'Geometry' folder.
     const showGeometriesMenu = this.geomFolder.add(this.guiParameters.geometries, 'show').name('Show').listen();
     showGeometriesMenu.onChange((value) => {
       this.three.getSceneManager().objectVisibility(SceneManager.GEOMETRIES_ID, value);
+    });
+    // A boolean toggle for closing sections created by clipping.
+    const closeClippedGeometriesMenu = this.geomFolder.add(this.guiParameters.geometries, 'closeClippedGeometries').name('Close Clipped').listen();
+    closeClippedGeometriesMenu.onChange((value) => {
+      this.three.getSceneManager().closeClippedGeometries(value);
     });
   }
 


### PR DESCRIPTION
Fixes #39

Hi,
Found that we can edit shaders of each material before compilation which is gonna be helpful for future as well.
This changes the shaders in a way that makes clipped geometries filled. Added for both GLTF and OBJ geometries.

I was wondering if this would be better as an argument (true/false)? WDYT?

**Before:**
![clipping-before](https://user-images.githubusercontent.com/36920441/80202508-2c267180-863f-11ea-8cf7-c7663bbc5602.PNG)

**After:**
![clipping-after](https://user-images.githubusercontent.com/36920441/80202516-30528f00-863f-11ea-8c9e-043737b0a763.PNG)
