### PR TITLE
Fix LHCb loader bug of loading collections

### DIFF
--- a/src/app/services/loaders/lhcb-loader.ts
+++ b/src/app/services/loaders/lhcb-loader.ts
@@ -33,8 +33,8 @@ export class LHCbLoader extends PhoenixLoader {
     const eventData = {
       eventNumber: this.data.eventNumber,
       runNumber: this.data.runNumber,
-      Hits: undefined,
-      Tracks: undefined
+      Hits: {},
+      Tracks: {}
     };
 
     let part_list = [];

--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -68,8 +68,10 @@ export class PhoenixLoader implements EventDataLoader {
 
     const collections = [];
     for (const objectType of Object.keys(this.eventData)) {
-      for (const collection of Object.keys(this.eventData[objectType])) {
-        collections.push(collection);
+      if (this.eventData[objectType]) {
+        for (const collection of Object.keys(this.eventData[objectType])) {
+          collections.push(collection);
+        }
       }
     }
     return collections;
@@ -86,9 +88,11 @@ export class PhoenixLoader implements EventDataLoader {
     }
 
     for (const objectType of Object.keys(this.eventData)) {
-      for (const collection of Object.keys(this.eventData[objectType])) {
-        if (collection === collectionName) {
-          return this.eventData[objectType][collection];
+      if (this.eventData[objectType]) {
+        for (const collection of Object.keys(this.eventData[objectType])) {
+          if (collection === collectionName) {
+            return this.eventData[objectType][collection];
+          }
         }
       }
     }


### PR DESCRIPTION
Hi,

The `getCollection` and `getCollections` functions were not checking for possible undefined values in event data collections. This could have been fixed by just changing the `lhcb-loader.ts` `Hits` to an empty object but since users can also put values like this, it's better to check if there is a value before iterating.

**Before:**
![image](https://user-images.githubusercontent.com/36920441/84446312-a6966980-ac5e-11ea-9b80-1917fede7c9b.png)

**After:**
![image](https://user-images.githubusercontent.com/36920441/84446327-b0b86800-ac5e-11ea-8720-4c9dc0c1c203.png)

Thanks. :)