### PR TITLE
Open compressed event data

### DIFF
--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -34,6 +34,9 @@ export class PhoenixObjects {
    */
   public static getTrack(trackParams: any): Object3D {
     let positions = trackParams.pos;
+    if (!positions) {
+      return;
+    }
     // Track with no points
     // if (positions.length==0) {
     //   console.log("Track with no positions.")

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
@@ -10,25 +10,26 @@
         type="file"
         id="eventJiveXMLDataFile"
         class="inputfile"
-        accept="text/xml"
+        accept="text/xml, application/zip"
         name="image"
         (change)="handleJiveXMLDataInput($event.target.files)"
       />
       <label for="eventJiveXMLDataFile" class="imageLabel">
-        <img src="assets/icons/eventData.svg" alt="Event data icon" /> Load .xml
+        <img src="assets/icons/eventData.svg" alt="Event data icon" />
+        Load .xml, .zip
       </label>
 
       <input
         type="file"
         id="eventDataFile"
         class="inputfile"
-        accept="application/json"
+        accept="application/json, application/zip"
         name="image"
-        (change)="handleEventDataInput($event.target.files)"
+        (change)="handleJSONEventDataInput($event.target.files)"
       />
       <label for="eventDataFile" class="imageLabel">
-        <img src="assets/icons/eventData.svg" alt="Event data icon" /> Load
-        .json
+        <img src="assets/icons/eventData.svg" alt="Event data icon" />
+        Load .json, .zip
       </label>
     </div>
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
@@ -8,28 +8,41 @@
     <div class="row centered">
       <input
         type="file"
-        id="eventJiveXMLDataFile"
+        id="eventDataJiveXMLFile"
         class="inputfile"
         accept="text/xml, application/zip"
         name="image"
         (change)="handleJiveXMLDataInput($event.target.files)"
       />
-      <label for="eventJiveXMLDataFile" class="imageLabel">
+      <label for="eventDataJiveXMLFile" class="imageLabel">
         <img src="assets/icons/eventData.svg" alt="Event data icon" />
         Load .xml, .zip
       </label>
 
       <input
         type="file"
-        id="eventDataFile"
+        id="eventDataJSONFile"
         class="inputfile"
         accept="application/json, application/zip"
         name="image"
         (change)="handleJSONEventDataInput($event.target.files)"
       />
-      <label for="eventDataFile" class="imageLabel">
+      <label for="eventDataJSONFile" class="imageLabel">
         <img src="assets/icons/eventData.svg" alt="Event data icon" />
         Load .json, .zip
+      </label>
+
+      <input
+        type="file"
+        id="eventDataZipFile"
+        class="inputfile"
+        accept="application/zip"
+        name="image"
+        (change)="handleZipEventDataInput($event.target.files)"
+      />
+      <label for="eventDataZipFile" class="imageLabel">
+        <img src="assets/icons/eventData.svg" alt="Event data icon" />
+        Load .zip
       </label>
     </div>
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
@@ -10,26 +10,26 @@
         type="file"
         id="eventDataJiveXMLFile"
         class="inputfile"
-        accept="text/xml, application/zip"
+        accept="text/xml"
         name="image"
         (change)="handleJiveXMLDataInput($event.target.files)"
       />
       <label for="eventDataJiveXMLFile" class="imageLabel">
         <img src="assets/icons/eventData.svg" alt="Event data icon" />
-        Load .xml, .zip
+        Load .xml
       </label>
 
       <input
         type="file"
         id="eventDataJSONFile"
         class="inputfile"
-        accept="application/json, application/zip"
+        accept="application/json"
         name="image"
         (change)="handleJSONEventDataInput($event.target.files)"
       />
       <label for="eventDataJSONFile" class="imageLabel">
         <img src="assets/icons/eventData.svg" alt="Event data icon" />
-        Load .json, .zip
+        Load .json
       </label>
 
       <input

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.spec.ts
@@ -4,6 +4,7 @@ import { IOOptionsDialogComponent } from './io-options-dialog.component';
 import { MatDialogRef } from '@angular/material/dialog';
 import { EventDisplayService } from '../../../../services/event-display.service';
 import { PhoenixUIModule } from '../../../phoenix-ui.module';
+import JSZip from 'jszip';
 
 const mockFileList = (files: File[]): FileList => {
   const fileList: FileList = {
@@ -66,7 +67,7 @@ describe('IoOptionsDialogComponent', () => {
     expect(mockDialogRef.close).toHaveBeenCalled();
   });
 
-  describe('handleEventDataInput', () => {
+  describe('handleFileInput', () => {
     beforeEach(() => {
       spyOn(component, 'handleFileInput').and.callThrough();
     });
@@ -83,7 +84,7 @@ describe('IoOptionsDialogComponent', () => {
         });
     }, 30000);
 
-    describe('handleEventDataInput sync', () => {
+    describe('handleFileInput sync', () => {
       afterEach(() => {
         expect(component.handleFileInput).toHaveBeenCalled();
       });
@@ -140,6 +141,36 @@ describe('IoOptionsDialogComponent', () => {
           }),
         ]);
         component.handlePhoenixInput(files);
+      });
+    });
+
+    describe('handleZipFileInput', () => {
+      beforeEach(() => {
+        spyOn(component, 'handleZipInput').and.callThrough();
+      });
+
+      afterEach(() => {
+        expect(component.handleZipInput).toHaveBeenCalled();
+      });
+
+      it('should handle zipped JiveXML event data', async () => {
+        const zip = new JSZip();
+        zip.file('test_data.xml', '<test>test data</test>');
+        const zipBlob = await zip.generateAsync({ type: 'blob' });
+        const files = mockFileList([
+          new File([zipBlob], 'test_data.zip', { type: 'application/zip' }),
+        ]);
+        component.handleJiveXMLDataInput(files);
+      });
+
+      it('should handle zipped JSON event data', async () => {
+        const zip = new JSZip();
+        zip.file('test_data.json', '{ "event": null }');
+        const zipBlob = await zip.generateAsync({ type: 'blob' });
+        const files = mockFileList([
+          new File([zipBlob], 'test_data.zip', { type: 'application/zip' }),
+        ]);
+        component.handleJSONEventDataInput(files);
       });
     });
   });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.spec.ts
@@ -5,6 +5,15 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { EventDisplayService } from '../../../../services/event-display.service';
 import { PhoenixUIModule } from '../../../phoenix-ui.module';
 
+const mockFileList = (files: File[]): FileList => {
+  const fileList: FileList = {
+    length: files.length,
+    item: (index) => files[index],
+  };
+  Object.assign(fileList, files);
+  return fileList;
+};
+
 describe('IoOptionsDialogComponent', () => {
   let component: IOOptionsDialogComponent;
   let fixture: ComponentFixture<IOOptionsDialogComponent>;
@@ -21,6 +30,7 @@ describe('IoOptionsDialogComponent', () => {
     parseGLTFGeometry: jasmine.createSpy('parseGLTFGeometry'),
     exportPhoenixDisplay: jasmine.createSpy('exportPhoenixDisplay'),
     exportToOBJ: jasmine.createSpy('exportToOBJ'),
+    getInfoLogger: () => jasmine.createSpyObj('InfoLogger', ['add']),
   };
 
   beforeEach(async(() => {
@@ -65,7 +75,9 @@ describe('IoOptionsDialogComponent', () => {
       await fetch('assets/test_data/JiveXML.xml')
         .then((res) => res.text())
         .then((res) => {
-          const files = [new File([res], 'testfile.xml', { type: 'text/xml' })];
+          const files = mockFileList([
+            new File([res], 'testfile.xml', { type: 'text/xml' }),
+          ]);
           component.handleJiveXMLDataInput(files);
           expect(component.handleFileInput).toHaveBeenCalled();
         });
@@ -77,44 +89,56 @@ describe('IoOptionsDialogComponent', () => {
       });
 
       it('should log error for wrong file', () => {
-        const filesWrong = [
-          new File(['test data'], 'testfile.xml', { type: 'text/xml' }),
-        ];
-        component.handleEventDataInput(filesWrong);
+        const filesWrong = mockFileList([
+          new File(['test data'], 'testfile.xml', {
+            type: 'text/xml',
+          }),
+        ]);
+        component.handleJSONEventDataInput(filesWrong);
       });
 
       it('should handle JSON event data input', () => {
-        const files = [
-          new File(['{}'], 'testfile.json', { type: 'application/json' }),
-        ];
-        component.handleEventDataInput(files);
+        const files = mockFileList([
+          new File(['{}'], 'testfile.json', {
+            type: 'application/json',
+          }),
+        ]);
+        component.handleJSONEventDataInput(files);
       });
 
       it('should handle OBJ file input', () => {
-        const files = [
-          new File(['test data'], 'testfile.obj', { type: 'text/plain' }),
-        ];
+        const files = mockFileList([
+          new File(['test data'], 'testfile.obj', {
+            type: 'text/plain',
+          }),
+        ]);
         component.handleOBJInput(files);
       });
 
       it('should handle scene file input', () => {
-        const files = [
-          new File(['test data'], 'testfile.phnx', { type: 'text/plain' }),
-        ];
+        const files = mockFileList([
+          new File(['test data'], 'testfile.phnx', {
+            type: 'text/plain',
+          }),
+        ]);
         component.handleSceneInput(files);
       });
 
       it('should handle glTF file input', () => {
-        const files = [
-          new File(['{}'], 'testfile.gltf', { type: 'application/json' }),
-        ];
+        const files = mockFileList([
+          new File(['{}'], 'testfile.gltf', {
+            type: 'application/json',
+          }),
+        ]);
         component.handleGLTFInput(files);
       });
 
       it('should handle phoenix file input', () => {
-        const files = [
-          new File(['{}'], 'testfile.phnx', { type: 'application/json' }),
-        ];
+        const files = mockFileList([
+          new File(['{}'], 'testfile.phnx', {
+            type: 'application/json',
+          }),
+        ]);
         component.handlePhoenixInput(files);
       });
     });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.spec.ts
@@ -143,36 +143,17 @@ describe('IoOptionsDialogComponent', () => {
         component.handlePhoenixInput(files);
       });
     });
+  });
 
-    describe('handleZipFileInput', () => {
-      beforeEach(() => {
-        spyOn(component, 'handleZipInput').and.callThrough();
-      });
-
-      afterEach(() => {
-        expect(component.handleZipInput).toHaveBeenCalled();
-      });
-
-      it('should handle zipped JiveXML event data', async () => {
-        const zip = new JSZip();
-        zip.file('test_data.xml', '<test>test data</test>');
-        const zipBlob = await zip.generateAsync({ type: 'blob' });
-        const files = mockFileList([
-          new File([zipBlob], 'test_data.zip', { type: 'application/zip' }),
-        ]);
-        component.handleJiveXMLDataInput(files);
-      });
-
-      it('should handle zipped JSON event data', async () => {
-        const zip = new JSZip();
-        zip.file('test_data.json', '{ "event": null }');
-        const zipBlob = await zip.generateAsync({ type: 'blob' });
-        const files = mockFileList([
-          new File([zipBlob], 'test_data.zip', { type: 'application/zip' }),
-        ]);
-        component.handleJSONEventDataInput(files);
-      });
-    });
+  it('should handle zipped event data', async () => {
+    const zip = new JSZip();
+    zip.file('test_data.json', '{ "event": null }');
+    zip.file('test_data.xml', '<test>test data</test>');
+    const zipBlob = await zip.generateAsync({ type: 'blob' });
+    const files = mockFileList([
+      new File([zipBlob], 'test_data.zip', { type: 'application/zip' }),
+    ]);
+    component.handleZipEventDataInput(files);
   });
 
   it('should save scene', () => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -127,6 +127,42 @@ export class IOOptionsDialogComponent {
     });
   }
 
+  handleZipEventDataInput(files: FileList) {
+    if (this.isFileOfExtension(files[0], 'zip')) {
+      this.handleZipInput(files[0], (allFilesWithData) => {
+        const allEventsObject = {};
+        console.log(allFilesWithData);
+
+        // JSON event data
+        Object.keys(allFilesWithData)
+          .filter((fileName) => fileName.endsWith('.json'))
+          .forEach((fileName) => {
+            Object.assign(
+              allEventsObject,
+              JSON.parse(allFilesWithData[fileName])
+            );
+          });
+
+        // JiveXML event data
+        const jiveloader = new JiveXMLLoader();
+        Object.keys(allFilesWithData)
+          .filter((fileName) => fileName.endsWith('.xml'))
+          .forEach((fileName) => {
+            jiveloader.process(allFilesWithData[fileName]);
+            const eventData = jiveloader.getEventData();
+            Object.assign(allEventsObject, { [fileName]: eventData });
+          });
+
+        this.eventDisplay.parsePhoenixEvents(allEventsObject);
+
+        this.onNoClick();
+      });
+    } else {
+      console.error('Error: Invalid file format!');
+      this.eventDisplay.getInfoLogger().add('Invalid file format!', 'Error');
+    }
+  }
+
   async handleZipInput(
     file: File,
     callback: (allFilesWithData: { [key: string]: string }) => void

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -24,50 +24,17 @@ export class IOOptionsDialogComponent {
       const json = typeof content === 'string' ? JSON.parse(content) : content;
       this.eventDisplay.parsePhoenixEvents(json);
     };
-
-    if (this.isFileOfExtension(files[0], 'zip')) {
-      this.handleZipInput(files[0], (allFilesWithData) => {
-        const allEventsObject = {};
-
-        Object.values(allFilesWithData).forEach((fileData) => {
-          Object.assign(allEventsObject, JSON.parse(fileData));
-        });
-
-        callback(allEventsObject);
-        this.onNoClick();
-      });
-    } else {
-      this.handleFileInput(files[0], 'json', callback);
-    }
+    this.handleFileInput(files[0], 'json', callback);
   }
 
   handleJiveXMLDataInput(files: FileList) {
-    const processEventData = (content: any) => {
+    const callback = (content: any) => {
       const jiveloader = new JiveXMLLoader();
       jiveloader.process(content);
-      return jiveloader.getEventData();
-    };
-
-    const callback = (content: any) => {
-      const eventData = processEventData(content);
+      const eventData = jiveloader.getEventData();
       this.eventDisplay.buildEventDataFromJSON(eventData);
     };
-
-    if (this.isFileOfExtension(files[0], 'zip')) {
-      this.handleZipInput(files[0], (allFilesWithData) => {
-        const allEventsObject = {};
-
-        Object.entries(allFilesWithData).forEach(([fileName, fileData]) => {
-          const eventData = processEventData(fileData);
-          Object.assign(allEventsObject, { [fileName]: eventData });
-        });
-
-        this.eventDisplay.parsePhoenixEvents(allEventsObject);
-        this.onNoClick();
-      });
-    } else {
-      this.handleFileInput(files[0], 'xml', callback);
-    }
+    this.handleFileInput(files[0], 'xml', callback);
   }
 
   handleOBJInput(files: FileList) {
@@ -131,7 +98,6 @@ export class IOOptionsDialogComponent {
     if (this.isFileOfExtension(files[0], 'zip')) {
       this.handleZipInput(files[0], (allFilesWithData) => {
         const allEventsObject = {};
-        console.log(allFilesWithData);
 
         // JSON event data
         Object.keys(allFilesWithData)

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -42,13 +42,32 @@ export class IOOptionsDialogComponent {
   }
 
   handleJiveXMLDataInput(files: FileList) {
-    const callback = (content: any) => {
+    const processEventData = (content: any) => {
       const jiveloader = new JiveXMLLoader();
       jiveloader.process(content);
-      const eventData = jiveloader.getEventData();
+      return jiveloader.getEventData();
+    };
+
+    const callback = (content: any) => {
+      const eventData = processEventData(content);
       this.eventDisplay.buildEventDataFromJSON(eventData);
     };
-    this.handleFileInput(files[0], 'xml', callback);
+
+    if (this.isFileOfExtension(files[0], 'zip')) {
+      this.handleZipInput(files[0], (allFilesWithData) => {
+        const allEventsObject = {};
+
+        Object.entries(allFilesWithData).forEach(([fileName, fileData]) => {
+          const eventData = processEventData(fileData);
+          Object.assign(allEventsObject, { [fileName]: eventData });
+        });
+
+        this.eventDisplay.parsePhoenixEvents(allEventsObject);
+        this.onNoClick();
+      });
+    } else {
+      this.handleFileInput(files[0], 'xml', callback);
+    }
   }
 
   handleOBJInput(files: FileList) {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { EventDisplayService } from '../../../../services/event-display.service';
 import { MatDialogRef } from '@angular/material/dialog';
 import { JiveXMLLoader, ScriptLoader } from 'phoenix-event-display';
+import JSZip from 'jszip';
 
 @Component({
   selector: 'app-io-options-dialog',
@@ -18,53 +19,67 @@ export class IOOptionsDialogComponent {
     this.dialogRef.close();
   }
 
-  handleEventDataInput(files: any) {
+  handleJSONEventDataInput(files: FileList) {
     const callback = (content: any) => {
-      const json = JSON.parse(content);
+      const json = typeof content === 'string' ? JSON.parse(content) : content;
       this.eventDisplay.parsePhoenixEvents(json);
     };
-    this.handleFileInput(files, 'json', callback);
+
+    if (this.isFileOfExtension(files[0], 'zip')) {
+      this.handleZipInput(files[0], (allFilesWithData) => {
+        const allEventsObject = {};
+
+        Object.values(allFilesWithData).forEach((fileData) => {
+          Object.assign(allEventsObject, JSON.parse(fileData));
+        });
+
+        callback(allEventsObject);
+        this.onNoClick();
+      });
+    } else {
+      this.handleFileInput(files[0], 'json', callback);
+    }
   }
 
-  handleJiveXMLDataInput(files: any) {
+  handleJiveXMLDataInput(files: FileList) {
     const callback = (content: any) => {
       const jiveloader = new JiveXMLLoader();
       jiveloader.process(content);
       const eventData = jiveloader.getEventData();
       this.eventDisplay.buildEventDataFromJSON(eventData);
     };
-    this.handleFileInput(files, 'xml', callback);
+    this.handleFileInput(files[0], 'xml', callback);
   }
 
-  handleOBJInput(files: any) {
+  handleOBJInput(files: FileList) {
     const callback = (content: any, name: string) => {
       this.eventDisplay.parseOBJGeometry(content, name);
     };
-    this.handleFileInput(files, 'obj', callback);
+    this.handleFileInput(files[0], 'obj', callback);
   }
 
-  handleSceneInput(files: any) {
+  handleSceneInput(files: FileList) {
     const callback = (content: any) => {
       this.eventDisplay.parsePhoenixDisplay(content);
     };
-    this.handleFileInput(files, 'phnx', callback);
+    this.handleFileInput(files[0], 'phnx', callback);
   }
 
-  handleGLTFInput(files: any) {
+  handleGLTFInput(files: FileList) {
     const callback = (content: any, name: string) => {
       this.eventDisplay.parseGLTFGeometry(content, name);
     };
-    this.handleFileInput(files, 'gltf', callback);
+    this.handleFileInput(files[0], 'gltf', callback);
   }
 
-  handlePhoenixInput(files: any) {
+  handlePhoenixInput(files: FileList) {
     const callback = (content: any) => {
       this.eventDisplay.parsePhoenixDisplay(content);
     };
-    this.handleFileInput(files, 'phnx', callback);
+    this.handleFileInput(files[0], 'phnx', callback);
   }
 
-  handleROOTInput(files: any) {
+  handleROOTInput(files: FileList) {
     ScriptLoader.loadJSRootScripts().then((JSROOT: any) => {
       const objectName = prompt('Enter object name in ROOT file');
       JSROOT.openFile(files[0]).then((file: any) => {
@@ -79,7 +94,7 @@ export class IOOptionsDialogComponent {
     this.onNoClick();
   }
 
-  handleRootJSONInput(files: any) {
+  handleRootJSONInput(files: FileList) {
     ScriptLoader.loadJSRootScripts().then((JSROOT: any) => {
       const callback = (content: any, name: string) => {
         this.eventDisplay.loadJSONGeometry(
@@ -89,26 +104,51 @@ export class IOOptionsDialogComponent {
           name
         );
       };
-      this.handleFileInput(files, 'gz', callback);
+      this.handleFileInput(files[0], 'gz', callback);
     });
   }
 
+  async handleZipInput(
+    file: File,
+    callback: (allFilesWithData: { [key: string]: string }) => void
+  ) {
+    const allFilesWithData: { [key: string]: string } = {};
+    // Using a try catch block to catch any errors in Promises
+    try {
+      const zipArchive = new JSZip();
+      await zipArchive.loadAsync(file);
+      const allFiles = Object.keys(zipArchive.files);
+      for (const singleFile of allFiles) {
+        const fileData = await zipArchive.file(singleFile).async('string');
+        allFilesWithData[singleFile] = fileData;
+      }
+      callback(allFilesWithData);
+    } catch (error) {
+      console.error('Error while reading zip', error);
+      this.eventDisplay.getInfoLogger().add('Could not read zip', 'Error');
+    }
+  }
+
   handleFileInput(
-    files: any,
+    file: File,
     extension: string,
     callback: (result: string, fileName?: string) => void
   ) {
-    const file = files[0];
     const reader = new FileReader();
-    if (file.name.split('.').pop() === extension) {
+    if (this.isFileOfExtension(file, extension)) {
       reader.onload = () => {
         callback(reader.result.toString(), file.name.split('.')[0]);
       };
       reader.readAsText(file);
     } else {
-      console.log('Error : ¡ Invalid file format !');
+      console.error('Error: Invalid file format!');
+      this.eventDisplay.getInfoLogger().add('Invalid file format!', 'Error');
     }
     this.onNoClick();
+  }
+
+  private isFileOfExtension(file: File, extension: string) {
+    return file.name.split('.').pop() === extension;
   }
 
   saveScene() {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -144,7 +144,7 @@ export class IOOptionsDialogComponent {
       callback(allFilesWithData);
     } catch (error) {
       console.error('Error while reading zip', error);
-      this.eventDisplay.getInfoLogger().add('Could not read zip', 'Error');
+      this.eventDisplay.getInfoLogger().add('Could not read zip file', 'Error');
     }
   }
 


### PR DESCRIPTION
Closes #232 

## Description

This adds support for importing zip files with event data in either JiveXML or JSON format.

## Added

* Ability to import event data from zip file with both JiveXML or JSON inside the zip  
  * All are loaded and available through the event selection list in UI menu
* Add and update tests for `IOOptionsDialog`
* Fix error caused when there are no track positions in JSON event data