### PR TITLE
URL options manager with option to hide all overlay widgets

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -71,13 +71,16 @@ export class EventDisplay {
     };
     this.graphicsLibrary.setAnimationLoop(uiLoop);
 
+    // Process and apply URL options
+    if (configuration.allowUrlOptions !== false) {
+      const urlOptionsManager = new URLOptionsManager(this, configuration);
+      urlOptionsManager.applyOptions();
+    }
+
     // Allow adding elements through console
     this.enableEventDisplayConsole();
     // Allow keyboard controls
     this.enableKeyboardControls();
-    // Process and apply URL options
-    const urlOptionsManager = new URLOptionsManager(this, configuration);
-    urlOptionsManager.applyOptions();
   }
 
   /**

--- a/packages/phoenix-event-display/src/extras/configuration.ts
+++ b/packages/phoenix-event-display/src/extras/configuration.ts
@@ -6,7 +6,7 @@ import { PhoenixMenuNode } from '../ui/phoenix-menu/phoenix-menu-node';
  * Configuration of the event display.
  */
 export interface Configuration {
-  /** Default view [x,y,z] */
+  /** Default view [x,y,z]. */
   defaultView?: number[];
   /** Preset views for switching event display camera. */
   presetViews?: PresetView[];
@@ -20,4 +20,6 @@ export interface Configuration {
   elementId?: string;
   /** Default event to load when none given in URL. */
   defaultEventFile?: { eventFile: string, eventType: string };
+  /** Whether to allow URL options or not (true by default). */
+  allowUrlOptions?: boolean;
 }

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -33,7 +33,7 @@ export class PhoenixLoader implements EventDataLoader {
 
   /**
    * Takes an object that represents ONE event and takes care of adding
-   * the different objects to the graphic library and the UI controls.
+   * the different objects to the graphics library and the UI controls.
    * @param eventData Object representing the event.
    * @param graphicsLibrary Service containing functionality to draw the 3D objects.
    * @param ui Service for showing menus and controls to manipulate the geometries.

--- a/packages/phoenix-event-display/src/managers/url-options-manager.ts
+++ b/packages/phoenix-event-display/src/managers/url-options-manager.ts
@@ -1,0 +1,99 @@
+import { JiveXMLLoader, PhoenixLoader } from "src";
+import { Configuration } from "src/extras/configuration";
+import { EventDisplay } from "../event-display";
+import { StateManager } from "./state-manager";
+
+/**
+ * A manager for managing options given through URL.
+ */
+export class URLOptionsManager {
+  /** Variable containing all URL search parameters. */
+  private urlOptions: URLSearchParams;
+
+  /**
+   * Constructor for the URL options manager.
+   * @param eventDisplay The Phoenix event display.
+   * @param configuration Configuration of the event display.
+   */
+  constructor(private eventDisplay: EventDisplay, private configuration: Configuration) {
+    const locationHref = window.location.href;
+    this.urlOptions = new URLSearchParams(locationHref.substr(locationHref.lastIndexOf('?')));
+  }
+
+  /**
+   * Initialize and process all URL options on page load.
+   */
+  public applyOptions() {
+    // Initialize event with data from URL if there is any
+    this.initEventFromURL(
+      this.configuration.defaultEventFile?.eventFile,
+      this.configuration.defaultEventFile?.eventType
+    );
+  }
+
+  /**
+   * Initialize the event display with event data and configuration from URL.
+   * (Only JiveXML and JSON)
+   * @param defaultEventPath Default event path to fallback to if none in URL.
+   * @param defaultEventType Default event type to fallback to if none in URL.
+   */
+  public initEventFromURL(defaultEventPath?: string, defaultEventType?: string) {
+    if (!('fetch' in window)) {
+      return;
+    }
+
+    let file: string, type: string;
+
+    if (!this.urlOptions.get('file') || !this.urlOptions.get('type')) {
+      file = defaultEventPath;
+      type = defaultEventType;
+    } else {
+      file = this.urlOptions.get('file');
+      type = this.urlOptions.get('type').toLowerCase();
+    }
+
+    // Load config from URL
+    const loadConfig = () => {
+      if (this.urlOptions.get('config')) {
+        this.eventDisplay.getLoadingManager().addLoadableItem('url_config');
+        fetch(this.urlOptions.get('config'))
+          .then(res => res.json())
+          .then(jsonState => {
+            const stateManager = new StateManager();
+            stateManager.loadStateFromJSON(jsonState);
+          }).finally(() => {
+            this.eventDisplay.getLoadingManager().itemLoaded('url_config');
+          });
+      }
+    }
+
+    // Load event file from URL
+    if (file && type) {
+      this.eventDisplay.getLoadingManager().addLoadableItem('url_event');
+      fetch(file)
+        .then(res => type === 'jivexml' ? res.text() : res.json())
+        .then((res: object | string) => {
+          if (type === 'jivexml') {
+            const loader = new JiveXMLLoader();
+            this.configuration.eventDataLoader = loader;
+            // Parse the JSON to extract events and their data
+            loader.process(res);
+            const eventData = loader.getEventData();
+            this.eventDisplay.buildEventDataFromJSON(eventData);
+          } else {
+            this.configuration.eventDataLoader = new PhoenixLoader();
+            this.eventDisplay.parsePhoenixEvents(res);
+          }
+        }).catch((error) => {
+          this.eventDisplay.getInfoLogger().add('Could not find the file specified in URL.', 'Error');
+          console.error('Could not find the file specified in URL.', error);
+        }).finally(() => {
+          // Load config from URL after loading the event
+          loadConfig();
+          this.eventDisplay.getLoadingManager().itemLoaded('url_event');
+        });
+    } else {
+      loadConfig();
+    }
+  }
+}

--- a/packages/phoenix-event-display/src/managers/url-options-manager.ts
+++ b/packages/phoenix-event-display/src/managers/url-options-manager.ts
@@ -105,11 +105,11 @@ export class URLOptionsManager {
   public applyHideWidgetsOption() {
     if (Boolean(this.urlOptions.get('hideWidgets')) === true) {
       // Hide overlay widgets
-      document.getElementById('overlayWidgets').style.display = 'none';
+      document.getElementById('overlayWidgets')?.style.setProperty('display', 'none');
       // Hide stats
-      (document.getElementsByClassName('ui-element')[0] as HTMLElement).style.display = 'none';
+      (document.getElementsByClassName('ui-element')[0] as HTMLElement)?.style.setProperty('display', 'none');
       // Hide dat.GUI menu
-      document.getElementById('gui').style.display = 'none';
+      document.getElementById('gui')?.style.setProperty('display', 'none');
     }
   }
 }

--- a/packages/phoenix-event-display/src/managers/url-options-manager.ts
+++ b/packages/phoenix-event-display/src/managers/url-options-manager.ts
@@ -1,7 +1,8 @@
-import { JiveXMLLoader, PhoenixLoader } from "src";
-import { Configuration } from "src/extras/configuration";
-import { EventDisplay } from "../event-display";
-import { StateManager } from "./state-manager";
+import { JiveXMLLoader } from '../loaders/jivexml-loader';
+import { PhoenixLoader } from '../loaders/phoenix-loader';
+import { Configuration } from '../extras/configuration';
+import { EventDisplay } from '../event-display';
+import { StateManager } from './state-manager';
 
 /**
  * A manager for managing options given through URL.
@@ -21,14 +22,15 @@ export class URLOptionsManager {
   }
 
   /**
-   * Initialize and process all URL options on page load.
+   * Initialize and apply all URL options on page load.
    */
   public applyOptions() {
     // Initialize event with data from URL if there is any
-    this.initEventFromURL(
+    this.applyEventOptions(
       this.configuration.defaultEventFile?.eventFile,
       this.configuration.defaultEventFile?.eventType
     );
+    this.applyHideWidgetsOption();
   }
 
   /**
@@ -37,7 +39,7 @@ export class URLOptionsManager {
    * @param defaultEventPath Default event path to fallback to if none in URL.
    * @param defaultEventType Default event type to fallback to if none in URL.
    */
-  public initEventFromURL(defaultEventPath?: string, defaultEventType?: string) {
+  public applyEventOptions(defaultEventPath?: string, defaultEventType?: string) {
     if (!('fetch' in window)) {
       return;
     }
@@ -94,6 +96,20 @@ export class URLOptionsManager {
         });
     } else {
       loadConfig();
+    }
+  }
+
+  /**
+   * Hide all overlay widgets if "hideWidgets" option from the URL is true.
+   */
+  public applyHideWidgetsOption() {
+    if (Boolean(this.urlOptions.get('hideWidgets')) === true) {
+      // Hide overlay widgets
+      document.getElementById('overlayWidgets').style.display = 'none';
+      // Hide stats
+      (document.getElementsByClassName('ui-element')[0] as HTMLElement).style.display = 'none';
+      // Hide dat.GUI menu
+      document.getElementById('gui').style.display = 'none';
     }
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.html
@@ -1,6 +1,8 @@
 <app-loader [loaded]="loaded"></app-loader>
-<app-nav></app-nav>
-<app-ui-menu></app-ui-menu>
-<app-experiment-info experiment="atlas" experimentTagline="ATLAS Experiment at CERN"></app-experiment-info>
-<app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+<div id="overlayWidgets">
+  <app-nav></app-nav>
+  <app-ui-menu></app-ui-menu>
+  <app-experiment-info experiment="atlas" experimentTagline="ATLAS Experiment at CERN"></app-experiment-info>
+  <app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+</div>
 <div id="eventDisplay"></div>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.html
@@ -1,6 +1,8 @@
 <app-loader [loaded]="loaded"></app-loader>
-<app-nav></app-nav>
-<app-ui-menu></app-ui-menu>
-<app-experiment-info experiment="cms" experimentTagline="CMS Experiment at LHC, CERN"></app-experiment-info>
-<app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+<div id="overlayWidgets">
+  <app-nav></app-nav>
+  <app-ui-menu></app-ui-menu>
+  <app-experiment-info experiment="cms" experimentTagline="CMS Experiment at LHC, CERN"></app-experiment-info>
+  <app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+</div>
 <div id="eventDisplay"></div>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.html
@@ -1,6 +1,8 @@
 <app-loader [loaded]="loaded"></app-loader>
-<app-nav></app-nav>
-<app-ui-menu></app-ui-menu>
-<app-experiment-info experiment="lhcb" experimentTagline="LHCb Experiment at CERN"></app-experiment-info>
-<app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+<div id="overlayWidgets">
+  <app-nav></app-nav>
+  <app-ui-menu></app-ui-menu>
+  <app-experiment-info experiment="lhcb" experimentTagline="LHCb Experiment at CERN"></app-experiment-info>
+  <app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+</div>
 <div id="eventDisplay"></div>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.html
@@ -1,5 +1,7 @@
 <app-loader [loaded]="loaded"></app-loader>
-<app-nav></app-nav>
-<app-ui-menu></app-ui-menu>
-<app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+<div id="overlayWidgets">
+  <app-nav></app-nav>
+  <app-ui-menu></app-ui-menu>
+  <app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
+</div>
 <div id="eventDisplay"></div>


### PR DESCRIPTION
## Description

This adds an option to hide all overlay widgets through a URL parameter.

## Usage

Set the `hideWidgets` parameter in the URL.

Examples:
http://localhost:4200/#/cms?hideWidgets=true
http://phoenix-pr-214.surge.sh/#/atlas?hideWidgets=true

## Added

* Create a `URLOptionsManager` for easily extending URL options
* Ability to hide all overlay widgets with a URL parameter
* Other code optimizations