### PR TITLE
Scalable Jets and fix depthTest

### DIFF
--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -97,8 +97,8 @@ export class PhoenixObjects {
     // Jet energy parameter can either be 'energy' or 'et'
     let length = (jetParams.energy ? jetParams.energy : jetParams.et) * 0.2;
     // Ugh - We don't want the Jets to go out of the event display
-    if (length > 2000) {
-      length = 2000;
+    if (length > 3000) {
+      length = 3000;
     }
     const width = length * 0.1;
 

--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -123,7 +123,15 @@ export class PhoenixLoader implements EventDataLoader {
         new Cut('energy', 2000, 10000)
       ];
 
-      this.addObjectType(eventData.Jets, PhoenixObjects.getJet, 'Jets', cuts);
+      const addJetsSizeOption = (typeFolder: any) => {
+        const sizeMenu = typeFolder.add({ jetsScale: 100 }, 'jetsScale', 1, 200)
+          .name('Jets Size (%)');
+        sizeMenu.onChange((value: number) => {
+          this.graphicsLibrary.getSceneManager().scaleJets(value);
+        });
+      };
+
+      this.addObjectType(eventData.Jets, PhoenixObjects.getJet, 'Jets', cuts, addJetsSizeOption);
     }
 
     if (eventData.Hits) {
@@ -152,10 +160,12 @@ export class PhoenixLoader implements EventDataLoader {
    * @param getObject Function that handles of reconstructing objects of the given type.
    * @param typeName Label for naming the object type.
    * @param cuts Filters that can be applied to the objects.
+   * @param extendEventDataTypeUI A callback to add more options to event data type UI folder.
    */
-  protected addObjectType(object: any, getObject: any, typeName: string, cuts?: Cut[]) {
+  protected addObjectType(object: any, getObject: any, typeName: string,
+    cuts?: Cut[], extendEventDataTypeUI?: (typeFolder: any) => void) {
 
-    const typeFolder = this.ui.addEventDataTypeFolder(typeName);
+    const typeFolder = this.ui.addEventDataTypeFolder(typeName, extendEventDataTypeUI);
     const objectGroup = this.graphicsLibrary.addEventDataTypeGroup(typeName);
 
     const collectionsList: string[] = this.getObjectTypeCollections(object);

--- a/src/app/services/three/scene-manager.ts
+++ b/src/app/services/three/scene-manager.ts
@@ -1,6 +1,5 @@
-import { Scene, Object3D, Color, LineSegments, Mesh, MeshPhongMaterial, LineBasicMaterial, Vector3, Group, AxesHelper, AmbientLight, DirectionalLight, Line, MeshBasicMaterial, Material, Points, PointsMaterial, MeshToonMaterial, Camera, CylinderGeometry } from 'three';
+import { Scene, Object3D, Color, LineSegments, Mesh, MeshPhongMaterial, LineBasicMaterial, Vector3, Group, AxesHelper, AmbientLight, DirectionalLight, Line, MeshBasicMaterial, Material, Points, PointsMaterial, MeshToonMaterial, Camera } from 'three';
 import { Cut } from '../extras/cut.model';
-import { PhoenixObjects } from '../loaders/objects/phoenix-objects';
 
 /**
  * Manager for managing functions of the three.js scene.
@@ -390,25 +389,20 @@ export class SceneManager {
         });
     }
 
-    public changeJetsSize(value: number) {
+    /**
+     * Change the scale of Jets.
+     * @param value Percentage factor by which the Jets are to be scaled.
+     */
+    public scaleJets(value: number) {
         const jets = this.scene.getObjectByName('Jets');
         value /= 100;
 
-        jets.traverse((objectChild: any) => {
+        jets.traverse((objectChild: Object3D) => {
             if (objectChild.name === 'Jet') {
-                const jetParent = objectChild.parent;
-                jetParent.remove(objectChild);
-                const jetParams = objectChild.userData;
-
-                // We don't want a reference
-                const oldJetParams = JSON.parse(JSON.stringify(jetParams));
-                
-                jetParams.energy ? jetParams.energy *= value : jetParams.et *= value;
-                const newJet = PhoenixObjects.getJet(jetParams);
-                
-                // Restoring energy value
-                newJet.userData.energy ? oldJetParams.energy : oldJetParams.et;
-                jetParent.add(newJet);
+                const previousScale = objectChild.scale.x;
+                objectChild.scale.setScalar(value);
+                // Restoring to original position and then moving again with the current value.
+                objectChild.position.divideScalar(previousScale).multiplyScalar(value);
             }
         });
     }

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -29,12 +29,8 @@ export class UIService {
   };
   /** dat.GUI menu folder containing geometries data. */
   private geomFolder: any;
-  /** dat.GUI menu folder containing controls. */
-  private controlsFolder: any;
   /** dat.GUI menu folder containing event related data. */
   private eventFolder: any;
-  /** dat.GUI menu folder containing view options. */
-  private viewFolder: any;
   /** Configuration options for preset views and event data loader. */
   private configuration: Configuration;
   /** Canvas in which event display is rendered. */
@@ -242,6 +238,14 @@ export class UIService {
     this.guiParameters.eventData[typeName] = true;
     const menu = typeFolder.add(this.guiParameters.eventData, typeName).name('Show').listen();
     menu.onChange((value) => this.three.getSceneManager().objectVisibility(typeName, value));
+
+    if (typeName.toLowerCase() === 'jets') {
+      const sizeMenu = typeFolder.add({ jetsSize: 0.01 }, 'jetsSize', 0.01, 2).name('Jets Size');
+      sizeMenu.onChange((value) => {
+        this.three.getSceneManager().changeJetsSize(value);
+      }); 
+    }
+
     return typeFolder;
   }
 

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -231,20 +231,17 @@ export class UIService {
   /**
    * Add folder for event data type like tracks or hits to the dat.GUI menu.
    * @param typeName Name of the type of event data.
+   * @param extendEventDataTypeUI A callback to add more options to event data type UI folder.
    * @returns dat.GUI menu's folder for event data type.
    */
-  public addEventDataTypeFolder(typeName: string): any {
+  public addEventDataTypeFolder(typeName: string,
+    extendEventDataTypeUI?: (typeFolder: any) => void): any {
     const typeFolder = this.eventFolder.addFolder(typeName);
     this.guiParameters.eventData[typeName] = true;
     const menu = typeFolder.add(this.guiParameters.eventData, typeName).name('Show').listen();
     menu.onChange((value) => this.three.getSceneManager().objectVisibility(typeName, value));
 
-    if (typeName.toLowerCase() === 'jets') {
-      const sizeMenu = typeFolder.add({ jetsSize: 0.01 }, 'jetsSize', 0.01, 2).name('Jets Size');
-      sizeMenu.onChange((value) => {
-        this.three.getSceneManager().changeJetsSize(value);
-      }); 
-    }
+    extendEventDataTypeUI?.(typeFolder);
 
     return typeFolder;
   }


### PR DESCRIPTION
Closes #103 

Hi,

## Description

This makes the Jets scalable and also allows to extend UI menu options for each object type which can be used with any loader (by using the `PhoenixLoader.addObjectType` method from a child class).

I have been trying out options to scale Jets since yesterday but removing and recreating the Jets with increased energy wasn't working for large number of Jets. So after a lot of tries I came up with a minimal method which I think is the best.

## Added
* Fixed depthTest not working correctly
* Removed custom synchronous function to loop through children for changing depthTest (I am not sure why but `Object3D.traverse` seems to work now - while depthTest only worked with `updateChildrenDepthTest` function earlier)
* Made Jets scalable by increasing their scale and changing their position
* Ability to scale Jets from 1% to 200%
* Increased maximum Jet length to 3000 as it looks like a better option
* **Mechanism to add exclusive options to each event data type folder of dat.GUI through an optional callback passed to `PhoenixLoader.addObjectType`**

## Screen Capture
![wip-scalable-jets](https://user-images.githubusercontent.com/36920441/86415564-e0e4ab00-bce0-11ea-8a97-af43b210c292.gif)
