### PR TITLE
Ability to add geometry to a folder

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -171,13 +171,14 @@ export class EventDisplay {
    * @param filename Path to the geometry.
    * @param name Name given to the geometry.
    * @param color Color to initialize the geometry.
+   * @param menuNodeName Name of the node in Phoenix menu to add the geometry to.
    * @param doubleSided Renders both sides of the material.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
   public loadOBJGeometry(filename: string, name: string, color: any,
-    doubleSided?: boolean, initiallyVisible: boolean = true) {
+    menuNodeName?: string, doubleSided?: boolean, initiallyVisible: boolean = true) {
     this.graphicsLibrary.loadOBJGeometry(filename, name, color, doubleSided, initiallyVisible);
-    this.ui.addGeometry(name, color, initiallyVisible);
+    this.ui.addGeometry(name, color, menuNodeName, initiallyVisible);
     this.infoLogger.add(name, 'Loaded OBJ geometry');
   }
 
@@ -186,11 +187,13 @@ export class EventDisplay {
    * and adds it to the dat.GUI menu.
    * @param content Content of the OBJ geometry.
    * @param name Name given to the geometry.
+   * @param menuNodeName Name of the node in Phoenix menu to add the geometry to.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public parseOBJGeometry(content: string, name: string, initiallyVisible: boolean = true) {
+  public parseOBJGeometry(content: string, name: string,
+    menuNodeName?: string, initiallyVisible: boolean = true) {
     this.graphicsLibrary.parseOBJGeometry(content, name, initiallyVisible);
-    this.ui.addGeometry(name, 0x000fff, initiallyVisible);
+    this.ui.addGeometry(name, 0x000fff, menuNodeName, initiallyVisible);
   }
 
   /**
@@ -241,13 +244,14 @@ export class EventDisplay {
    * and adds it to the dat.GUI menu.
    * @param url URL to the GLTF (.gltf) file.
    * @param name Name of the loaded scene/geometry.
+   * @param menuNodeName Name of the node in Phoenix menu to add the geometry to.
    * @param scale Scale of the geometry.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadGLTFGeometry(url: any, name: string,
+  public loadGLTFGeometry(url: any, name: string, menuNodeName?: string,
     scale?: number, initiallyVisible: boolean = true) {
     this.graphicsLibrary.loadGLTFGeometry(url, name, scale, initiallyVisible);
-    this.ui.addGeometry(name, undefined, initiallyVisible);
+    this.ui.addGeometry(name, undefined, menuNodeName, initiallyVisible);
     this.infoLogger.add(name, 'Loaded GLTF geometry');
   }
 
@@ -255,14 +259,15 @@ export class EventDisplay {
    * Loads geometries from JSON.
    * @param json JSON or URL to JSON file of the geometry.
    * @param name Name of the geometry or group of geometries.
+   * @param menuNodeName Name of the node in Phoenix menu to add the geometry to.
    * @param scale Scale of the geometry.
    * @param doubleSided Renders both sides of the material.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadJSONGeometry(json: string | object, name: string,
+  public loadJSONGeometry(json: string | object, name: string, menuNodeName?: string,
     scale?: number, doubleSided?: boolean, initiallyVisible: boolean = true) {
     this.graphicsLibrary.loadJSONGeometry(json, name, scale, doubleSided, initiallyVisible);
-    this.ui.addGeometry(name, undefined, initiallyVisible);
+    this.ui.addGeometry(name, undefined, menuNodeName, initiallyVisible);
     this.infoLogger.add(name, 'Loaded JSON geometry');
   }
 
@@ -271,15 +276,16 @@ export class EventDisplay {
    * @param JSROOT JSRoot object containing all the JSROOT functions.
    * @param url URL of the JSRoot geometry file.
    * @param name Name of the geometry.
+   * @param menuNodeName Name of the node in Phoenix menu to add the geometry to.
    * @param scale Scale of the geometry.
    * @param doubleSided Renders both sides of the material.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public loadRootJSONGeometry(JSROOT: any, url: string, name: string,
+  public loadRootJSONGeometry(JSROOT: any, url: string, name: string, menuNodeName?: string,
     scale?: number, doubleSided?: boolean, initiallyVisible: boolean = true) {
     JSROOT.NewHttpRequest(url, 'object', (obj: any) => {
       this.loadJSONGeometry(JSROOT.GEO.build(obj, { dflt_colors: true }).toJSON(),
-        name, scale, doubleSided, initiallyVisible);
+        name, menuNodeName, scale, doubleSided, initiallyVisible);
     }).send();
   }
 
@@ -289,17 +295,19 @@ export class EventDisplay {
    * @param url URL of the JSRoot file.
    * @param objectName Name of the object inside the ".root" file.
    * @param name Name of the geometry.
+   * @param menuNodeName Name of the node in Phoenix menu to add the geometry to.
    * @param scale Scale of the geometry.
    * @param doubleSided Renders both sides of the material.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
   public loadRootGeometry(JSROOT: any, url: string, objectName: string,
-    name: string, scale?: number, doubleSided?: boolean, initiallyVisible: boolean = true) {
+    name: string, menuNodeName?: string, scale?: number, doubleSided?: boolean,
+    initiallyVisible: boolean = true) {
     if (url.indexOf('.root') > 0) {
       JSROOT.OpenFile(url, (file: any) => {
         file.ReadObject(objectName, (obj: any) => {
           this.loadJSONGeometry(JSROOT.GEO.build(obj, { dflt_colors: true }).toJSON(),
-            name, scale, doubleSided, initiallyVisible);
+            name, menuNodeName, scale, doubleSided, initiallyVisible);
         });
       });
     }
@@ -388,12 +396,13 @@ export class EventDisplay {
       loadGLTFGeometry: (sceneUrl: string, name: string) => {
         this.loadGLTFGeometry(sceneUrl, name);
       },
-      loadOBJGeometry: (filename: string, name: string, colour: any, doubleSided: boolean) => {
-        this.loadOBJGeometry(filename, name, colour, doubleSided);
+      loadOBJGeometry: (filename: string, name: string, colour: any,
+        menuNodeName: string, doubleSided: boolean) => {
+        this.loadOBJGeometry(filename, name, colour, menuNodeName, doubleSided);
       },
-      loadJSONGeometry: (json: string | object, name: string,
+      loadJSONGeometry: (json: string | object, name: string, menuNodeName: string,
         scale?: number, doubleSided?: boolean, initiallyVisible: boolean = true) => {
-        this.loadJSONGeometry(json, name, scale, doubleSided, initiallyVisible);
+        this.loadJSONGeometry(json, name, menuNodeName, scale, doubleSided, initiallyVisible);
       }
     };
   }

--- a/packages/phoenix-event-display/src/ui/index.ts
+++ b/packages/phoenix-event-display/src/ui/index.ts
@@ -247,9 +247,10 @@ export class UIManager {
    * Adds geometry to the dat.GUI menu's geometry folder and sets up its configurable options.
    * @param name Name of the geometry.
    * @param color Color of the geometry.
+   * @param menuNodeName Name of the node in Phoenix menu to add the geometry to.
    * @param initiallyVisible Whether the geometry is initially visible or not.
    */
-  public addGeometry(name: string, color: any, initiallyVisible: boolean = true) {
+  public addGeometry(name: string, color: any, menuNodeName?: string, initiallyVisible: boolean = true) {
     if (!this.geomFolderAdded) {
       this.addGeomFolder();
     }
@@ -289,8 +290,12 @@ export class UIManager {
     }
 
     if (this.hasPhoenixMenu) {
+      let parentNode: PhoenixMenuNode = this.geomFolderPM;
+      if (menuNodeName) {
+        parentNode = this.geomFolderPM.findInTreeOrCreate(menuNodeName);
+      }
       // Phoenix menu
-      const objFolderPM = this.geomFolderPM.addChild(name, (value: boolean) => {
+      const objFolderPM = parentNode.addChild(name, (value: boolean) => {
         this.three.getSceneManager().objectVisibility(name, value);
       });
       objFolderPM.toggleState = initiallyVisible;

--- a/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/ui/phoenix-menu/phoenix-menu-node.ts
@@ -193,4 +193,34 @@ export class PhoenixMenuNode {
       }
     }
   }
+
+  /**
+   * Find a node in the tree by name.
+   * @param name Name of the node to find.
+   * @returns The found node.
+   */
+  findInTree(name: string): PhoenixMenuNode {
+    if (this.name === name) {
+      return this;
+    } else {
+      for (const child of this.children) {
+        return child.findInTree(name);
+      }
+    }
+  }
+
+  /**
+   * Find a node in the tree by name or create one.
+   * @param name Name of the node to find or create.
+   * @returns The found or created node.
+   */
+  findInTreeOrCreate(name: string): PhoenixMenuNode {
+    let prevNode: PhoenixMenuNode = this;
+    name.split('>').forEach(nodeName => {
+      nodeName = nodeName.trim();
+      const nodeFound = prevNode.findInTree(nodeName);
+      prevNode = nodeFound ? nodeFound : prevNode.addChild(nodeName, () => { });
+    });
+    return prevNode;
+  }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
@@ -54,20 +54,20 @@ export class AtlasComponent implements OnInit {
 
     // Load detector geometries
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/toroids.obj', 'Toroids', 0x8c8c8c, false, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/toroids.obj', 'Toroids', 0x8c8c8c, undefined, false, false);
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/TRT.obj', 'TRT', 0x356aa5, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/TRT.obj', 'TRT', 0x356aa5, undefined, false);
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/SCT.obj', 'SCT', 0xfff400, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/SCT.obj', 'SCT', 0xfff400, undefined, false);
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/pixel.obj', 'Pixel', 0x356aa5, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/pixel.obj', 'Pixel', 0x356aa5, undefined, false);
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/LAR_Bar.obj', 'LAr Barrel', 0x19CCD2, true, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/LAR_Bar.obj', 'LAr Barrel', 0x19CCD2, undefined, true, false);
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/LAR_EC1.obj', 'LAr EC1', 0x19CCD2, true, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/LAR_EC1.obj', 'LAr EC1', 0x19CCD2, undefined, true, false);
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/LAR_EC2.obj', 'LAr EC2', 0x19CCD2, true, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/LAR_EC2.obj', 'LAr EC2', 0x19CCD2, undefined, true, false);
     this.eventDisplay
-      .loadOBJGeometry('assets/geometry/ATLAS/TileCal.obj', 'Tile Cal', 0xc14343, true, false);
+      .loadOBJGeometry('assets/geometry/ATLAS/TileCal.obj', 'Tile Cal', 0xc14343, undefined, true, false);
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.ts
@@ -30,7 +30,7 @@ export class CMSComponent implements OnInit {
     this.eventDisplay.init(configuration);
 
     ScriptLoader.loadJSRootScripts((JSROOT) => {
-      this.eventDisplay.loadRootJSONGeometry(JSROOT, 'https://root.cern/js/files/geom/cms.json.gz', 'CMS Detector', 10, true);
+      this.eventDisplay.loadRootJSONGeometry(JSROOT, 'https://root.cern/js/files/geom/cms.json.gz', 'CMS Detector', undefined, 10, true);
     });
 
     cmsLoader.readIgArchive('assets/files/cms/Hto4l_120-130GeV.ig', (allEvents: any[]) => {

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.ts
@@ -41,11 +41,11 @@ export class TrackmlComponent implements OnInit {
     };
 
     this.eventDisplay.init(configuration);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/strip_long_simplified.obj', 'Long Strip', 0xe9a23b, true);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/pixel_simplified.obj', 'Pixel', 0xe2a9e8, true);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/strip_short_simplified.obj', 'Short Strip', 0x369f95, true);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/beampipe_simplified.obj', 'Beampipe', 0x7f7f7f, true);
-    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/pixel_support_tube_simplified.obj', 'PST', 0x7bb3ff, true);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/strip_long_simplified.obj', 'Long Strip', 0xe9a23b, undefined, true);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/pixel_simplified.obj', 'Pixel', 0xe2a9e8, undefined, true);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/strip_short_simplified.obj', 'Short Strip', 0x369f95, undefined, true);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/beampipe_simplified.obj', 'Beampipe', 0x7f7f7f, undefined, true);
+    this.eventDisplay.loadOBJGeometry('assets/geometry/TrackML/pixel_support_tube_simplified.obj', 'PST', 0x7bb3ff, undefined, true);
     this.loadTrackMLData();
   }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
@@ -18,9 +18,11 @@ export class SSModeComponent {
       setTimeout(() => {
         document.addEventListener('click', this.onDocumentClick);
       }, 1);
+      document.documentElement.requestFullscreen();
     } else {
       document.removeEventListener('keydown', this.onEscapePress);
       document.removeEventListener('click', this.onDocumentClick);
+      document.exitFullscreen();
     }
   }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ss-mode/ss-mode.component.ts
@@ -18,11 +18,11 @@ export class SSModeComponent {
       setTimeout(() => {
         document.addEventListener('click', this.onDocumentClick);
       }, 1);
-      document.documentElement.requestFullscreen();
+      document.documentElement.requestFullscreen?.();
     } else {
       document.removeEventListener('keydown', this.onEscapePress);
       document.removeEventListener('click', this.onDocumentClick);
-      document.exitFullscreen();
+      document.exitFullscreen?.();
     }
   }
 


### PR DESCRIPTION
Closes #171 

Hi,

## Description

This adds support to add geometries to a folder / node in Phoenix menu. The geometries can also be added in multi level node hierarchies.

## Added

* Ability to add geometry to a menu folder
* Ability to specify the folder hierarchy to add the geometry to multilevel Phoenix menu folder.

Misc

* Full screen in screenshot mode

## Usage

For example, if we want to add an `OBJ` geometry to  the "Inner Detector" folder inside the "Detector" folder of Phoenix menu.

```js
EventDisplay.loadOBJGeometry('path/to/object.obj', 'Geometry', 0xffffff, 'Inner Detector');
```

And if we want to add an `OBJ` geometry to  the "Pixel" folder inside the "Inner Detector" folder which will be inside the "Detector" folder of Phoenix menu. The `>` works as a separator for specifying the hierarchy.

```js
EventDisplay.loadOBJGeometry('path/to/object.obj', 'Geometry', 0xffffff, 'Inner Detector > Pixel');
```

## Screenshot

```js
this.eventDisplay.loadGLTFGeometry('assets/geometry/LHCb/lhcb.gltf', 'LHCb detector', 'Folder > Sub Folder');
```

![image](https://user-images.githubusercontent.com/36920441/99219924-764f8a00-27ff-11eb-93c6-b8dc19413537.png)
