### PR TITLE
Hide tube tracks on zoom

### DIFF
--- a/packages/phoenix-event-display/src/three/controls-manager.ts
+++ b/packages/phoenix-event-display/src/three/controls-manager.ts
@@ -1,5 +1,5 @@
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
-import { Camera, PerspectiveCamera, OrthographicCamera, Object3D, Vector3, Group } from 'three';
+import { Camera, PerspectiveCamera, OrthographicCamera, Object3D, Vector3, Group, Scene, Mesh, TubeBufferGeometry } from 'three';
 import { RendererManager } from './renderer-manager';
 import * as TWEEN from '@tweenjs/tween.js';
 
@@ -304,6 +304,37 @@ export class ControlsManager {
             }, 200).start();
           }
         }
+      }
+    });
+  }
+
+  /**
+   * Hide tube geometry of tracks on zoom if the camera is too close.
+   * (For visibility of vertices)
+   * @param scene Scene to look in for tracks.
+   * @param minRadius Radius after which the tube tracks should be invisible.
+   */
+  public hideTubeTracksOnZoom(scene: Scene, minRadius: number) {
+    let tracksHidden = false;
+    this.activeControls.addEventListener('change', (event) => {
+      const isCameraClose = (event.target.object.position as Vector3)
+        .toArray().every((val) => val < minRadius);
+      if (isCameraClose && !tracksHidden) {
+        const tracks = scene.getObjectByName('Tracks');
+        tracks.traverse(track => {
+          if (track.name === 'Track' && (track as Mesh).geometry instanceof TubeBufferGeometry) {
+            track.visible = false;
+          }
+        });
+        tracksHidden = true;
+      } else if (!isCameraClose && tracksHidden) {
+        const tracks = scene.getObjectByName('Tracks');
+        tracks.traverse(track => {
+          if (track.name === 'Track' && (track as Mesh).geometry instanceof TubeBufferGeometry) {
+            track.visible = true;
+          }
+        });
+        tracksHidden = false;
       }
     });
   }

--- a/packages/phoenix-event-display/src/three/controls-manager.ts
+++ b/packages/phoenix-event-display/src/three/controls-manager.ts
@@ -317,19 +317,17 @@ export class ControlsManager {
   public hideTubeTracksOnZoom(scene: Scene, minRadius: number) {
     let tracksHidden = false;
     this.activeControls.addEventListener('change', (event) => {
-      const isCameraClose = (event.target.object.position as Vector3)
-        .toArray().every((val) => val < minRadius);
+      const isCameraClose = (event?.target?.object?.position as Vector3)
+        .distanceTo(new Vector3()) < 200;
       if (isCameraClose && !tracksHidden) {
-        const tracks = scene.getObjectByName('Tracks');
-        tracks.traverse(track => {
+        scene.getObjectByName('Tracks').traverse(track => {
           if (track.name === 'Track' && (track as Mesh).geometry instanceof TubeBufferGeometry) {
             track.visible = false;
           }
         });
         tracksHidden = true;
       } else if (!isCameraClose && tracksHidden) {
-        const tracks = scene.getObjectByName('Tracks');
-        tracks.traverse(track => {
+        scene.getObjectByName('Tracks').traverse(track => {
           if (track.name === 'Track' && (track as Mesh).geometry instanceof TubeBufferGeometry) {
             track.visible = true;
           }

--- a/packages/phoenix-event-display/src/three/index.ts
+++ b/packages/phoenix-event-display/src/three/index.ts
@@ -99,6 +99,7 @@ export class ThreeManager {
     this.rendererManager.init(configuration.elementId);
     // Controls manager
     this.controlsManager = new ControlsManager(this.rendererManager, configuration.defaultView);
+    this.controlsManager.hideTubeTracksOnZoom(this.sceneManager.getScene(), 200);
     // Effects manager
     this.effectsManager = new EffectsManager(
       this.controlsManager.getMainCamera(),


### PR DESCRIPTION
Closes #178

Hi,

## Description

This hides the tube tracks when the camera gets closer to the origin within 200 radius.

**NOTE:** THIS IS FOR ALL EXPERIMENTS

## Added

* Function to enable the behavior of hiding tube tracks on zoom

## Screen Capture

![feat-hide-vertices](https://user-images.githubusercontent.com/36920441/101813515-a2300800-3b3e-11eb-8d73-48efc6cda760.gif)
