### PR TITLE
[WIP] Jive xml improvements

### DIFF
--- a/src/app/services/extras/runge-kutta.ts
+++ b/src/app/services/extras/runge-kutta.ts
@@ -85,11 +85,12 @@ export class RungeKutta {
    * @param q Charge.
    * @param mss Max step size.
    * @param plength Path length.
+   * @param inbounds Function which returns true until the passed position is out of bounds, when it returns false.
    * @returns An array containing position and direction at that position calculated
    * through the Runge-Kutta steps.
    */
   static propagate(startPos: Vector3, startDir: Vector3, p: number, q: number,
-    mss: number = -1, plength: number = 1000): { pos: Vector3, dir: Vector3 }[] {
+    mss: number = -1, plength: number = 1000, inbounds: any): { pos: Vector3, dir: Vector3 }[] {
     let rkState: State = new State();
     rkState.pos = startPos;
     rkState.dir = startDir;
@@ -99,7 +100,7 @@ export class RungeKutta {
 
     let result: { pos: Vector3, dir: Vector3 }[] = [];
 
-    while (rkState.pathLength < plength) {
+    while (rkState.pathLength < plength ) {
       rkState.pathLength += RungeKutta.step(rkState);
       // Cloning state to avoid using the reference
       let copiedState = JSON.parse(JSON.stringify(rkState));
@@ -107,6 +108,12 @@ export class RungeKutta {
         pos: copiedState.pos,
         dir: copiedState.dir
       });
+      // Ugly
+      if ( inbounds(copiedState.pos) != true){
+        console.log("Truncating at position = "+copiedState.pos)
+        console.log(Math.sqrt(copiedState.pos.x*copiedState.pos.x + copiedState.pos.y*copiedState.pos.y))
+        break;
+      }
     }
 
     return result;

--- a/src/app/services/helpers/rk-helper.ts
+++ b/src/app/services/helpers/rk-helper.ts
@@ -25,9 +25,11 @@ export class RKHelper {
   /**
    * Extrapolate tracks using RungeKutta propagator.
    * @param track Track which is to be extrapolated.
+   * @param inbounds Function which returns true until the passed position is out of bounds, when it returns false. Default just always returns true.
    * @returns An array of track positions.
+
    */
-  public static extrapolateTrackPositions(track: { dparams: any }): any {
+  public static extrapolateTrackPositions(track: { dparams: any },  inbounds: any=function() {return true;}): any {
     const dparams = track.dparams;
     // ATLAS uses mm, MeV
     let d0 = dparams[0],
@@ -66,7 +68,12 @@ export class RKHelper {
     const startDir = globalMomentum.clone();
     startDir.normalize();
 
-    const traj = RungeKutta.propagate(startPos, startDir, p, q, 10, 2500);
+    // if (p < 0.5 ){
+    //   console.log("Track with very low momentum - not going to try to extrapolate.")
+    //   return positions;
+    // }
+
+    const traj = RungeKutta.propagate(startPos, startDir, p, q, 10, 2500 , inbounds);
 
     const extrapolatedPos = traj.map(val => [val.pos.x, val.pos.y, val.pos.z]);
 

--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -186,7 +186,7 @@ export class PhoenixObjects {
    * @returns Cluster object.
    */
   public static getCluster(clusterParams: any): Object3D {
-    const maxR = 1100.0;
+    const maxR = 1100.0; // This needs to be configurable. 
     const maxZ = 3200.0;
     const length = clusterParams.energy * 0.003;
     // geometry
@@ -213,6 +213,26 @@ export class PhoenixObjects {
     clusterParams.uuid = cube.uuid;
 
     return cube;
+  }
+
+  public static getVertex(vertexParams: any): Object3D {
+
+    // geometry
+    const geometry = new THREE.SphereBufferGeometry(3);
+    // material
+    const material = new THREE.MeshPhongMaterial({ color: 0xFFD166 });
+    // object
+    const sphere = new THREE.Mesh(geometry, material);
+    sphere.position.x = vertexParams.x;
+    sphere.position.y = vertexParams.y;
+    sphere.position.z = vertexParams.y;
+
+    sphere.userData = vertexParams;
+    sphere.name = 'Vertex';
+    // Setting uuid for selection from collections info
+    vertexParams.uuid = sphere.uuid;
+
+    return sphere;
   }
 
 }

--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -16,19 +16,33 @@ export class PhoenixObjects {
   public static getTrack(trackParams: any): Object3D {
     let positions = trackParams.pos;
     // Track with no points
-    if (!positions) {
-      console.log("Track with no positions.")
-      return;
-    }
+    // if (positions.length==0) {
+    //   console.log("Track with no positions.")
+    //   return;
+    // }
+
+    // Test, for ATLAS. 
+    // FIXME - make configurable
+    let inBounds = function (pos: THREE.Vector3) {
+      if (pos.z>3000) return false;
+      if ( Math.sqrt(pos.x*pos.x + pos.y*pos.y) > 1100) return false;
+      return true
+    };
 
     // Track with too few points are extrapolated with RungeKutta
     if (positions.length < 3) {
       if (trackParams?.dparams) {
-        positions = RKHelper.extrapolateTrackPositions(trackParams);
-      } else {
-        return;
+        // console.log("About to extrapolate track with "+trackParams);
+        positions = RKHelper.extrapolateTrackPositions(trackParams, inBounds);
+        // console.log("After extrapolation, got back "+positions.length+".")
       }
     }
+    // Check again, in case there was an issue with the extrapolation.
+    if (positions.length < 3) {
+      console.log("Error in getTrack: Track with "+positions.length+" positions even after attempt at extrapolation.")
+      return;
+    }
+   
 
     // const length = 100;
     let objectColor = 0xff0000;

--- a/src/app/services/loaders/objects/phoenix-objects.ts
+++ b/src/app/services/loaders/objects/phoenix-objects.ts
@@ -39,7 +39,7 @@ export class PhoenixObjects {
     }
     // Check again, in case there was an issue with the extrapolation.
     if (positions.length < 3) {
-      console.log("Error in getTrack: Track with "+positions.length+" positions even after attempt at extrapolation.")
+      // console.log("Error in getTrack: Track with "+positions.length+" positions even after attempt at extrapolation.")
       return;
     }
    

--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -176,6 +176,14 @@ export class PhoenixLoader implements EventDataLoader {
       this.addObjectType(eventData.Muons, this.getMuon, 'Muons');
     }
 
+    // if (eventData.Photons) {
+    //   this.addObjectType(eventData.Photons, PhoenixObjects.getPhotons, 'Muons');
+    // }
+
+    // if (eventData.Electrons) {
+    //   this.addObjectType(eventData.Photons, PhoenixObjects.getElectrons, 'Muons');
+    // }
+
     if (eventData.Vertices) {
       this.addObjectType(eventData.Vertices, PhoenixObjects.getVertex, 'Vertices');
     }
@@ -201,7 +209,7 @@ export class PhoenixLoader implements EventDataLoader {
 
     for (const collectionName of collectionsList) {
       const objectCollection = object[collectionName];
-      // console.log(typeName+" collection "+collectionName+" has "+objectCollection.length+" constituents.")
+      console.log(typeName+" collection "+collectionName+" has "+objectCollection.length+" constituents.")
 
       this.addCollection(objectCollection, collectionName, getObject, objectGroup);
 
@@ -259,29 +267,31 @@ export class PhoenixLoader implements EventDataLoader {
    */
   protected getMuon(muonParams: any): Object3D {
     const muonScene = new Group();
+    if ('LinkedClusters' in muonParams){
+      for (const clusterID of muonParams.LinkedClusters) {
+        const clusterColl = clusterID.split(':')[0];
+        const clusterIndex = clusterID.split(':')[1];
 
-    for (const clusterID of muonParams.LinkedClusters) {
-      const clusterColl = clusterID.split(':')[0];
-      const clusterIndex = clusterID.split(':')[1];
-
-      if (clusterColl && clusterIndex && this.eventData.CaloClusters && this.eventData.CaloClusters[clusterColl]) {
-        const clusterParams = this.eventData.CaloClusters[clusterColl][clusterIndex];
-        if (clusterParams) {
-          const cluster = PhoenixObjects.getCluster(clusterParams);
-          muonScene.add(cluster);
+        if (clusterColl && clusterIndex && this.eventData.CaloClusters && this.eventData.CaloClusters[clusterColl]) {
+          const clusterParams = this.eventData.CaloClusters[clusterColl][clusterIndex];
+          if (clusterParams) {
+            const cluster = PhoenixObjects.getCluster(clusterParams);
+            muonScene.add(cluster);
+          }
         }
       }
     }
+    if ('LinkedTracks' in muonParams){
+      for (const trackID of muonParams.LinkedTracks) {
+        const trackColl = trackID.split(':')[0];
+        const trackIndex = trackID.split(':')[1];
 
-    for (const trackID of muonParams.LinkedTracks) {
-      const trackColl = trackID.split(':')[0];
-      const trackIndex = trackID.split(':')[1];
-
-      if (trackColl && trackIndex && this.eventData.Tracks && this.eventData.Tracks[trackColl]) {
-        const trackParams = this.eventData.Tracks[trackColl][trackIndex];
-        if (trackParams) {
-          const track = PhoenixObjects.getTrack(trackParams);
-          muonScene.add(track);
+        if (trackColl && trackIndex && this.eventData.Tracks && this.eventData.Tracks[trackColl]) {
+          const trackParams = this.eventData.Tracks[trackColl][trackIndex];
+          if (trackParams) {
+            const track = PhoenixObjects.getTrack(trackParams);
+            muonScene.add(track);
+          }
         }
       }
     }

--- a/src/app/services/loaders/phoenix-loader.ts
+++ b/src/app/services/loaders/phoenix-loader.ts
@@ -175,6 +175,10 @@ export class PhoenixLoader implements EventDataLoader {
     if (eventData.Muons) {
       this.addObjectType(eventData.Muons, this.getMuon, 'Muons');
     }
+
+    if (eventData.Vertices) {
+      this.addObjectType(eventData.Vertices, PhoenixObjects.getVertex, 'Vertices');
+    }
   }
 
   /**


### PR DESCRIPTION
This adds some new types of objects to Phoenix (not all can be displayed yet) and also adds the ability to truncate the Track extrapolation at a Volume. For example, for ATLAS it doesn't really make sense to extrapolate tracks past the entrance to the calorimeter.

This is not very elegant TypeScript - @9inpachi I'd appreciate a code review! I bet there are better ways to do a lot of this, especially the changes to the RK, and the conditional checks on the JiveXML contents (some tracks have some variables, which are missing on others).

There is one *big* problem at the moment - opening some jiveXML is very very slow (it does eventually complete) because the tracks are very low transverse momenta and so get extrapolated a long way. I think the path length and step size could help, but also it would be good to not try to propagate tracks with too low momenta.