### PR TITLE
Support for screenshot mode

### DIFF
--- a/packages/phoenix-event-display/src/three/index.ts
+++ b/packages/phoenix-event-display/src/three/index.ts
@@ -483,7 +483,7 @@ export class ThreeManager {
    * Enable keyboard controls for some Three service operations.
    */
   public enableKeyboardControls() {
-    document.addEventListener("keydown", (e: KeyboardEvent) => {
+    document.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.shiftKey) {
         switch (e.code) {
           case 'KeyR': // shift + "r"

--- a/packages/phoenix-event-display/src/three/renderer-manager.ts
+++ b/packages/phoenix-event-display/src/three/renderer-manager.ts
@@ -56,8 +56,7 @@ export class RendererManager {
       window.innerHeight,
       false
     );
-    this.getMainRenderer().setPixelRatio(window.devicePixelRatio)
-    this.getMainRenderer().domElement.className = 'ui-element';
+    this.getMainRenderer().setPixelRatio(window.devicePixelRatio);
     this.getMainRenderer().domElement.id = 'three-canvas';
     let canvas = document.getElementById(elementId);
     if (canvas == null) {

--- a/packages/phoenix-ng/angular.json
+++ b/packages/phoenix-ng/angular.json
@@ -168,7 +168,10 @@
           "options": {
             "main": "projects/phoenix-ui-components/src/test.ts",
             "tsConfig": "projects/phoenix-ui-components/tsconfig.spec.json",
-            "karmaConfig": "projects/phoenix-ui-components/karma.conf.js"
+            "karmaConfig": "projects/phoenix-ui-components/karma.conf.js",
+            "codeCoverageExclude": [
+              "projects/phoenix-ui-components/src/services/extras/**"
+            ]
           }
         },
         "lint": {

--- a/packages/phoenix-ng/projects/phoenix-app/src/assets/icons/ss-mode.svg
+++ b/packages/phoenix-ng/projects/phoenix-app/src/assets/icons/ss-mode.svg
@@ -1,0 +1,9 @@
+<svg width="0" height="0" class="hidden">
+  <symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" id="ss-mode">
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="180.9,39 39.9,39 39.9,184" />
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="332.9,39 473.9,39 473.9,184" />
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="180.9,473 39.9,473 39.9,328" />
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="332.9,473 473.9,473 473.9,328" />
+    <circle stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" cx="256.9" cy="255" r="92.5" />
+  </symbol>
+</svg>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/assets/icons/ss-mode.svg
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/assets/icons/ss-mode.svg
@@ -1,0 +1,9 @@
+<svg width="0" height="0" class="hidden">
+  <symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" id="ss-mode">
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="180.9,39 39.9,39 39.9,184" />
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="332.9,39 473.9,39 473.9,184" />
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="180.9,473 39.9,473 39.9,328" />
+    <polyline stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" points="332.9,473 473.9,473 473.9,328" />
+    <circle stroke="var(--phoenix-options-icon-path, #fff)" fill="none" stroke-width="60" cx="256.9" cy="255" r="92.5" />
+  </symbol>
+</svg>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/phoenix-ui.module.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/phoenix-ui.module.ts
@@ -42,7 +42,8 @@ import {
   TreeMenuItemComponent,
   AnimateCameraComponent,
   AnimateEventComponent,
-  VrToggleComponent
+  VrToggleComponent,
+  SSModeComponent
 } from './ui-menu';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
@@ -79,7 +80,8 @@ const PHOENIX_COMPONENTS: Type<any>[] = [
   ConfigSliderComponent,
   AnimateCameraComponent,
   AnimateEventComponent,
-  VrToggleComponent
+  VrToggleComponent,
+  SSModeComponent
 ];
 
 @NgModule({

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/index.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/index.ts
@@ -23,4 +23,5 @@ export * from './tree-menu/tree-menu-item/tree-menu-item.component';
 export * from './view-options/view-options.component';
 export * from './vr-toggle/vr-toggle.component';
 export * from './zoom-controls/zoom-controls.component';
+export * from './ss-mode/ss-mode.component';
 export * from './ui-menu.component';

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.html
@@ -1,0 +1,2 @@
+<app-menu-toggle tooltip="Toggle screenshot mode" [active]="ssMode" icon="ss-mode" (click)="toggleSSMode()">
+</app-menu-toggle>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.scss
@@ -1,6 +1,7 @@
 app-ui-menu .optionsWrapper,
 app-phoenix-menu #phoenix-menu,
 app-nav .main-logo,
+.overlay-card,
 .ui-element {
   visibility: visible;
   opacity: 1;
@@ -12,6 +13,7 @@ app-nav .main-logo,
   app-ui-menu .optionsWrapper,
   app-phoenix-menu #phoenix-menu,
   app-nav .main-logo,
+  .overlay-card,
   .ui-element {
     visibility: hidden;
     opacity: 0;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.scss
@@ -1,0 +1,19 @@
+app-ui-menu .optionsWrapper,
+app-phoenix-menu #phoenix-menu,
+app-nav .main-logo,
+.ui-element {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.4s;
+}
+
+.ss-mode {
+
+  app-ui-menu .optionsWrapper,
+  app-phoenix-menu #phoenix-menu,
+  app-nav .main-logo,
+  .ui-element {
+    visibility: hidden;
+    opacity: 0;
+  }
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SsModeComponent } from './ss-mode.component';
+
+describe('SsModeComponent', () => {
+  let component: SsModeComponent;
+  let fixture: ComponentFixture<SsModeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SsModeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SsModeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.spec.ts
@@ -1,25 +1,56 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { SsModeComponent } from './ss-mode.component';
+import { SSModeComponent } from './ss-mode.component';
 
-describe('SsModeComponent', () => {
-  let component: SsModeComponent;
-  let fixture: ComponentFixture<SsModeComponent>;
+describe('SSModeComponent', () => {
+  let component: SSModeComponent;
+  let fixture: ComponentFixture<SSModeComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SsModeComponent ]
+      declarations: [SSModeComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SsModeComponent);
+    fixture = TestBed.createComponent(SSModeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should toggle screenshot mode', () => {
+    expect(component.ssMode).toBe(false);
+    component.toggleSSMode();
+    expect(component.ssMode).toBe(true);
+    component.toggleSSMode();
+    expect(component.ssMode).toBe(false);
+  });
+
+  it('should toggle screenshot mode on click', () => {
+    component.toggleSSMode();
+    expect(component.ssMode).toBe(true);
+    (component as any).onDocumentClick();
+    expect(component.ssMode).toBe(false);
+  });
+
+  it('should toggle screenshot mode on escape', () => {
+    component.toggleSSMode();
+    expect(component.ssMode).toBe(true);
+
+    // Faking the event
+    const event = document.createEvent('Event');
+    (event as any).code = 'Escape';
+    (component as any).onEscapePress(event);
+
+    expect(component.ssMode).toBe(false);
+
+    // For branch coverage
+    (event as any).code = 'KeyA';
+    (component as any).onEscapePress(event);
   });
 });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
@@ -16,21 +16,21 @@ export class SSModeComponent {
       document.addEventListener('keydown', this.onEscapePress);
       // WORKAROUND - Adding the event listener directly somehow calls it on the first click
       setTimeout(() => {
-        document.addEventListener('click', this.onDoubleClick);
+        document.addEventListener('click', this.onDocumentClick);
       }, 1);
     } else {
       document.removeEventListener('keydown', this.onEscapePress);
-      document.removeEventListener('click', this.onDoubleClick);
+      document.removeEventListener('click', this.onDocumentClick);
     }
   }
 
   private onEscapePress = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
+    if (e.code === 'Escape') {
       this.toggleSSMode();
     }
   }
 
-  private onDoubleClick = () => {
+  private onDocumentClick = () => {
     this.toggleSSMode();
   }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
@@ -1,0 +1,37 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-ss-mode',
+  templateUrl: './ss-mode.component.html',
+  styleUrls: ['./ss-mode.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class SSModeComponent {
+  ssMode: boolean = false;
+
+  toggleSSMode() {
+    this.ssMode = !this.ssMode;
+    document.body.classList.toggle('ss-mode');
+    if (this.ssMode) {
+      document.addEventListener('keydown', this.onEscapePress);
+      // WORKAROUND - Adding the event listener directly somehow calls it on the first click
+      setTimeout(() => {
+        document.addEventListener('click', this.onDoubleClick);
+      }, 1);
+    } else {
+      document.removeEventListener('keydown', this.onEscapePress);
+      document.removeEventListener('click', this.onDoubleClick);
+    }
+  }
+
+  private onEscapePress = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      this.toggleSSMode();
+    }
+  }
+
+  private onDoubleClick = () => {
+    this.toggleSSMode();
+  }
+
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ui-menu.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ui-menu.component.html
@@ -9,6 +9,9 @@
     <!-- Toggle for loading geometries modal-->
     <app-io-options></app-io-options>
 
+    <!-- Toggle for  -->
+    <app-ss-mode></app-ss-mode>
+
     <!-- Toggle for VR -->
     <app-vr-toggle></app-vr-toggle>
 


### PR DESCRIPTION
Hi,

## Description

This adds a toggle to enable screenshot mode in which all overlay elements (UI menu, Phoenix menu etc.) are hidden except the experiment info overlay.

## Added

* Toggle in UI menu for screenshot mode
* Ability to close screenshot mode on click or on escape key press
* Tests for the screenshot mode component

## Screen Capture

![feat-ss-mode](https://user-images.githubusercontent.com/36920441/98516414-4b5cb780-228e-11eb-9103-0cc6602e601c.gif)
