### PR TITLE
Support to start or deploy Phoenix with a specific event

### DIFF
--- a/packages/phoenix-ng/README.md
+++ b/packages/phoenix-ng/README.md
@@ -1,8 +1,5 @@
 # Phoenix application
 
-[![Version](https://img.shields.io/npm/v/phoenix-app.svg)](https://www.npmjs.com/package/phoenix-app)
-[![Downloads](https://img.shields.io/npm/dt/phoenix-app.svg)](https://www.npmjs.com/package/phoenix-app)
-
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 7.3.4.
 
 ## Build and run
@@ -61,3 +58,13 @@ You can then copy the files generated in `./docs` to your server e.g. with:
 ```sh
 rsync -avz docs/ your-server.net:path/to/website
 ```
+
+#### Deploy with a specific event
+
+Phoenix can also be deployed as a single page application with a specific event. To do that.
+
+1. Copy the event data to [./projects/phoenix-app/src/assets](./projects/phoenix-app/src/assets) (or you can use a URL instead)
+1. Specify the event data type and file path (or URL) in [./projects/phoenix-app/event-config.json](./projects/phoenix-app/event-config.json)
+1. Lastly, in the `packages/phoenix-ng` directory, run the command: `npm run deploy:web:single`
+
+The deployed application will be in [./docs](./docs) which can be copied directly to a server.

--- a/packages/phoenix-ng/angular.json
+++ b/packages/phoenix-ng/angular.json
@@ -53,7 +53,35 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2mb",
+                  "maximumWarning": "3mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb"
+                }
+              ]
+            },
+            "singleEvent": {
+              "fileReplacements": [
+                {
+                  "replace": "projects/phoenix-app/src/environments/environment.ts",
+                  "with": "projects/phoenix-app/src/environments/environment.single.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "3mb",
                   "maximumError": "5mb"
                 },
                 {
@@ -72,6 +100,9 @@
           "configurations": {
             "production": {
               "browserTarget": "phoenix-app:build:production"
+            },
+            "singleEvent": {
+              "browserTarget": "phoenix-app:build:singleEvent"
             }
           }
         },

--- a/packages/phoenix-ng/package.json
+++ b/packages/phoenix-ng/package.json
@@ -16,7 +16,8 @@
     "test:coverage": "rm -rf ./coverage && ng test --no-watch --code-coverage",
     "coveralls": "cat ./coverage/phoenix-ui-components/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "version": "npm run deploy",
-    "deploy:web": "ng build --prod --output-path ./docs --base-href \"./\" && cp ./docs/index.html ./docs/404.html"
+    "deploy:web": "ng build --prod --output-path ./docs --base-href \"./\" && cp ./docs/index.html ./docs/404.html",
+    "deploy:web:single": "ng build --configuration singleEvent --prod --output-path ./docs --base-href \"./\" && cp ./docs/index.html ./docs/404.html"
   },
   "dependencies": {
     "@angular/animations": "^10.0.14",

--- a/packages/phoenix-ng/package.json
+++ b/packages/phoenix-ng/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "start:ssl": "ng serve --ssl --host=0.0.0.0",
+    "start:single": "ng serve --configuration singleEvent",
     "build": "ng build",
     "build:ui-components": "ng build phoenix-ui-components --prod",
     "prepare": "npm run build:ui-components",

--- a/packages/phoenix-ng/projects/phoenix-app/event-config.json
+++ b/packages/phoenix-ng/projects/phoenix-app/event-config.json
@@ -1,0 +1,4 @@
+{
+  "eventFile": "assets/files/JiveXML/JiveXML_336567_2327102923.xml",
+  "eventType": "jivexml"
+}

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/app.module.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/app.module.ts
@@ -13,17 +13,26 @@ import { PhoenixUIModule } from 'phoenix-ui-components';
 import { RouterModule, Routes } from '@angular/router';
 import { PlaygroundComponent } from './sections/playground/playground.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { environment } from '../environments/environment';
 
-const routes: Routes = [
-  { path: '', component: HomeComponent },
-  { path: 'home', component: HomeComponent },
-  { path: 'geometry', component: GeometryComponent },
-  { path: 'atlas', component: AtlasComponent },
-  { path: 'lhcb', component: LHCbComponent },
-  { path: 'cms', component: CMSComponent },
-  { path: 'trackml', component: TrackmlComponent },
-  { path: 'playground', component: PlaygroundComponent }
-];
+let routes: Routes;
+
+if (environment?.singleEvent) {
+  routes = [
+    { path: '', component: AtlasComponent }
+  ];
+} else {
+  routes = [
+    { path: '', component: HomeComponent },
+    { path: 'home', component: HomeComponent },
+    { path: 'geometry', component: GeometryComponent },
+    { path: 'atlas', component: AtlasComponent },
+    { path: 'lhcb', component: LHCbComponent },
+    { path: 'cms', component: CMSComponent },
+    { path: 'trackml', component: TrackmlComponent },
+    { path: 'playground', component: PlaygroundComponent }
+  ];
+}
 
 @NgModule({
   declarations: [
@@ -39,7 +48,7 @@ const routes: Routes = [
   imports: [
     BrowserModule,
     HttpClientModule,
-    RouterModule.forRoot(routes, { useHash: true }),
+    RouterModule.forRoot(routes, { useHash: environment?.singleEvent ? false : true }),
     BrowserAnimationsModule,
     PhoenixUIModule
   ],

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { EventDisplayService } from 'phoenix-ui-components';
 import { Configuration, PresetView, PhoenixMenuNode, PhoenixLoader } from 'phoenix-event-display';
+import { environment } from '../../../environments/environment';
+import eventConfig from '../../../../event-config.json';
 
 @Component({
   selector: 'app-atlas',
@@ -13,6 +15,17 @@ export class AtlasComponent implements OnInit {
   constructor(private eventDisplay: EventDisplayService) { }
 
   ngOnInit() {
+    let defaultEvent: { eventFile: string, eventType: string };
+    // Get default event from configuration
+    if (environment?.singleEvent) {
+      defaultEvent = eventConfig;
+    } else {
+      defaultEvent = {
+        eventFile: 'assets/files/JiveXML/JiveXML_336567_2327102923.xml',
+        eventType: 'jivexml'
+      }
+    }
+
     // Define the configuration
     const configuration: Configuration = {
       eventDataLoader: new PhoenixLoader(),
@@ -26,10 +39,7 @@ export class AtlasComponent implements OnInit {
       phoenixMenuRoot: this.phoenixMenuRoot,
       // Default event data to fallback to if none given in URL
       // Do not set if there should be no event loaded by default
-      defaultEventFile: {
-        eventFile: 'assets/files/JiveXML/JiveXML_336567_2327102923.xml',
-        eventType: 'jivexml'
-      }
+      defaultEventFile: defaultEvent
     };
 
     // Initialize the event display

--- a/packages/phoenix-ng/projects/phoenix-app/src/environments/environment.single.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/environments/environment.single.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  singleEvent: false
+  singleEvent: true
 };

--- a/packages/phoenix-ng/projects/phoenix-app/src/environments/environment.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  singleEvent: false
 };
 
 /*

--- a/packages/phoenix-ng/projects/phoenix-app/tsconfig.app.json
+++ b/packages/phoenix-ng/projects/phoenix-app/tsconfig.app.json
@@ -9,6 +9,7 @@
     "src/polyfills.ts"
   ],
   "include": [
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "event-config.json"
   ]
 }

--- a/packages/phoenix-ng/tsconfig.json
+++ b/packages/phoenix-ng/tsconfig.json
@@ -8,6 +8,8 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
     "importHelpers": true,
     "target": "es2015",
     "module": "es2020",


### PR DESCRIPTION
Closes #149 
Closes #163

Hi,

## Description

This adds support for starting or deploying Phoenix with a specific event that a user can specify in a configuration file.

## Added

* A new `environment.single.ts` file for specifying configuration to deploy Phoenix with a specific event
* A configuration file `event-config.json` (`phoenix-app/event-config.json`) which specifies the event file and type to be used for Phoenix with a single event
* Scripts for starting and deploying Phoenix with a specific event
* Code for different behavior when Phoenix with a specific event is to run or deploy

## Usage

Instructions specified in [phoenix-ng README](https://github.com/9inpachi/phoenix/tree/feat-deploy-with-event/packages/phoenix-ng#readme).

For only running the app with a specific event, use `npm run start:single` from the `packages/phoenix-ng` directory.