### PR TITLE
Add toggle for wireframing geometries

### DIFF
--- a/src/app/services/three/scene-manager.ts
+++ b/src/app/services/three/scene-manager.ts
@@ -320,4 +320,26 @@ export class SceneManager {
             }
         });
     }
+
+    /**
+     * Wireframe geometries and decrease their opacity.
+     * @param value A boolean to specify if geometries are to be wireframed
+     * or not.
+     */
+    public wireframeGeometries(value: boolean) {
+        const allGeoms = this.getGeometries();
+        allGeoms.traverse((object: any) => {
+            if (object.material) {
+                object.material.wireframe = value;
+                if (value) {
+                    object.material.transparent = true;
+                    object.material.opacity = 0.1;
+                } else {
+                    // Rolling back transparency because depthTest doesn't work with it
+                    object.material.transparent = false;
+                    object.material.opacity = 1;
+                }
+            }
+        });
+    }
 }

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -87,11 +87,16 @@ export class UIService {
     if (this.geomFolder == null) {
       this.geomFolder = this.gui.addFolder(SceneManager.GEOMETRIES_ID);
     }
-    this.guiParameters.geometries = { show: true };
+    this.guiParameters.geometries = { show: true, wireframe: false };
     // A boolean toggle for showing/hiding the geometries is added to the 'Geometry' folder.
     const showGeometriesMenu = this.geomFolder.add(this.guiParameters.geometries, 'show').name('Show').listen();
     showGeometriesMenu.onChange((value) => {
       this.three.getSceneManager().objectVisibility(SceneManager.GEOMETRIES_ID, value);
+    });
+    // A boolean toggle for enabling/disabling the geometries' wireframing.
+    const wireframeGeometriesMenu = this.geomFolder.add(this.guiParameters.geometries, 'wireframe').name('Wireframe').listen();
+    wireframeGeometriesMenu.onChange((value) => {
+      this.three.getSceneManager().wireframeGeometries(value);
     });
   }
 


### PR DESCRIPTION
Hi,

Added a toggle for wireframing detector geometry and decreasing it's opacity for a better event view. Here's how it looks:
![image](https://user-images.githubusercontent.com/36920441/83337862-4e637d00-a2d8-11ea-95a6-c49ddc49bd3b.png)
