### PR TITLE
Selection of 3D object from collections info panel

### DIFF
--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -1,6 +1,7 @@
 <!-- Show objects -->
 <app-overlay title="Collections Info" icon="info" [resizable]="true" [active]="showObjectsInfo">
-  <div class="collectionsInfo m-2">
+  <!-- Using ngIf to remove it from DOM since this panel requires heavy computing -->
+  <div *ngIf="showObjectsInfo" class="collectionsInfo m-2">
     <div class="collectionSelector mb-2 d-flex align-items-center" *ngIf="collections!=null">
       <span>Choose a collection: </span>
       <div class="eventSelector">

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -29,12 +29,14 @@
             <td>#{{i}}</td>
             <td>
               <div *ngIf="object.uuid" class="row justify-content-center object-select">
-                <div class="col-6 object-select-lookat" (click)="lookAtObject(object.uuid)">
+                <div class="col-6 object-select-lookat" matTooltip="Move camera to object"
+                  (click)="lookAtObject(object.uuid)">
                   <svg>
                     <use href="assets/icons/views.svg#views"></use>
                   </svg>
                 </div>
-                <div class="col-6 object-select-highlight" (click)="highlightObject(object.uuid)">
+                <div class="col-6 object-select-highlight" matTooltip="Highlight object"
+                  (click)="highlightObject(object.uuid)">
                   <svg>
                     <use href="assets/icons/cursor.svg#cursor"></use>
                   </svg>

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -14,12 +14,12 @@
       </div>
     </div>
 
-    <div class="boxBody">
-      <table id="collectionTable" *ngIf="showingCollection">
+    <div class="boxBody table-responsive">
+      <table id="collectionTable" class="table table-borderless table-sm" *ngIf="showingCollection">
         <thead>
           <tr>
             <th>No.</th>
-            <th>Go to</th>
+            <th>Selection</th>
             <th *ngFor="let column of collectionColumns">{{column}}</th>
           </tr>
         </thead>
@@ -27,10 +27,19 @@
           <tr *ngFor="let object of showingCollection; index as i" [attr.id]="object.uuid"
             [ngClass]="{'active-object': activeObjectId && activeObjectId === object.uuid}">
             <td>#{{i}}</td>
-            <td class="look-at-object" (click)="lookAtObject(object.uuid)">
-              <svg *ngIf="object.uuid">
-                <use href="assets/icons/views.svg#views"></use>
-              </svg>
+            <td>
+              <div *ngIf="object.uuid" class="row justify-content-center object-select">
+                <div class="col-6 object-select-lookat" (click)="lookAtObject(object.uuid)">
+                  <svg>
+                    <use href="assets/icons/views.svg#views"></use>
+                  </svg>
+                </div>
+                <div class="col-6 object-select-highlight" (click)="highlightObject(object.uuid)">
+                  <svg>
+                    <use href="assets/icons/cursor.svg#cursor"></use>
+                  </svg>
+                </div>
+              </div>
             </td>
             <td *ngFor="let column of collectionColumns">{{object[column]}}</td>
           </tr>

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -19,13 +19,19 @@
         <thead>
           <tr>
             <th>No.</th>
+            <th>Go to</th>
             <th *ngFor="let column of collectionColumns">{{column}}</th>
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let object of showingCollection; index as i" [attr.id]="object.uuid ? object.uuid : null"
+          <tr *ngFor="let object of showingCollection; index as i" [attr.id]="object.uuid"
             [ngClass]="{'active-object': activeObjectId && activeObjectId === object.uuid}">
             <td>#{{i}}</td>
+            <td class="look-at-object" (click)="lookAtObject(object.uuid)">
+              <svg *ngIf="object.uuid">
+                <use href="assets/icons/views.svg#views"></use>
+              </svg>
+            </td>
             <td *ngFor="let column of collectionColumns">{{object[column]}}</td>
           </tr>
         </tbody>

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -23,7 +23,8 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let object of showingCollection; index as i">
+          <tr *ngFor="let object of showingCollection; index as i" [attr.id]="object.uuid ? object.uuid : null"
+            [ngClass]="{'active-object': activeObjectId && activeObjectId === object.uuid}">
             <td>#{{i}}</td>
             <td *ngFor="let column of collectionColumns">{{object[column]}}</td>
           </tr>

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
@@ -35,7 +35,29 @@
 
   tr.active-object {
     color: var(--phoenix-background-color);
-    background: var(--phoenix-text-color-hover);
-    box-shadow: 0 0 15px var(--phoenix-text-color-hover);
+    background: var(--phoenix-text-color);
+    box-shadow: 0 0 15px var(--phoenix-text-color);
+
+    td.look-at-object {
+      --phoenix-options-icon-path: var(--phoenix-background-color);
+      --phoenix-options-icon-bg: var(--phoenix-text-color-hover);
+    }
+  }
+
+  td.look-at-object {
+    max-width: 1rem;
+    max-height: 1rem;
+    padding: 0.2rem;
+    text-align: center;
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--phoenix-options-icon-bg);
+    }
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+    }
   }
 }

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
@@ -1,13 +1,18 @@
-.collectionSelector {
+.collectionsInfo {
+  height: 90%;
 
-  span {
-    color: var(--phoenix-text-color-secondary);
-    margin-right: 1rem;
+  .collectionSelector {
+  
+    span {
+      color: var(--phoenix-text-color-secondary);
+      margin-right: 1rem;
+    }
   }
+
 }
 
 .boxBody {
-  max-height: 40vh;
+  height: 90%;
   overflow: scroll;
 
   p.emptyBox {
@@ -22,6 +27,7 @@
   thead tr th {
     position: sticky;
     top: 0;
+    z-index: 100;
     background: var(--phoenix-background-color-secondary);
   }
 
@@ -38,26 +44,31 @@
     background: var(--phoenix-text-color);
     box-shadow: 0 0 15px var(--phoenix-text-color);
 
-    td.look-at-object {
+    div.object-select {
       --phoenix-options-icon-path: var(--phoenix-background-color);
       --phoenix-options-icon-bg: var(--phoenix-text-color-hover);
     }
   }
 
-  td.look-at-object {
-    max-width: 1rem;
-    max-height: 1rem;
-    padding: 0.2rem;
-    text-align: center;
-    cursor: pointer;
+  td {
 
-    &:hover {
-      background-color: var(--phoenix-options-icon-bg);
-    }
-
-    svg {
-      width: 1rem;
-      height: 1rem;
+    .object-select > div {
+      max-width: 2em;
+      max-height: 2em;
+      padding: 0.4em;
+      text-align: center;
+      cursor: pointer;
+  
+      &:hover {
+        background-color: var(--phoenix-options-icon-bg);
+        border-radius: 10px;
+      }
+  
+      svg {
+        width: 100%;
+        height: 100%;
+        vertical-align: top;
+      }
     }
   }
 }

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
@@ -32,4 +32,10 @@
       padding-right: 0;
     }
   }
+
+  tr.active-object {
+    color: var(--phoenix-background-color);
+    background: var(--phoenix-text-color-hover);
+    box-shadow: 0 0 15px var(--phoenix-text-color-hover);
+  }
 }

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
@@ -1,7 +1,9 @@
 .collectionsInfo {
-  height: 90%;
+  height: 95%;
 
   .collectionSelector {
+    height: 15%;
+    min-height: 2rem;
   
     span {
       color: var(--phoenix-text-color-secondary);
@@ -12,7 +14,7 @@
 }
 
 .boxBody {
-  height: 90%;
+  height: 85%;
   overflow: scroll;
 
   p.emptyBox {
@@ -55,13 +57,19 @@
     .object-select > div {
       max-width: 2em;
       max-height: 2em;
-      padding: 0.4em;
+      padding: 0.5em;
+      margin-right: 0.4em;
       text-align: center;
+      background-color: var(--phoenix-options-icon-bg);
+      border-radius: 10px;
       cursor: pointer;
+
+      &:last-child {
+        margin-right: 0;
+      }
   
       &:hover {
-        background-color: var(--phoenix-options-icon-bg);
-        border-radius: 10px;
+        border: 1px solid var(--phoenix-options-icon-path);
       }
   
       svg {

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
 import { EventdisplayService } from 'src/app/services/eventdisplay.service';
 
 @Component({
@@ -13,17 +13,24 @@ export class CollectionsInfoOverlayComponent implements OnInit {
   collections: string[];
   showingCollection: any;
   collectionColumns: string[];
+  activeObjectId: string;
 
   constructor(private eventDisplay: EventdisplayService) { }
 
   ngOnInit() {
     this.eventDisplay.listenToDisplayedEventChange((event) => this.collections = this.eventDisplay.getCollections());
+    this.eventDisplay.getActiveObjectId().subscribe((value) => {
+      this.activeObjectId = value;
+      if (document.getElementById(value)) {
+        document.getElementById(value).scrollIntoView(false);
+      }
+    });
   }
 
   changeCollection(selected: any) {
     const value = selected.target.value;
     this.showingCollection = this.eventDisplay.getCollection(value);
-    this.collectionColumns = Object.keys(this.showingCollection[0]);
+    this.collectionColumns = Object.keys(this.showingCollection[0]).filter((column) => column !== 'uuid');
   }
 
 }

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { EventdisplayService } from 'src/app/services/eventdisplay.service';
 
 @Component({

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -33,4 +33,11 @@ export class CollectionsInfoOverlayComponent implements OnInit {
     this.collectionColumns = Object.keys(this.showingCollection[0]).filter((column) => column !== 'uuid');
   }
 
+  lookAtObject(uuid: string) {
+    if (uuid) {
+      this.eventDisplay.getActiveObjectId().next(uuid);
+      this.eventDisplay.lookAtObject(uuid);
+    }
+  }
+
 }

--- a/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/src/app/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -40,4 +40,11 @@ export class CollectionsInfoOverlayComponent implements OnInit {
     }
   }
 
+  highlightObject(uuid: string) {
+    if (uuid) {
+      this.eventDisplay.getActiveObjectId().next(uuid);
+      this.eventDisplay.highlightObject(uuid);
+    }
+  }
+
 }

--- a/src/app/components/ui-menu/event-selector/event-selector.component.scss
+++ b/src/app/components/ui-menu/event-selector/event-selector.component.scss
@@ -1,8 +1,4 @@
 .eventSelector {
   margin-left: 1rem;
   margin-right: 1rem;
-
-  #event {
-    border-radius: 30px;
-  }
 }

--- a/src/app/components/ui-menu/overlay/overlay.component.scss
+++ b/src/app/components/ui-menu/overlay/overlay.component.scss
@@ -4,6 +4,7 @@
   max-width: 50vw;
   /* Same min-width as overlay.component.ts MIN_RES_WIDTH */
   min-width: 300px;
+  height: 100%;
   max-height: 70vh;
   box-shadow: none;
   border: none;

--- a/src/app/services/eventdisplay.service.ts
+++ b/src/app/services/eventdisplay.service.ts
@@ -368,4 +368,12 @@ export class EventdisplayService {
   public getActiveObjectId(): any {
       return this.graphicsLibrary.getActiveObjectId();
   }
+
+  /**
+   * Move the camera to look at the object with the given uuid.
+   * @param uuid uuid of the object.
+   */
+  public lookAtObject(uuid: string) {
+    this.graphicsLibrary.lookAtObject(uuid);
+  }
 }

--- a/src/app/services/eventdisplay.service.ts
+++ b/src/app/services/eventdisplay.service.ts
@@ -360,4 +360,12 @@ export class EventdisplayService {
   public fixOverlayView(fixed: boolean) {
     this.graphicsLibrary.fixOverlayView(fixed);
   }
+
+  /**
+   * Get the uuid of the currently selected object.
+   * @returns uuid of the currently selected object.
+   */
+  public getActiveObjectId(): any {
+      return this.graphicsLibrary.getActiveObjectId();
+  }
 }

--- a/src/app/services/eventdisplay.service.ts
+++ b/src/app/services/eventdisplay.service.ts
@@ -370,11 +370,13 @@ export class EventdisplayService {
   }
 
   /**
-   * Move the camera to look at the object with the given uuid.
+   * Move the camera to look at the object with the given uuid
+   * and highlight it.
    * @param uuid uuid of the object.
    */
   public lookAtObject(uuid: string) {
     this.graphicsLibrary.lookAtObject(uuid);
+    this.graphicsLibrary.highlightObject(uuid);
   }
 
   /**

--- a/src/app/services/eventdisplay.service.ts
+++ b/src/app/services/eventdisplay.service.ts
@@ -376,4 +376,12 @@ export class EventdisplayService {
   public lookAtObject(uuid: string) {
     this.graphicsLibrary.lookAtObject(uuid);
   }
+
+  /**
+   * Highlight the object with the given uuid by giving it an outline.
+   * @param uuid uuid of the object.
+   */
+  public highlightObject(uuid: string) {
+    this.graphicsLibrary.highlightObject(uuid);
+  }
 }

--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -33,7 +33,7 @@ export class PhoenixObjects {
     });
 
     // const length = 100;
-    let objectColor = localStorage.getItem('theme') === 'dark' ? 0xfcf44e : 0xff0000;
+    let objectColor = 0xff0000;
     if (trackParams.color) {
       objectColor = parseInt(trackParams.color, 16);
     }

--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -64,6 +64,7 @@ export class PhoenixObjects {
     // object
     const splineObject = new THREE.Line(geometry, material);
     splineObject.userData = trackParams;
+    splineObject.userData.uuid = splineObject.uuid;
     splineObject.name = 'Track';
 
     return splineObject;
@@ -103,6 +104,7 @@ export class PhoenixObjects {
     mesh.position.copy(translation);
     mesh.quaternion.copy(quaternion);
     mesh.userData = jetParams;
+    mesh.userData.uuid = mesh.uuid;
     mesh.name = 'Jet';
 
     return mesh;
@@ -133,6 +135,7 @@ export class PhoenixObjects {
     // object
     const pointsObj = new THREE.Points(geometry, material);
     pointsObj.userData = hitsParams;
+    pointsObj.userData.uuid = pointsObj.uuid;
     pointsObj.name = 'Hit';
 
     return pointsObj;
@@ -165,6 +168,7 @@ export class PhoenixObjects {
     cube.position.z = Math.max(Math.min(pos.z, maxZ), -maxZ); // keep in maxZ range.
     cube.lookAt(new THREE.Vector3(0, 0, 0));
     cube.userData = clusterParams;
+    cube.userData.uuid = cube.uuid;
     cube.name = 'Cluster';
 
     return cube;

--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -55,19 +55,31 @@ export class PhoenixObjects {
 
     // attributes
     const curve = new THREE.CatmullRomCurve3(points);
-    const vertices = curve.getPoints(50);
-    // geometry
-    const geometry = new THREE.TubeBufferGeometry(curve, undefined, 2);
-    // material
-    const material = new THREE.MeshToonMaterial({ color: objectColor });
-    // material.linewidth = 2;
-    // object
-    const splineObject = new THREE.Mesh(geometry, material);
-    splineObject.userData = trackParams;
-    splineObject.userData.uuid = splineObject.uuid;
-    splineObject.name = 'Track';
 
-    return splineObject;
+    // TubeGeometry
+    const geometry = new THREE.TubeBufferGeometry(curve, undefined, 2);
+    const material = new THREE.MeshToonMaterial({ color: objectColor });
+    const tubeObject = new THREE.Mesh(geometry, material);
+    // Setting info to the tubeObject since it will be used for selection
+    tubeObject.userData = trackParams;
+    tubeObject.userData.uuid = tubeObject.uuid;
+    tubeObject.name = 'Track';
+
+    // Line - Creating a Line to put inside the tube to show tracks even on zoom out
+    const vertices = curve.getPoints(50);
+    const lineGeometry = new THREE.BufferGeometry().setFromPoints(vertices);
+    const lineMaterial = new THREE.LineBasicMaterial({
+      color: objectColor,
+      linewidth: 2
+    });
+    const lineObject = new THREE.Line(lineGeometry, lineMaterial);
+
+    // Creating a group to add both the Tube curve and the Line
+    const trackObject = new THREE.Object3D();
+    trackObject.add(tubeObject);
+    trackObject.add(lineObject);
+
+    return trackObject;
   }
 
   /**

--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -33,7 +33,7 @@ export class PhoenixObjects {
     });
 
     // const length = 100;
-    let objectColor = 0xff0000;
+    let objectColor = localStorage.getItem('theme') === 'dark' ? 0xfcf44e : 0xff0000;
     if (trackParams.color) {
       objectColor = parseInt(trackParams.color, 16);
     }
@@ -57,12 +57,12 @@ export class PhoenixObjects {
     const curve = new THREE.CatmullRomCurve3(points);
     const vertices = curve.getPoints(50);
     // geometry
-    const geometry = new THREE.BufferGeometry().setFromPoints(vertices);
+    const geometry = new THREE.TubeBufferGeometry(curve, undefined, 2);
     // material
-    const material = new THREE.LineBasicMaterial({ color: objectColor });
-    material.linewidth = 2;
+    const material = new THREE.MeshToonMaterial({ color: objectColor });
+    // material.linewidth = 2;
     // object
-    const splineObject = new THREE.Line(geometry, material);
+    const splineObject = new THREE.Mesh(geometry, material);
     splineObject.userData = trackParams;
     splineObject.userData.uuid = splineObject.uuid;
     splineObject.name = 'Track';

--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -242,6 +242,7 @@ export class PhoenixLoader implements EventDataLoader {
     }
     // uuid for selection of muons from the collections info panel
     muonParams.uuid = muonScene.uuid;
+    muonScene.name = 'Muon';
     // add to scene
     return muonScene;
   }

--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -240,6 +240,8 @@ export class PhoenixLoader implements EventDataLoader {
         }
       }
     }
+    // uuid for selection of muons from the collections info panel
+    muonParams.uuid = muonScene.uuid;
     // add to scene
     return muonScene;
   }

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -414,4 +414,12 @@ export class ThreeService {
   public lookAtObject(uuid: string) {
     this.controlsManager.lookAtObject(uuid, this.getSceneManager().getEventData());
   }
+
+  /**
+   * Highlight the object with the given uuid by giving it an outline.
+   * @param uuid uuid of the object.
+   */
+  public highlightObject(uuid: string) {
+    this.selectionManager.highlightObject(uuid, this.getSceneManager().getEventData());
+  }
 }

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -398,4 +398,12 @@ export class ThreeService {
     );
     rotAnimation.start();
   }
+
+  /**
+   * Get the uuid of the currently selected object.
+   * @returns uuid of the currently selected object.
+   */
+  public getActiveObjectId(): any {
+      return this.getSelectionManager().getActiveObjectId();
+  }
 }

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -404,6 +404,14 @@ export class ThreeService {
    * @returns uuid of the currently selected object.
    */
   public getActiveObjectId(): any {
-      return this.getSelectionManager().getActiveObjectId();
+    return this.getSelectionManager().getActiveObjectId();
+  }
+
+  /**
+   * Move the camera to look at the object with the given uuid.
+   * @param uuid uuid of the object.
+   */
+  public lookAtObject(uuid: string) {
+    this.controlsManager.lookAtObject(uuid, this.getSceneManager().getEventData());
   }
 }

--- a/src/app/services/three/controls-manager.ts
+++ b/src/app/services/three/controls-manager.ts
@@ -1,5 +1,5 @@
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
-import { Camera, PerspectiveCamera, OrthographicCamera, Object3D } from 'three';
+import { Camera, PerspectiveCamera, OrthographicCamera, Object3D, Vector3 } from 'three';
 import { RendererManager } from './renderer-manager';
 import * as TWEEN from '@tweenjs/tween.js';
 
@@ -257,8 +257,10 @@ export class ControlsManager {
      */
     public lookAtObject(uuid: string, objectsGroup: Object3D) {
         const cameras = [this.getMainCamera(), this.getOverlayCamera()];
+        const origin = new Vector3(0, 0, 0);
         objectsGroup.traverse((object: any) => {
-            if (object.uuid === uuid) {
+            if (object.uuid === uuid &&
+                object.position.distanceTo(origin) > 1) {
                 for (const camera of cameras) {
                     // Moving the camera to the object's position and then zooming out
                     new TWEEN.Tween(camera.position).to({

--- a/src/app/services/three/controls-manager.ts
+++ b/src/app/services/three/controls-manager.ts
@@ -1,5 +1,5 @@
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
-import { Camera, PerspectiveCamera, OrthographicCamera } from 'three';
+import { Camera, PerspectiveCamera, OrthographicCamera, Object3D } from 'three';
 import { RendererManager } from './renderer-manager';
 import * as TWEEN from '@tweenjs/tween.js';
 
@@ -247,6 +247,28 @@ export class ControlsManager {
             }
             anim.start();
         }
+    }
+
+    /**
+     * Move the camera to look at the object with the given uuid.
+     * @param uuid uuid of the object.
+     * @param alLObjects Group of objects to be traversed for finding the object
+     * with the given uuid.
+     */
+    public lookAtObject(uuid: string, objectsGroup: Object3D) {
+        const cameras = [this.getMainCamera(), this.getOverlayCamera()];
+        objectsGroup.traverse((object: any) => {
+            if (object.uuid === uuid) {
+                for (const camera of cameras) {
+                    // Moving the camera to the object's position and then zooming out
+                    new TWEEN.Tween(camera.position).to({
+                        x: object.position.x * 1.1,
+                        y: object.position.y * 1.1,
+                        z: object.position.z * 1.1
+                    }, 200).start();
+                }
+            }
+        });
     }
 
     /**

--- a/src/app/services/three/controls-manager.ts
+++ b/src/app/services/three/controls-manager.ts
@@ -305,7 +305,7 @@ export class ControlsManager {
      * Initialize the zoom controls by setting up the camera and their animations as pairs.
      */
     private initializeZoomControls() {
-        const allCameras: any[] = [this.getMainCamera(), this.getOverlayCamera()];
+        const allCameras: any[] = this.getAllCameras();
         this.zoomCameraAnimPairs = [];
         for (const camera of allCameras) {
             const animation = camera.isOrthographicCamera

--- a/src/app/services/three/scene-manager.ts
+++ b/src/app/services/three/scene-manager.ts
@@ -1,4 +1,4 @@
-import { Scene, Object3D, Color, LineSegments, Mesh, MeshPhongMaterial, LineBasicMaterial, Vector3, Group, AxesHelper, AmbientLight, DirectionalLight, Line, MeshBasicMaterial, Material, Points, PointsMaterial } from 'three';
+import { Scene, Object3D, Color, LineSegments, Mesh, MeshPhongMaterial, LineBasicMaterial, Vector3, Group, AxesHelper, AmbientLight, DirectionalLight, Line, MeshBasicMaterial, Material, Points, PointsMaterial, MeshToonMaterial } from 'three';
 import { Cut } from '../extras/cut.model';
 
 /**
@@ -216,7 +216,8 @@ export class SceneManager {
                         object.material instanceof MeshBasicMaterial ||
                         object.material instanceof MeshBasicMaterial ||
                         object.material instanceof PointsMaterial ||
-                        object.material instanceof MeshPhongMaterial
+                        object.material instanceof MeshPhongMaterial ||
+                        object.material instanceof MeshToonMaterial
                     ) {
                         object.material.color.set(color);
 

--- a/src/app/services/three/selection-manager.ts
+++ b/src/app/services/three/selection-manager.ts
@@ -26,8 +26,6 @@ export class SelectionManager {
     private selectedObject: { name: string; attributes: any[]; };
     /** BehaviorSubject for the currently selected object. */
     private activeObject = new BehaviorSubject<string>('');
-    /** Observable for the uuid of the currently selected object. */
-    private activeObjectId = this.activeObject.asObservable();
     /** Objects to be ignored on hovering over the scene. */
     private ignoreList: string[];
 
@@ -94,7 +92,7 @@ export class SelectionManager {
      * @returns uuid of the currently selected object.
      */
     public getActiveObjectId(): any {
-        return this.activeObjectId;
+        return this.activeObject;
     }
 
     /**

--- a/src/app/services/three/selection-manager.ts
+++ b/src/app/services/three/selection-manager.ts
@@ -217,4 +217,17 @@ export class SelectionManager {
         }
     }
 
+    /**
+     * Highlight the object with the given uuid by giving it an outline.
+     * @param uuid uuid of the object.
+     * @param alLObjects Group of objects to be traversed for finding the object
+     * with the given uuid.
+     */
+    public highlightObject(uuid: string, alLObjects: Object3D) {
+        alLObjects.traverse((object: any) => {
+            if (object.uuid === uuid) {
+                this.outlinePass.selectedObjects = [object];
+            }
+        });
+    }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -113,6 +113,10 @@ canvas {
   outline: none;
 }
 
+select {
+  border-radius: 30px;
+}
+
 #eventDisplay {
   height: 100vh;
   overflow: hidden;


### PR DESCRIPTION
Fixes #93 

Hi,

## Description
Updated the collections info panel so that selection in the scene will highlight the event data items in the collections info panel and users can also highlight or move to objects in the scene from the collections info panel.

## Added
* Highlight event data in collections info panel on selection of event object from the scene
* Highlight event data in the scene on selection of event data from the collections info panel
* Ability to highlight and move camera to object from the collections info panel
* Works for all event data including Tracks, Muons, Hits and Clusters
* Two different options "Move camera to object" and "Highlight object" for highlighting event data from collections info panel
* Some fixes to the collections info panel
* A combination of `Tube` and `Line` for better selection of Tracks (Fixes #73)
* Use yellow color for Tracks if the theme is dark (should I remove this or is it fine? [CODE](https://github.com/9inpachi/phoenix/blob/wip-collections/src/app/services/loaders/objects/phoenix-objects.ts#L36))

## Screen Capture
![wip-collections-final](https://user-images.githubusercontent.com/36920441/84781234-034ba880-b000-11ea-9dfc-fb0af9f51aee.gif)
