### PR TITLE
Loading data of all events in CMS

### DIFF
--- a/src/app/sections/cms/cms.component.ts
+++ b/src/app/sections/cms/cms.component.ts
@@ -33,9 +33,9 @@ export class CMSComponent implements OnInit {
 
     this.eventDisplay.loadGLTFGeometry('assets/geometry/CMS/cms.gltf', 'CMS detector', 400);
 
-    cmsLoader.loadEventDataFromIg('assets/files/cms/EventData.ig', 'Event', (eventData: any) => {
-      cmsLoader.putEventData(eventData);
-      this.eventDisplay.buildEventDataFromJSON(cmsLoader.getEventData());
+    cmsLoader.readIgArchive('assets/files/cms/Hto4l_120-130GeV.ig', (allEvents: any[]) => {
+      const allEventsData = cmsLoader.getAllEventsData(allEvents);
+      this.eventDisplay.parsePhoenixEvents(allEventsData);
     });
 
   }

--- a/src/app/services/loaders/cms-loader.ts
+++ b/src/app/services/loaders/cms-loader.ts
@@ -69,6 +69,9 @@ export class CMSLoader extends PhoenixLoader {
                                 i++;
                             });
                     } else {
+                        if (i === allFilesPath.length) {
+                            onFileRead(eventsDataInIg);
+                        }
                         i++;
                     }
                 }
@@ -138,6 +141,20 @@ export class CMSLoader extends PhoenixLoader {
         }
 
         return eventData;
+    }
+
+    /**
+     * Get event data of all events.
+     * @param allEventsDataFromIg An array containing data of all events from ".ig" file.
+     * @returns An object containing event data for all events.
+     */
+    public getAllEventsData(allEventsDataFromIg: any[]): any {
+        let allEventsData = {};
+        for (const eventData of allEventsDataFromIg) {
+            this.data = eventData;
+            allEventsData[eventData.eventPath] = this.getEventData();
+        }
+        return allEventsData;
     }
 
     /**


### PR DESCRIPTION
Hi,

## Description

This enables loading data of all events from an ".ig" file in the CMS section of Phoenix.

## Added

* A function to get data of all events from ".ig" file in a format suitable for Phoenix
* Loading all events from ".ig" file using `EventDisplay.parsePhoenixEvents` which adds the option to select any event from the UI menu

## Screen Capture

![wip-cms-all-events](https://user-images.githubusercontent.com/36920441/86579957-7610c980-bf97-11ea-80ff-4c598118e719.gif)
