### PR TITLE
Option to load geometry on demand

### DIFF
--- a/src/app/sections/atlas/atlas.component.ts
+++ b/src/app/sections/atlas/atlas.component.ts
@@ -31,14 +31,14 @@ export class AtlasComponent implements OnInit {
     this.eventDisplay.init(configuration);
     this.http.get('assets/files/event_data/atlaseventdump2.json')
       .subscribe((res: any) => this.eventDisplay.parsePhoenixEvents(res));
-    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/toroids.obj', 'Toroids', 0x8c8c8c, false);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/toroids.obj', 'Toroids', 0x8c8c8c, false, false);
     this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/TRT.obj', 'TRT', 0x356aa5, false);
     this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/SCT.obj', 'SCT', 0xfff400, false);
     this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/pixel.obj', 'Pixel', 0x356aa5, false);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/LAR_Bar.obj', 'LAr Barrel', 0x19CCD2, true);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/LAR_EC1.obj', 'LAr EC1', 0x19CCD2, true);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/LAR_EC2.obj', 'LAr EC2', 0x19CCD2, true);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/TileCal.obj', 'Tile Cal', 0xc14343, true);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/LAR_Bar.obj', 'LAr Barrel', 0x19CCD2, true, false);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/LAR_EC1.obj', 'LAr EC1', 0x19CCD2, true, false);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/LAR_EC2.obj', 'LAr EC2', 0x19CCD2, true, false);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/ATLAS/TileCal.obj', 'Tile Cal', 0xc14343, true, false);
 
   }
 }

--- a/src/app/services/eventdisplay.service.ts
+++ b/src/app/services/eventdisplay.service.ts
@@ -141,10 +141,12 @@ export class EventdisplayService {
    * @param name Name given to the geometry.
    * @param color Color to initialize the geometry.
    * @param doubleSided Renders both sides of the material.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadOBJGeometry(filename: string, name: string, color: any, doubleSided: boolean) {
-    this.graphicsLibrary.loadOBJGeometry(filename, name, color, doubleSided);
-    this.ui.addGeometry(name, color);
+  public loadOBJGeometry(filename: string, name: string, color: any,
+    doubleSided: boolean = false, initiallyVisible: boolean = true) {
+    this.graphicsLibrary.loadOBJGeometry(filename, name, color, doubleSided, initiallyVisible);
+    this.ui.addGeometry(name, color, initiallyVisible);
     this.infoLogger.add(name, 'Loaded OBJ geometry');
   }
 
@@ -153,10 +155,11 @@ export class EventdisplayService {
    * and adds it to the dat.GUI menu.
    * @param content Content of the OBJ geometry.
    * @param name Name given to the geometry.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public parseOBJGeometry(content: string, name: string) {
-    this.graphicsLibrary.parseOBJGeometry(content, name);
-    this.ui.addGeometry(name, 0x000fff);
+  public parseOBJGeometry(content: string, name: string, initiallyVisible: boolean = true) {
+    this.graphicsLibrary.parseOBJGeometry(content, name, initiallyVisible);
+    this.ui.addGeometry(name, 0x000fff, initiallyVisible);
   }
 
   /**
@@ -208,10 +211,12 @@ export class EventdisplayService {
    * @param url URL to the GLTF (.gltf) file.
    * @param name Name of the loaded scene/geometry.
    * @param scale Scale of the geometry.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadGLTFGeometry(url: any, name: string, scale?: number) {
-    this.graphicsLibrary.loadGLTFGeometry(url, name, scale);
-    this.ui.addGeometry(name, 0xff0000);
+  public loadGLTFGeometry(url: any, name: string,
+    scale?: number, initiallyVisible: boolean = true) {
+    this.graphicsLibrary.loadGLTFGeometry(url, name, scale, initiallyVisible);
+    this.ui.addGeometry(name, 0xff0000, initiallyVisible);
     this.infoLogger.add(name, 'Loaded GLTF geometry');
   }
 
@@ -220,10 +225,12 @@ export class EventdisplayService {
    * @param json JSON or URL to JSON file of the geometry.
    * @param name Name of the geometry or group of geometries.
    * @param scale Scale of the geometry.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadJSONGeometry(json: string | object, name: string, scale?: number) {
-    this.graphicsLibrary.loadJSONGeometry(json, name, scale);
-    this.ui.addGeometry(name, 0xff0000);
+  public loadJSONGeometry(json: string | object, name: string,
+    scale?: number, initiallyVisible: boolean = true) {
+    this.graphicsLibrary.loadJSONGeometry(json, name, scale, initiallyVisible);
+    this.ui.addGeometry(name, 0xff0000, initiallyVisible);
     this.infoLogger.add(name, 'Loaded JSON geometry');
   }
 
@@ -378,7 +385,7 @@ export class EventdisplayService {
    * @returns uuid of the currently selected object.
    */
   public getActiveObjectId(): any {
-      return this.graphicsLibrary.getActiveObjectId();
+    return this.graphicsLibrary.getActiveObjectId();
   }
 
   /**

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -206,15 +206,20 @@ export class ThreeService {
    * @param name Name given to the geometry.
    * @param color Color to initialize the geometry.
    * @param doubleSided Renders both sides of the material.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
   public loadOBJGeometry(
     filename: string,
     name: string,
     color: any,
-    doubleSided: boolean
+    doubleSided: boolean = false,
+    initiallyVisible: boolean = true
   ): void {
     const geometries = this.sceneManager.getGeometries();
-    const callback = (object: Group) => geometries.add(object);
+    const callback = (object: Group) => {
+      object.visible = initiallyVisible;
+      geometries.add(object);
+    };
     this.importManager.loadOBJGeometry(callback, filename, name, color, doubleSided);
   }
 
@@ -223,10 +228,15 @@ export class ThreeService {
    * @param sceneUrl URL to the GLTF (.gltf) file.
    * @param name Name of the loaded scene/geometry.
    * @param scale Scale of the geometry.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadGLTFGeometry(sceneUrl: any, name: string, scale?: number) {
+  public loadGLTFGeometry(sceneUrl: any, name: string,
+    scale?: number, initiallyVisible: boolean = true) {
     const geometries = this.sceneManager.getGeometries();
-    const callback = (geometry: Object3D) => geometries.add(geometry);
+    const callback = (geometry: Object3D) => {
+      geometry.visible = initiallyVisible;
+      geometries.add(geometry);
+    };
     this.importManager.loadGLTFGeometry(sceneUrl, name, callback, scale);
   }
 
@@ -234,10 +244,12 @@ export class ThreeService {
    * Parses and loads a geometry in OBJ (.obj) format.
    * @param geometry Geometry in OBJ (.obj) format.
    * @param name Name given to the geometry.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public parseOBJGeometry(geometry: string, name: string) {
+  public parseOBJGeometry(geometry: string, name: string, initiallyVisible: boolean = true) {
     const geometries = this.sceneManager.getGeometries();
     const object = this.importManager.parseOBJGeometry(geometry, name);
+    object.visible = initiallyVisible;
     geometries.add(object);
   }
 
@@ -258,10 +270,15 @@ export class ThreeService {
    * @param json JSON or URL to JSON file of the geometry.
    * @param name Name of the geometry or group of geometries.
    * @param scale Scale of the geometry.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadJSONGeometry(json: string | object, name: string, scale?: number) {
+  public loadJSONGeometry(json: string | object, name: string,
+    scale?: number, initiallyVisible: boolean = true) {
     const geometries = this.sceneManager.getGeometries();
-    const callback = (geometry: Object3D) => geometries.add(geometry);
+    const callback = (geometry: Object3D) => {
+      geometry.visible = initiallyVisible;
+      geometries.add(geometry);
+    };
     this.importManager.loadJSONGeometry(json, name, callback, scale);
   }
 
@@ -274,7 +291,8 @@ export class ThreeService {
   }
 
   /**
-   * Exports scene as phoenix format, allowing to load it later and recover the saved configuration.
+   * Exports scene as phoenix format, allowing to 
+   * load it later and recover the saved configuration.
    */
   public exportPhoenixScene() {
     const scene = this.sceneManager.getCleanScene();
@@ -351,9 +369,9 @@ export class ThreeService {
     this.controlsManager.zoomTo(zoomFactor, zoomTime);
   }
 
-  // *********************************
-  // * Private auxiliary functions.  *
-  // *********************************
+  // ********************************
+  // * Private auxiliary functions. *
+  // ********************************
 
   /**
    * Sets different parameters according to the configuration.

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -69,12 +69,13 @@ export class UIService {
    * @param configuration Configuration options for preset views and event data loader.
    */
   public showUI(configuration: Configuration) {
+    this.configuration = configuration;
     // Shows a panel on screen with information about the performance (fps).
     this.showStats();
     // Shows the menu that contains the options to interact with the scene.
     if (configuration.enableDatGUIMenu) {
       this.hasDatGUIMenu = true;
-      this.showDatGUIMenu(configuration);
+      this.showDatGUIMenu();
     }
     // Detect UI color scheme
     this.detectColorScheme();
@@ -109,10 +110,8 @@ export class UIService {
 
   /**
    * Show dat.GUI menu with different controls related to detector geometry and event data.
-   * @param configuration Configuration options for the menu.
    */
-  private showDatGUIMenu(configuration: Configuration) {
-    this.configuration = configuration;
+  private showDatGUIMenu() {
     this.gui = new dat.GUI();
     this.gui.domElement.id = 'gui';
     this.canvas = document.getElementById('eventDisplay');
@@ -190,15 +189,16 @@ export class UIService {
    * Adds geometry to the dat.GUI menu's geometry folder and sets up its configurable options.
    * @param name Name of the geometry.
    * @param colour Color of the geometry.
+   * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public addGeometry(name: string, colour: any) {
+  public addGeometry(name: string, colour: any, initiallyVisible: boolean = true) {
     if (this.hasDatGUIMenu) {
       if (this.geomFolder == null) {
         this.addGeomFolder();
       }
       // A new folder for the object is added to the 'Geometry' folder
       this.guiParameters[name] = {
-        show: true, color: colour, x: 0, y: 0, z: 0, detectorOpacity: 1.0, remove: this.removeOBJ(name), scale: 1
+        show: initiallyVisible, color: colour, x: 0, y: 0, z: 0, detectorOpacity: 1.0, remove: this.removeOBJ(name), scale: 1
       };
       const objFolder = this.geomFolder.addFolder(name);
       // A color picker is added to the object's folder
@@ -237,6 +237,7 @@ export class UIService {
       const objFolderPM = this.geomFolderPM.addChild(name, (value: boolean) => {
         this.three.getSceneManager().objectVisibility(name, value);
       });
+      objFolderPM.toggleState = initiallyVisible;
       objFolderPM.addConfig('color', {
         label: 'Color',
         onChange: (value: any) => {


### PR DESCRIPTION
Closes #106 

Hi,

## Description

This adds option for making the geometry initially invisible through the geometry loading functions.
**NOTE:** @EdwardMoyse let me know which geometries from ATLAS are to be made initially invisible. I will push to this PR once I know.

## Added

* Added param `initiallyVisible: boolean = true` to `loadOBJGeometry`, `parseOBJGeometry`,  `loadGLTFGeometry` and `loadJSONGeometry` functions of `EventdisplayService` for making geometry invisible (initiallyVisible = false) by default
* Fix preset views not loading (set the configuration property of `UIService` through `showUI` instead of `showDatGUIMenu` since dat.GUI menu is optional now)

## Screen Capture

(With "Toroids" and "Tile Cal" initially invisible)
![fix-geometry-on-demand](https://user-images.githubusercontent.com/36920441/88386288-80b9c400-cdc9-11ea-8a0f-e1a42e842127.gif)
