### PR TITLE
Keyboard controls

### DIFF
--- a/src/app/components/ui-menu/overlay-view/overlay-view.component.ts
+++ b/src/app/components/ui-menu/overlay-view/overlay-view.component.ts
@@ -1,8 +1,6 @@
 import { Component, ComponentRef, OnDestroy, OnInit } from '@angular/core';
-import { EventdisplayService } from 'src/app/services/eventdisplay.service';
 import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { ObjectSelectionOverlayComponent } from '../object-selection/object-selection-overlay/object-selection-overlay.component';
 import { OverlayViewWindowComponent } from './overlay-view-window/overlay-view-window.component';
 
 @Component({

--- a/src/app/services/eventdisplay.service.ts
+++ b/src/app/services/eventdisplay.service.ts
@@ -67,6 +67,8 @@ export class EventdisplayService {
 
     // Allow adding elements through console
     this.enableEventDisplayConsole();
+    // Allow keyboard controls
+    this.enableKeyboardControls();
   }
 
   /**
@@ -436,5 +438,13 @@ export class EventdisplayService {
    */
   public highlightObject(uuid: string) {
     this.graphicsLibrary.highlightObject(uuid);
+  }
+
+  /**
+   * Enable keyboard controls for the event display.
+   */
+  public enableKeyboardControls() {
+    this.ui.enableKeyboardControls();
+    this.graphicsLibrary.enableKeyboardControls();
   }
 }

--- a/src/app/services/three.service.ts
+++ b/src/app/services/three.service.ts
@@ -9,8 +9,7 @@ import {
   Quaternion,
   AmbientLight,
   DirectionalLight,
-  AxesHelper,
-  Camera
+  AxesHelper
 } from 'three';
 import { Configuration } from './extras/configuration.model';
 import { ControlsManager } from './three/controls-manager';
@@ -265,7 +264,7 @@ export class ThreeService {
     this.importManager.parseGLTFGeometry(geometry, callback);
   }
 
-  /**	
+  /**
    * Loads geometries from JSON.
    * @param json JSON or URL to JSON file of the geometry.
    * @param name Name of the geometry or group of geometries.
@@ -292,7 +291,7 @@ export class ThreeService {
   }
 
   /**
-   * Exports scene as phoenix format, allowing to 
+   * Exports scene as phoenix format, allowing to
    * load it later and recover the saved configuration.
    */
   public exportPhoenixScene() {
@@ -454,5 +453,37 @@ export class ThreeService {
    */
   public highlightObject(uuid: string) {
     this.selectionManager.highlightObject(uuid, this.getSceneManager().getEventData());
+  }
+
+  /**
+   * Enable keyboard controls for some Three service operations.
+   */
+  public enableKeyboardControls() {
+    document.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.shiftKey) {
+        switch (e.keyCode) {
+          case 82: // shift + "r"
+            this.autoRotate(!this.controlsManager.getActiveControls().autoRotate);
+            break;
+          case 187: // shift + "+"
+            this.zoomTo(1 / 1.2, 100);
+            break;
+          case 189: // shift + "-"
+            this.zoomTo(1.2, 100);
+            break;
+          case 67: // shift + "c"
+            this.setClipping(!this.rendererManager.getLocalClipping());
+            if (this.rendererManager.getLocalClipping()) {
+              this.rotateClipping(180);
+            }
+            break;
+          case 86: // shift + "v"
+            const isOrthographicView = this.controlsManager.getMainCamera()
+              .type === 'OrthographicCamera';
+            this.swapCameras(!isOrthographicView);
+            break;
+        }
+      }
+    });
   }
 }

--- a/src/app/services/three/renderer-manager.ts
+++ b/src/app/services/three/renderer-manager.ts
@@ -186,6 +186,16 @@ export class RendererManager {
   }
 
   /**
+   * Get if the local clipping for the first renderer is enabled or disabled.
+   * @returns If the renderer local clipping is enabled or disabled.
+   */
+  public getLocalClipping() {
+    if (this.renderers.length > 0) {
+      return this.renderers[0].localClippingEnabled;
+    }
+  }
+
+  /**
    * Check if the overlay is fixed or not.
    * @returns If the overlay is fixed or not.
    */

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -500,6 +500,8 @@ export class UIService {
       localStorage.setItem('theme', 'light');
       document.documentElement.setAttribute('data-theme', 'light');
     }
+
+    this.darkTheme = dark;
     this.three.getSceneManager().darkBackground(dark);
   }
 
@@ -553,10 +555,6 @@ export class UIService {
     this.three.setOverlayRenderer(overlayCanvas);
   }
 
-  // ****************
-  // * PHOENIX MENU *
-  // ****************
-
   /**
    * Set the phoenix menu to be used by the UI service.
    * @param phoenixMenu The root node of phoenix menu.
@@ -565,4 +563,26 @@ export class UIService {
     this.phoenixMenu = phoenixMenu;
   }
 
+  /**
+   * Enable keyboard controls for some UI service operations.
+   */
+  public enableKeyboardControls() {
+    document.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.shiftKey) {
+        switch (e.keyCode) {
+          case 68: // shift + "d"
+            this.setDarkTheme(!this.getDarkTheme());
+            break;
+        }
+
+        // Shortcut keys for preset views (shift + 1...9)
+        if (e.keyCode > 48 && e.keyCode < 57) {
+          const indexFromKeyCode = Math.abs(49 - e.keyCode);
+          if (this.configuration.presetViews[indexFromKeyCode]) {
+            this.displayView(this.configuration.presetViews[indexFromKeyCode]);
+          }
+        }
+      }
+    });
+  }
 }

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -570,7 +570,7 @@ export class UIService {
     document.addEventListener("keydown", (e: KeyboardEvent) => {
       if (e.shiftKey) {
         switch (e.keyCode) {
-          case 68: // shift + "d"
+          case 84: // shift + "t"
             this.setDarkTheme(!this.getDarkTheme());
             break;
         }


### PR DESCRIPTION
**Note:** To be merged after PR 118 

Hi,

## Description

This adds keyboard controls for common event display and three service functions.

## Added

* Keyboard controls for
  * Toggling theme (`shift + t`)
  * Going to preset view (`shift + 1..9` - 1 to 9 is the index of preset view with 1 being the first preset view)
  * Autorotate (`shift + r`)
  * Zoom in (`shift + "+"`)
  * Zoom out (`shift + "-"`)
  * 180° Clipping (`shift + c`)
  * Toggling view (`shift + v`)