### PR TITLE
Save and load Phoenix menu state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,14 @@ addons:
 cache:
   directories:
     - ./packages/phoenix-app/node_modules
-
-before_install:
-  - cd ./packages/phoenix-event-display
-  - npm link
-  - cd ../phoenix-app
+    - ./packages/phoenix-event-display/node_modules
 
 install:
-  - npm install
-  - npm link "phoenix-event-display"
+  - npm install lerna --global
+  - npm run install:dependencies
 
 script:
+  - cd ./packages/phoenix-app
   - npm run test:coverage -- --no-watch --no-progress --browsers=ChromeHeadlessCI
   - npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
   # Bug with Angular 10 (https://github.com/angular/protractor/issues/5460)

--- a/packages/phoenix-app/package-lock.json
+++ b/packages/phoenix-app/package-lock.json
@@ -8998,7 +8998,7 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "phoenix-event-display": {
-      "version": "file:../phoenix-event-display",
+      "version": "1.0.2",
       "requires": {
         "@tweenjs/tween.js": "^17.4.0",
         "dat.gui": "^0.7.7",

--- a/packages/phoenix-app/src/app/components/phoenix-menu/pheonix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-app/src/app/components/phoenix-menu/pheonix-menu-item/phoenix-menu-item.component.html
@@ -54,7 +54,9 @@
                 (input)="config.onChange($event.target.value); config.color = $event.target.value" />
 
               <ng5-slider *ngSwitchCase="'rangeSlider'" class="range-slider" [value]="config.min"
-                [highValue]="config.max" (userChange)="config.onChange($event)" [options]="{
+                [highValue]="config.max"
+                (userChange)="config.onChange($event); config.value = $event.value; config.highValue = $event.highValue"
+                [options]="{
                   floor: config.min,
                   ceil: config.max,
                   step: config.step,

--- a/packages/phoenix-app/src/app/components/phoenix-menu/pheonix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-app/src/app/components/phoenix-menu/pheonix-menu-item/phoenix-menu-item.component.html
@@ -53,8 +53,9 @@
               <input *ngSwitchCase="'color'" type="color" [value]="config.color"
                 (input)="config.onChange($event.target.value); config.color = $event.target.value" />
 
-              <ng5-slider *ngSwitchCase="'rangeSlider'" class="range-slider" [value]="config.min"
-                [highValue]="config.max"
+              <ng5-slider *ngSwitchCase="'rangeSlider'" class="range-slider"
+                [value]="config.value ? config.value : config.min"
+                [highValue]="config.highValue ? config.highValue : config.max"
                 (userChange)="config.onChange($event); config.value = $event.value; config.highValue = $event.highValue"
                 [options]="{
                   floor: config.min,

--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -237,7 +237,7 @@ export class EventDisplay {
   public loadGLTFGeometry(url: any, name: string,
     scale?: number, initiallyVisible: boolean = true) {
     this.graphicsLibrary.loadGLTFGeometry(url, name, scale, initiallyVisible);
-    this.ui.addGeometry(name, 0xff0000, initiallyVisible);
+    this.ui.addGeometry(name, undefined, initiallyVisible);
     this.infoLogger.add(name, 'Loaded GLTF geometry');
   }
 
@@ -252,7 +252,7 @@ export class EventDisplay {
   public loadJSONGeometry(json: string | object, name: string,
     scale?: number, doubleSided?: boolean, initiallyVisible: boolean = true) {
     this.graphicsLibrary.loadJSONGeometry(json, name, scale, doubleSided, initiallyVisible);
-    this.ui.addGeometry(name, 0xff0000, initiallyVisible);
+    this.ui.addGeometry(name, undefined, initiallyVisible);
     this.infoLogger.add(name, 'Loaded JSON geometry');
   }
 

--- a/packages/phoenix-event-display/src/extras/configuration.model.ts
+++ b/packages/phoenix-event-display/src/extras/configuration.model.ts
@@ -64,6 +64,19 @@ export class Configuration {
    */
   public setPhoenixMenuRoot(phoenixMenuNode: PhoenixMenuNode) {
     this.phoenixMenuRoot = phoenixMenuNode;
+
+    // Add save and load config buttons to the root node
+    this.phoenixMenuRoot.addConfig('button', {
+      label: 'Save state',
+      onClick: () => {
+        this.phoenixMenuRoot.saveStateAsJSON();
+      }
+    }).addConfig('button', {
+      label: 'Load state',
+      onClick: () => {
+        this.phoenixMenuRoot.loadStateFromFile();
+      }
+    });
   }
 
   /**

--- a/packages/phoenix-event-display/src/helpers/constants.ts
+++ b/packages/phoenix-event-display/src/helpers/constants.ts
@@ -1,0 +1,10 @@
+import { Color } from "three";
+
+export const EVENT_DATA_TYPE_COLORS = {
+  Hits: new Color(0xff0000),
+  Tracks: new Color(0xff0000),
+  Jets: new Color(0x2194CE),
+  CaloClusters: new Color(0xffd166),
+  MuonChambers: new Color(0xff0000),
+  Vertices: new Color(0xFFD166)
+};

--- a/packages/phoenix-event-display/src/loaders/objects/cms-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/cms-objects.ts
@@ -1,5 +1,5 @@
 import { Object3D, Vector3, Geometry, Face3, Group, Mesh, MeshBasicMaterial, EdgesGeometry, Line, LineBasicMaterial, DoubleSide, LineSegments, BufferGeometry } from "three";
-import { PhoenixObjects } from "./phoenix-objects";
+import { EVENT_DATA_TYPE_COLORS } from "../../helpers/constants";
 
 /**
  * Physics objects that make up an event in CMS that are not a part of {@link PhoenixObjects}.
@@ -60,7 +60,7 @@ export class CMSObjects {
     const boxBuffer = new BufferGeometry().fromGeometry(box);
 
     const boxObject = new Mesh(boxBuffer, new MeshBasicMaterial({
-      color: 0xff0000,
+      color: EVENT_DATA_TYPE_COLORS['MuonChambers'],
       transparent: true,
       opacity: 0.1,
       side: DoubleSide

--- a/packages/phoenix-event-display/src/loaders/objects/cms-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/cms-objects.ts
@@ -5,85 +5,85 @@ import { PhoenixObjects } from "./phoenix-objects";
  * Physics objects that make up an event in CMS that are not a part of {@link PhoenixObjects}.
  */
 export class CMSObjects {
-    /**
-     * Process the Muon Chamber from the given parameters.
-     * and get it as a geometry.
-     * @param muonChamberParams Parameters of the Muon Chamber.
-     * @returns Muon Chamber object.
-     */
-    public static getMuonChamber(muonChamberParams: any): Object3D {
-        let faces = [];
-        let backs = [];
+  /**
+   * Process the Muon Chamber from the given parameters.
+   * and get it as a geometry.
+   * @param muonChamberParams Parameters of the Muon Chamber.
+   * @returns Muon Chamber object.
+   */
+  public static getMuonChamber(muonChamberParams: any): Object3D {
+    let faces = [];
+    let backs = [];
 
-        for (const param of Object.keys(muonChamberParams)) {
-            if (param.startsWith('front')) {
-                faces.push(
-                    new Vector3().fromArray(muonChamberParams[param])
-                );
-            } else if (param.startsWith('back')) {
-                backs.push(
-                    new Vector3().fromArray(muonChamberParams[param])
-                );
-            }
-        }
-
-        let box = new Geometry();
-        box.vertices = faces.concat(backs);
-
-        // front
-        box.faces.push(new Face3(0, 1, 2));
-        box.faces.push(new Face3(2, 3, 0));
-
-        // back
-        box.faces.push(new Face3(4, 5, 6));
-        box.faces.push(new Face3(6, 7, 4));
-
-        // top
-        box.faces.push(new Face3(4, 5, 1));
-        box.faces.push(new Face3(1, 0, 4));
-
-        // bottom
-        box.faces.push(new Face3(7, 6, 2));
-        box.faces.push(new Face3(2, 3, 7));
-
-        // left
-        box.faces.push(new Face3(0, 3, 7));
-        box.faces.push(new Face3(7, 4, 0));
-
-        // right
-        box.faces.push(new Face3(1, 5, 6));
-        box.faces.push(new Face3(6, 2, 1));
-
-        box.computeFaceNormals();
-        box.computeVertexNormals();
-
-        const boxBuffer = new BufferGeometry().fromGeometry(box);
-
-        const boxObject = new Mesh(boxBuffer, new MeshBasicMaterial({
-            color: 0xff0000,
-            transparent: true,
-            opacity: 0.1,
-            side: DoubleSide
-        }));
-
-        boxObject.userData = Object.assign({}, muonChamberParams);
-        boxObject.name = 'MuonChamber';
-
-        // These are the lines along the box edges
-
-        const boxEdges = new EdgesGeometry(boxBuffer);
-        const lineBoxObject = new LineSegments(boxEdges, new LineBasicMaterial({
-            color: 0xffffff,
-            transparent: true,
-            opacity: 0.7
-        }));
-
-        const muonChamber = new Group();
-        muonChamber.add(boxObject);
-        muonChamber.add(lineBoxObject);
-
-        muonChamberParams.uuid = boxObject.uuid;
-
-        return muonChamber;
+    for (const param of Object.keys(muonChamberParams)) {
+      if (param.startsWith('front')) {
+        faces.push(
+          new Vector3().fromArray(muonChamberParams[param])
+        );
+      } else if (param.startsWith('back')) {
+        backs.push(
+          new Vector3().fromArray(muonChamberParams[param])
+        );
+      }
     }
+
+    let box = new Geometry();
+    box.vertices = faces.concat(backs);
+
+    // front
+    box.faces.push(new Face3(0, 1, 2));
+    box.faces.push(new Face3(2, 3, 0));
+
+    // back
+    box.faces.push(new Face3(4, 5, 6));
+    box.faces.push(new Face3(6, 7, 4));
+
+    // top
+    box.faces.push(new Face3(4, 5, 1));
+    box.faces.push(new Face3(1, 0, 4));
+
+    // bottom
+    box.faces.push(new Face3(7, 6, 2));
+    box.faces.push(new Face3(2, 3, 7));
+
+    // left
+    box.faces.push(new Face3(0, 3, 7));
+    box.faces.push(new Face3(7, 4, 0));
+
+    // right
+    box.faces.push(new Face3(1, 5, 6));
+    box.faces.push(new Face3(6, 2, 1));
+
+    box.computeFaceNormals();
+    box.computeVertexNormals();
+
+    const boxBuffer = new BufferGeometry().fromGeometry(box);
+
+    const boxObject = new Mesh(boxBuffer, new MeshBasicMaterial({
+      color: 0xff0000,
+      transparent: true,
+      opacity: 0.1,
+      side: DoubleSide
+    }));
+
+    boxObject.userData = Object.assign({}, muonChamberParams);
+    boxObject.name = 'MuonChamber';
+
+    // These are the lines along the box edges
+
+    const boxEdges = new EdgesGeometry(boxBuffer);
+    const lineBoxObject = new LineSegments(boxEdges, new LineBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.7
+    }));
+
+    const muonChamber = new Group();
+    muonChamber.add(boxObject);
+    muonChamber.add(lineBoxObject);
+
+    muonChamberParams.uuid = boxObject.uuid;
+
+    return muonChamber;
+  }
 }

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -1,4 +1,5 @@
 import { Vector3, Object3D, CatmullRomCurve3, TubeBufferGeometry, MeshToonMaterial, Mesh, BufferGeometry, LineBasicMaterial, Line, Group, Quaternion, CylinderBufferGeometry, MeshBasicMaterial, BufferAttribute, PointsMaterial, Points, BoxBufferGeometry, MeshPhongMaterial, SphereBufferGeometry } from 'three';
+import { EVENT_DATA_TYPE_COLORS } from '../../helpers/constants';
 import { RKHelper } from '../../helpers/rk-helper';
 
 /**
@@ -44,7 +45,7 @@ export class PhoenixObjects {
 
 
     // const length = 100;
-    let objectColor = 0xff0000;
+    let objectColor = EVENT_DATA_TYPE_COLORS['Tracks'].getHex();
     if (trackParams.color) {
       objectColor = parseInt(trackParams.color, 16);
     }
@@ -134,7 +135,7 @@ export class PhoenixObjects {
 
     const geometry = new CylinderBufferGeometry(width, 1, length, 50, 50, false); // Cone
 
-    const material = new MeshBasicMaterial({ color: 0x2194CE, opacity: 0.3, transparent: true });
+    const material = new MeshBasicMaterial({ color: EVENT_DATA_TYPE_COLORS['Jets'], opacity: 0.3, transparent: true });
     material.opacity = 0.5;
     const mesh = new Mesh(geometry, material);
     mesh.position.copy(translation);
@@ -180,8 +181,7 @@ export class PhoenixObjects {
     geometry.setAttribute('position', new BufferAttribute(pointPos, 3));
     geometry.computeBoundingSphere();
     // material
-    const material = new PointsMaterial({ size: 10 });
-    material.color.set('#ff0000');
+    const material = new PointsMaterial({ size: 10, color: EVENT_DATA_TYPE_COLORS['Hits'] });
     // object
     const pointsObj = new Points(geometry, material);
     pointsObj.userData = Object.assign({}, hitsParamsClone);
@@ -204,7 +204,7 @@ export class PhoenixObjects {
     // geometry
     const geometry = new BoxBufferGeometry(30, 30, length);
     // material
-    const material = new MeshPhongMaterial({ color: 0xFFD166 });
+    const material = new MeshPhongMaterial({ color: EVENT_DATA_TYPE_COLORS['CaloClusters'] });
     // object
     const cube = new Mesh(geometry, material);
     const theta = 2 * Math.atan(Math.pow(Math.E, clusterParams.eta));
@@ -236,7 +236,7 @@ export class PhoenixObjects {
     // geometry
     const geometry = new SphereBufferGeometry(3);
     // material
-    const material = new MeshPhongMaterial({ color: 0xFFD166 });
+    const material = new MeshPhongMaterial({ color: EVENT_DATA_TYPE_COLORS['Vertices'] });
     // object
     const sphere = new Mesh(geometry, material);
     sphere.position.x = vertexParams.x;

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -1,11 +1,12 @@
 import { EventDataLoader } from '../event-data-loader';
-import { Group, Object3D } from 'three';
+import { Color, Group, Object3D } from 'three';
 import { UIManager } from '../ui';
 import { ThreeManager } from '../three';
 import { Cut } from '../extras/cut.model';
 import { PhoenixObjects } from './objects/phoenix-objects';
 import { InfoLogger } from '../info-logger';
 import { PhoenixMenuNode } from '../ui/phoenix-menu/phoenix-menu-node';
+import { EVENT_DATA_TYPE_COLORS } from '../helpers/constants';
 
 /**
  * Loader for processing and loading an event.
@@ -206,16 +207,23 @@ export class PhoenixLoader implements EventDataLoader {
 
     const collectionsList: string[] = this.getObjectTypeCollections(object);
 
-
     for (const collectionName of collectionsList) {
       const objectCollection = object[collectionName];
-      console.log(typeName+" collection "+collectionName+" has "+objectCollection.length+" constituents.")
+      console.log(`${typeName} collection ${collectionName} has ${objectCollection.length} constituents.`)
 
       this.addCollection(objectCollection, collectionName, getObject, objectGroup);
 
+      let collectionColor: Color;
+      if (object[collectionName][0]?.color) {
+        collectionColor = new Color(parseInt(object[collectionName][0]?.color));
+      } else {
+        // If the color is not in event data use the default one
+        collectionColor = EVENT_DATA_TYPE_COLORS[typeName];
+      }
+
       cuts = cuts?.filter(cut => objectCollection[0][cut.field]);
-      this.ui.addCollection(typeFolder, collectionName, cuts);
-      this.ui.addCollectionPM(typeFolderPM, collectionName, cuts);
+      this.ui.addCollection(typeFolder, collectionName, cuts, collectionColor);
+      this.ui.addCollectionPM(typeFolderPM, collectionName, cuts, collectionColor);
     }
   }
 

--- a/packages/phoenix-event-display/src/three/index.ts
+++ b/packages/phoenix-event-display/src/three/index.ts
@@ -566,4 +566,12 @@ export class ThreeManager {
     mainRenderer.setAnimationLoop(null);
     this.vrManager.endVRSession();
   }
+
+  /**
+   * Get an object from the scene by name.
+   * @param objectName Name of the object in scene.
+   */
+  public getObjectByName(objectName: string): Object3D {
+    return this.getSceneManager().getScene().getObjectByName(objectName);
+  }
 }

--- a/packages/phoenix-event-display/src/ui/index.ts
+++ b/packages/phoenix-event-display/src/ui/index.ts
@@ -289,7 +289,7 @@ export class UIManager {
       objFolderPM.toggleState = initiallyVisible;
       objFolderPM.addConfig('color', {
         label: 'Color',
-        color,
+        color: color ? `#${new Color(color).getHexString()}` : undefined,
         onChange: (value: any) => {
           this.three.getSceneManager().OBJGeometryColor(name, value)
         }

--- a/packages/phoenix-event-display/src/ui/index.ts
+++ b/packages/phoenix-event-display/src/ui/index.ts
@@ -7,6 +7,7 @@ import { Cut } from '../extras/cut.model';
 import { SceneManager } from '../three/scene-manager';
 import { PhoenixMenuNode } from './phoenix-menu/phoenix-menu-node';
 import { PrettySymbols } from '../helpers/pretty-symbols';
+import { Color } from 'three';
 
 /**
  * Manager for UI related operations including the dat.GUI menu, stats-js and theme settings.
@@ -238,10 +239,10 @@ export class UIManager {
   /**
    * Adds geometry to the dat.GUI menu's geometry folder and sets up its configurable options.
    * @param name Name of the geometry.
-   * @param colour Color of the geometry.
+   * @param color Color of the geometry.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public addGeometry(name: string, colour: any, initiallyVisible: boolean = true) {
+  public addGeometry(name: string, color: any, initiallyVisible: boolean = true) {
     if (!this.geomFolderAdded) {
       this.addGeomFolder();
     }
@@ -249,7 +250,7 @@ export class UIManager {
     if (this.hasDatGUIMenu) {
       // A new folder for the object is added to the 'Geometry' folder
       this.guiParameters[name] = {
-        show: initiallyVisible, color: colour, x: 0, y: 0, z: 0, detectorOpacity: 1.0, remove: this.removeOBJ(name), scale: 1
+        show: initiallyVisible, color, x: 0, y: 0, z: 0, detectorOpacity: 1.0, remove: this.removeOBJ(name), scale: 1
       };
       const objFolder = this.geomFolder.addFolder(name);
       // A color picker is added to the object's folder
@@ -288,6 +289,7 @@ export class UIManager {
       objFolderPM.toggleState = initiallyVisible;
       objFolderPM.addConfig('color', {
         label: 'Color',
+        color,
         onChange: (value: any) => {
           this.three.getSceneManager().OBJGeometryColor(name, value)
         }
@@ -412,7 +414,8 @@ export class UIManager {
    * @param collectionName Name of the collection to be added in the type of event data (tracks, hits etc.).
    * @param cuts Cuts to the collection of event data that are to be made configurable to filter event data.
    */
-  public addCollection(typeFolder: any, collectionName: string, cuts?: Cut[]) {
+  public addCollection(typeFolder: any, collectionName: string,
+    cuts?: Cut[], collectionColor?: Color) {
     if (typeFolder && this.hasDatGUIMenu) {
       // A new folder for the collection is added to the 'Event Data' folder
       this.guiParameters[collectionName] = {
@@ -428,6 +431,7 @@ export class UIManager {
       // A color picker is added to the collection's folder
       const colorMenu = collFolder.addColor(this.guiParameters[collectionName], 'color').name('Color');
       colorMenu.onChange((value) => this.three.getSceneManager().collectionColor(collectionName, value));
+      colorMenu.setValue(collectionColor?.getHex());
       // Cuts menu
       if (cuts) {
         const cutsFolder = collFolder.addFolder('Cuts');
@@ -451,8 +455,10 @@ export class UIManager {
    * @param typeFolder Phoenix menu node of an event data type.
    * @param collectionName Name of the collection to be added in the type of event data (tracks, hits etc.).
    * @param cuts Cuts to the collection of event data that are to be made configurable to filter event data.
+   * @param collectionColor Default color of the collection.
    */
-  public addCollectionPM(typeFolderPM: PhoenixMenuNode, collectionName: string, cuts?: Cut[]) {
+  public addCollectionPM(typeFolderPM: PhoenixMenuNode, collectionName: string,
+    cuts?: Cut[], collectionColor?: Color) {
     // Phoenix menu
     if (this.hasPhoenixMenu) {
       const collectionNode = typeFolderPM.addChild(collectionName, (value: boolean) => {
@@ -462,6 +468,7 @@ export class UIManager {
 
       collectionNode.addConfig('color', {
         label: 'Color',
+        color: collectionColor ? `#${collectionColor?.getHexString()}` : undefined,
         onChange: (value: any) => {
           this.three.getSceneManager().collectionColor(collectionName, value)
         }

--- a/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
@@ -175,22 +175,25 @@ export class PhoenixMenuNode {
       const nodeConfig = this.configs.filter(nodeConfig =>
         nodeConfig.type === configState['type'] && nodeConfig.label === configState['label']
       )[0];
-      for (const prop in configState) {
-        nodeConfig[prop] = configState[prop];
-      }
 
-      // Apply configs of different config types - manual
-      if (nodeConfig.type === 'checkbox' && configState?.['isChecked']) {
-        nodeConfig.onChange?.(configState?.['isChecked']);
-      } else if (nodeConfig.type === 'color' && configState?.['color']) {
-        nodeConfig.onChange?.(configState?.['color']);
-      } else if (nodeConfig.type === 'slider' && configState?.['value']) {
-        nodeConfig.onChange?.(configState?.['value']);
-      } else if (nodeConfig.type === 'rangeSlider' && configState?.['value']) {
-        nodeConfig.onChange?.({
-          value: configState?.['value'],
-          highValue: configState?.['highValue']
-        });
+      if (nodeConfig) {
+        for (const prop in configState) {
+          nodeConfig[prop] = configState[prop];
+        }
+
+        // Apply configs of different config types - manual
+        if (nodeConfig.type === 'checkbox' && configState?.['isChecked']) {
+          nodeConfig.onChange?.(configState?.['isChecked']);
+        } else if (nodeConfig.type === 'color' && configState?.['color']) {
+          nodeConfig.onChange?.(configState?.['color']);
+        } else if (nodeConfig.type === 'slider' && configState?.['value']) {
+          nodeConfig.onChange?.(configState?.['value']);
+        } else if (nodeConfig.type === 'rangeSlider' && configState?.['value']) {
+          nodeConfig.onChange?.({
+            value: configState?.['value'],
+            highValue: configState?.['highValue']
+          });
+        }
       }
     }
 
@@ -198,6 +201,7 @@ export class PhoenixMenuNode {
       const nodeChild = this.children.filter(nodeChild =>
         nodeChild.name === childState.name && nodeChild.nodeLevel === childState.nodeLevel
       )[0];
+
       if (nodeChild) {
         nodeChild.loadStateFromJSON(childState);
       }

--- a/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
@@ -122,6 +122,7 @@ export class PhoenixMenuNode {
 
   /**
    * Get current state of the node as an object.
+   * @returns State of the node as an object.
    */
   private getNodeState(): object {
     const phoenixNodeJSON: object = {};
@@ -208,7 +209,7 @@ export class PhoenixMenuNode {
    * @param onFileRead Callback with JSON file data when the file data is read.
    */
   loadStateFromFile(onFileRead?: (json: object) => void) {
-    // Create a fake input file element and use that to read the file
+    // Create a mock input file element and use that to read the file
     const inputFile = document.createElement('input');
     inputFile.type = 'file';
     inputFile.accept = 'application/json';
@@ -223,7 +224,7 @@ export class PhoenixMenuNode {
 
         inputFile.remove();
         this.configActive = false;
-      }
+      };
       reader.readAsText(configFile);
     }
     inputFile.click();

--- a/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
@@ -178,11 +178,18 @@ export class PhoenixMenuNode {
         nodeConfig[prop] = configState[prop];
       }
 
-      // Apply configs of different config types
-      if (nodeConfig.type === 'color') {
+      // Apply configs of different config types - manual
+      if (nodeConfig.type === 'checkbox' && configState?.['isChecked']) {
+        nodeConfig.onChange?.(configState?.['isChecked']);
+      } else if (nodeConfig.type === 'color' && configState?.['color']) {
         nodeConfig.onChange?.(configState?.['color']);
-      } else if (nodeConfig.type === 'slider') {
+      } else if (nodeConfig.type === 'slider' && configState?.['value']) {
         nodeConfig.onChange?.(configState?.['value']);
+      } else if (nodeConfig.type === 'rangeSlider' && configState?.['value']) {
+        nodeConfig.onChange?.({
+          value: configState?.['value'],
+          highValue: configState?.['highValue']
+        });
       }
     }
 
@@ -215,6 +222,7 @@ export class PhoenixMenuNode {
         this.loadStateFromJSON(jsonData);
 
         inputFile.remove();
+        this.configActive = false;
       }
       reader.readAsText(configFile);
     }

--- a/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
@@ -2,6 +2,8 @@
  * A single node of phoenix menu item.
  */
 export class PhoenixMenuNode {
+  /** ID of the phoenix node. */
+  private nodeId: string;
   /** Name of the node. */
   name: string;
   /** Icon of the node. */
@@ -117,6 +119,63 @@ export class PhoenixMenuNode {
     this.toggleState = value;
     for (const child of this.children) {
       child.toggleSelfAndDescendants(value);
+    }
+  }
+
+  /**
+   * Get current state of the node as an object.
+   */
+  private getNodeState(): object {
+    const phoenixNodeJSON: object = {};
+
+    phoenixNodeJSON['toggleState'] = this.toggleState;
+    phoenixNodeJSON['childrenActive'] = this.childrenActive;
+    phoenixNodeJSON['configs'] = this.configs;
+    phoenixNodeJSON['children'] = [];
+
+    for (const child of this.children) {
+      phoenixNodeJSON['children'].push(child.getNodeState());
+    }
+
+    return phoenixNodeJSON;
+  }
+
+  /**
+   * Save the state of the phoenix menu node as JSON.
+   */
+  saveStateAsJSON() {
+    const blob = new Blob([JSON.stringify(this.getNodeState())], {
+      type: 'application/json'
+    });
+    const tempAnchor = document.createElement('a');
+    tempAnchor.href = URL.createObjectURL(blob);
+    tempAnchor.download = 'phoenix-menu-config.json';
+    tempAnchor.click();
+    tempAnchor.remove();
+  }
+
+  /**
+   * Load the state of the phoenix menu node from JSON.
+   */
+  loadStateFromJSON(json: string | object) {
+    let jsonObject: any;
+    if (typeof json === 'string') {
+      jsonObject = JSON.parse(json);
+    } else {
+      jsonObject = json;
+    }
+
+    this.toggleState = jsonObject['toggleState'];
+    this.childrenActive = jsonObject['childrenActive'];
+
+    for (const config of jsonObject['configs']) {
+      const nodeConfig = this.configs.find(nodeConfig => {
+        return nodeConfig.type === config['type']
+          && nodeConfig.label === config['label'];
+      });
+      for (const configProp in config) {
+        nodeConfig[configProp] = config[configProp];
+      }
     }
   }
 }


### PR DESCRIPTION
Hi,

## Description

This adds feature to save and load configuration aka state of the Phoenix menu with effects to the scene (like event data color, geometry opacity etc.). This works well for all configurations in the Phoenix menu. It saves the Phoenix menu state as a `json` file which can later be loaded. The state can also be loaded directly from code (using `PhoenixMenuNode.loadStateFromJSON(json: object } string)`.

It works REALLY WELL and will be very useful. I didn't think it would turn out this good.

The PR includes some other fixes and improvements as well.

## Added

* Save state of the Phoenix menu as JSON  
  * Save state of the node like the toggle state, all configuration options (like color and slider values) of the node and the state of all its children
* Process and load the state of the Phoenix menu from JSON  
  * Load state of the node like the toggle state, process all configuration options (like color and slider values) and apply them to the objects in scene and load state of all of its children
* Add options to save and load state to the root Phoenix menu node

Misc

* Set the default event data collection color on load in the Phoenix menu
* Set the default geometry color on load in the Phoenix menu
* Fix CI and use lerna based commands in CI

## Screen Captures

**Setting and saving the Phoenix menu state**

![wip-config-save](https://user-images.githubusercontent.com/36920441/95688591-d5304b00-0c24-11eb-971f-692e7e412e55.gif)

**Loading the Phoenix menu state in a fresh scene**

The options we set in the upper screen capture will all be loaded on loading the state.

![wip-config-load](https://user-images.githubusercontent.com/36920441/95688605-da8d9580-0c24-11eb-9cb8-42b9ba180bd3.gif)
