### PR TITLE
feat(event-display): add ability to scale clusters in just one direction

### DIFF
--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -318,7 +318,7 @@ export class PhoenixObjects {
   public static getCluster(clusterParams: any): Object3D {
     const maxR = 1100.0; // This needs to be configurable.
     const maxZ = 3200.0;
-    const length = clusterParams.energy * 0.003;
+    const length = clusterParams.energy * 0.03;
     // geometry
     const geometry = new BoxBufferGeometry(30, 30, length);
     // material

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -227,7 +227,7 @@ export class PhoenixLoader implements EventDataLoader {
         const scaleCaloClusters = (value: number) => {
           this.graphicsLibrary
             .getSceneManager()
-            .scaleChildObjects('CaloClusters', value / 100);
+            .scaleChildObjects('CaloClusters', value / 100, 'z');
         };
 
         if (typeFolder) {

--- a/packages/phoenix-event-display/src/three/scene-manager.ts
+++ b/packages/phoenix-event-display/src/three/scene-manager.ts
@@ -480,13 +480,18 @@ export class SceneManager {
    * Scale lowest level objects in a group.
    * @param groupName Name of the group to scale objects of.
    * @param value Value of the scale. Default is 1.
+   * @param axis If passed, the local axis to scale.
    */
-  public scaleChildObjects(groupName: string, value: number) {
+  public scaleChildObjects(groupName: string, value: number, axis?: string) {
     const object = this.scene.getObjectByName(groupName);
 
     object.traverse((objectChild: Object3D) => {
       if (objectChild.children.length === 0) {
-        objectChild.scale.setScalar(value);
+        if (!axis) {
+          objectChild.scale.setScalar(value);
+        } else {
+          objectChild.scale[axis] = value;
+        }
       }
     });
   }


### PR DESCRIPTION
Follow up to discussion on PR #257

Allows to scale clusters just in z direction (but made this a general feature of `scaleChildObjects`)