### PR TITLE
Fix geometry demo

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -315,6 +315,14 @@ export class EventDisplay {
   }
 
   /**
+   * Build Geometry from thr passed parameters, where 
+   * @param parameters 
+   */
+  public buildGeometryFromParameters(parameters: any): void {
+    this.graphicsLibrary.addGeometryFromParameters(parameters);
+  }
+
+  /**
    * Zoom all the cameras by a specific zoom factor.
    * The factor may either be greater (zoom in) or smaller (zoom out) than 1.
    * @param zoomFactor The factor to zoom by.
@@ -404,7 +412,8 @@ export class EventDisplay {
       loadJSONGeometry: (json: string | object, name: string, menuNodeName: string,
         scale?: number, doubleSided?: boolean, initiallyVisible: boolean = true) => {
         this.loadJSONGeometry(json, name, menuNodeName, scale, doubleSided, initiallyVisible);
-      }
+      },
+      buildGeometryFromParameters: (parameters:object)=> this.buildGeometryFromParameters(parameters)
     };
   }
 

--- a/packages/phoenix-event-display/src/three/index.ts
+++ b/packages/phoenix-event-display/src/three/index.ts
@@ -584,6 +584,9 @@ export class ThreeManager {
     return this.getSceneManager().getScene().getObjectByName(objectName);
   }
 
+  /** Add parametrised geometry to the scene.
+   * @param parameters The name, dimensions, and radial values for this cylindrical volume.
+   */
   public addGeometryFromParameters(parameters: any): void {
     let scene = this.getSceneManager().getScene();
     let moduleName = parameters.ModuleName;

--- a/packages/phoenix-event-display/src/three/index.ts
+++ b/packages/phoenix-event-display/src/three/index.ts
@@ -7,7 +7,11 @@ import {
   Quaternion,
   AmbientLight,
   DirectionalLight,
-  AxesHelper
+  AxesHelper,
+  BoxGeometry,
+  Mesh,
+  MeshBasicMaterial,
+  Euler
 } from 'three';
 import { Configuration } from '../extras/configuration';
 import { ControlsManager } from './controls-manager';
@@ -578,5 +582,53 @@ export class ThreeManager {
    */
   public getObjectByName(objectName: string): Object3D {
     return this.getSceneManager().getScene().getObjectByName(objectName);
+  }
+
+  public addGeometryFromParameters(parameters: any): void {
+    let scene = this.getSceneManager().getScene();
+    let moduleName = parameters.ModuleName;
+    let moduleXdim = parameters.Xdim;
+    let moduleYdim = parameters.Ydim;
+    let moduleZdim = parameters.Zdim;
+    let numPhiEl = parameters.NumPhiEl;
+    let numZEl = parameters.NumZEl;
+    let radius = parameters.Radius;
+
+    let minZ = parameters.MinZ;
+    let maxZ = parameters.MaxZ;
+    let tiltAngle = parameters.TiltAngle;
+    let ztiltAngle = parameters.ZTiltAngle;
+    let phiOffset = parameters.PhiOffset;
+    let colour = parameters.Colour;
+    let edgecolour = parameters.EdgeColour;
+    // Make the geometry and material
+    var geometry = new BoxGeometry(moduleXdim, moduleYdim, moduleZdim);
+    var material = new MeshBasicMaterial({ color: colour, opacity: 0.5, transparent: true });
+
+    var zstep = (maxZ - minZ) / numZEl;
+    var phistep = 2. * Math.PI / numPhiEl;
+
+    var z = minZ + zstep / 2.;
+
+    var halfPi = Math.PI / 2.0;
+    var modulecentre;
+    for (var elZ = 0; elZ < numZEl; elZ++) {
+      var phi = phiOffset;
+      for (var elPhi = 0; elPhi < numPhiEl; elPhi++) {
+        phi += phistep;
+        modulecentre = new Vector3(radius * Math.cos(phi), radius * Math.sin(phi), z);
+        var cube = new Mesh(geometry.clone(), material);
+
+        cube.matrix.makeRotationFromEuler(new Euler(ztiltAngle, 0.0, halfPi + phi + tiltAngle));
+        cube.matrix.setPosition(modulecentre);
+        cube.matrixAutoUpdate = false;
+        scene.add(cube);
+
+        // var egh = new EdgesHelper(cube, edgecolour);
+        // egh.material.linewidth = 2;
+        // scene.add(egh);
+      }
+      z += zstep
+    }
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.html
@@ -1,13 +1,12 @@
 <app-nav></app-nav>
-<app-experiment-info  experimentTagline="Geometry Demo">
-    <div>
-        <p>
-        Try opening the console and typing:
-<!--
-    {{ var parameters = { ModuleName: "Module 3", Xdim: 10., Ydim: 1., Zdim: 45, NumPhiEl: 64, NumZEl: 10, Radius: 105, MinZ: -250, MaxZ: 250, TiltAngle: 0.3, PhiOffset: 0.0, Colour: 0xffff00, EdgeColour: 0x449458 };}}        
-    {{window.EventDisplay.buildGeometryFromParameters(parameters)}}
--->
-    </p>
-    </div>
-</app-experiment-info>
+<div class="demo-info">
+  <p><b>Geometry Demo</b></p>
+  <p>Try opening the console and typing:</p>
+  <code id="geometryCode">
+    {{'var parameters = { ModuleName: "Module 3", Xdim: 10., Ydim: 1., Zdim: 45, NumPhiEl: 64, NumZEl: 10, Radius: 105, MinZ: -250, MaxZ: 250, TiltAngle: 0.3, PhiOffset: 0.0, Colour: 0xffff00, EdgeColour: 0x449458 };\
+    window.EventDisplay.buildGeometryFromParameters(parameters);'}}
+  </code>
+  <p class="copy-code" (click)="copyCode()"><b>Copy</b></p>
+</div>
+
 <div id="eventDisplay"></div>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.html
@@ -1,2 +1,13 @@
 <app-nav></app-nav>
+<app-experiment-info  experimentTagline="Geometry Demo">
+    <div>
+        <p>
+        Try opening the console and typing:
+<!--
+    {{ var parameters = { ModuleName: "Module 3", Xdim: 10., Ydim: 1., Zdim: 45, NumPhiEl: 64, NumZEl: 10, Radius: 105, MinZ: -250, MaxZ: 250, TiltAngle: 0.3, PhiOffset: 0.0, Colour: 0xffff00, EdgeColour: 0x449458 };}}        
+    {{window.EventDisplay.buildGeometryFromParameters(parameters)}}
+-->
+    </p>
+    </div>
+</app-experiment-info>
 <div id="eventDisplay"></div>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.scss
@@ -1,0 +1,18 @@
+.demo-info {
+  position: absolute;
+  top: 5rem;
+  left: 1rem;
+  font-size: 0.8rem;
+  color: var(--phoenix-text-color-secondary);
+  width: 20rem;
+  max-width: 40%;
+
+  code {
+    color: var(--phoenix-text-color-secondary);
+    cursor: text;
+  }
+
+  .copy-code {
+    cursor: pointer;
+  }
+}

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
@@ -12,6 +12,8 @@ export class GeometryComponent implements OnInit {
 
   ngOnInit() {
     this.eventDisplay.init({});
+    var parameters = { ModuleName: "Module 2", Xdim: 10., Ydim: 1., Zdim: 45, NumPhiEl: 64, NumZEl: 10, Radius: 75, MinZ: -250, MaxZ: 250, TiltAngle: 0.3, PhiOffset: 0.0, Colour: 0x00ff00, EdgeColour: 0x449458 };
+    this.eventDisplay.buildGeometryFromParameters(parameters);
   }
 
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
@@ -16,4 +16,14 @@ export class GeometryComponent implements OnInit {
     this.eventDisplay.buildGeometryFromParameters(parameters);
   }
 
+  copyCode() {
+    const code = document.getElementById('geometryCode').textContent.trim();
+    const inputElement = document.createElement('input');
+    document.body.appendChild(inputElement);
+    inputElement.value = code;
+    inputElement.select();
+    document.execCommand('copy');
+    document.body.removeChild(inputElement);
+  }
+
 }


### PR DESCRIPTION
Get the geometry demo working properly again.

The problem was the code to draw parametrised geometry was lost in the move to angular. So I re-implemented this, and added two new functions:
- buildGeometryFromParameters to EventDisplay
- addGeometryFromParameters to ThreeManager

Thanks to @9inpachi for the help!