### PR TITLE
Add more cuts

### DIFF
--- a/packages/phoenix-event-display/src/loaders/jivexml-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/jivexml-loader.ts
@@ -165,7 +165,7 @@ export class JiveXMLLoader extends PhoenixLoader {
         if (chi2.length>0) track.chi2 = chi2[i]
         if (numDoF.length>0) track.dof = numDoF[i]
         const theta = Math.tan(cotTheta[i]);
-        track.pT = pT[i];
+        track.pT = Math.abs(pT[i]);
         const momentum =  pT[i]/Math.sin(theta) * 1000 ; // JiveXML uses GeV 
         track.dparams = [d0[i], z0[i], phi0[i], theta, 1.0 / momentum];
         const pos = [];

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -119,7 +119,7 @@ export class PhoenixLoader implements EventDataLoader {
       const cuts: Cut[] = [
         new Cut('chi2', 0, 100),
         new Cut('dof', 0, 100),
-        new Cut('mom', 0, 500)
+        new Cut('pT', 0, 50)
       ];
 
       this.addObjectType(eventData.Tracks, PhoenixObjects.getTrack, 'Tracks', cuts);
@@ -159,6 +159,7 @@ export class PhoenixLoader implements EventDataLoader {
     }
 
     if (eventData.Hits) {
+      // Cannot currently cut on just a postion array.
       this.addObjectType(eventData.Hits, PhoenixObjects.getHits, 'Hits');
     }
 
@@ -174,7 +175,13 @@ export class PhoenixLoader implements EventDataLoader {
     }
 
     if (eventData.Muons) {
-      this.addObjectType(eventData.Muons, this.getMuon, 'Muons');
+      const cuts = [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -100, 100),
+        new Cut('energy', 0, 10000),
+        new Cut('pT', 0, 50)
+      ];
+      this.addObjectType(eventData.Muons, this.getMuon, 'Muons', cuts);
     }
 
     // if (eventData.Photons) {
@@ -186,7 +193,10 @@ export class PhoenixLoader implements EventDataLoader {
     // }
 
     if (eventData.Vertices) {
-      this.addObjectType(eventData.Vertices, PhoenixObjects.getVertex, 'Vertices');
+      const cuts = [
+        new Cut('vertexType', 0, 5)
+      ];
+      this.addObjectType(eventData.Vertices, PhoenixObjects.getVertex, 'Vertices', cuts);
     }
   }
 

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -231,7 +231,7 @@ export class PhoenixLoader implements EventDataLoader {
         collectionColor = EVENT_DATA_TYPE_COLORS[typeName];
       }
 
-      cuts = cuts?.filter(cut => objectCollection[0][cut.field]);
+      cuts = cuts?.filter(cut => cut.field in objectCollection[0]);
       this.ui.addCollection(typeFolder, collectionName, cuts, collectionColor);
       this.ui.addCollectionPM(typeFolderPM, collectionName, cuts, collectionColor);
     }


### PR DESCRIPTION
I noticed that the pT cuts weren't appearing for Tracks and decided to investigate
I also decided to add a few missing cuts

There are a few issues here. One, is that the cuts are very atlas-specific, so they should really be added by the JiveXML loader.

Another is that I don't think there is a way at the moment to add e.g. x,y,z cuts when the property is just a 3 dim array.