### PR TITLE
feat(event-display): add guidelines and simplify some coordinate tran…

### DIFF
--- a/packages/phoenix-event-display/src/helpers/coordinate-helper.ts
+++ b/packages/phoenix-event-display/src/helpers/coordinate-helper.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from 'three';
+import { Vector3, Quaternion } from 'three';
 
 /**
  * Helper methods for coordinate conversions.
@@ -26,7 +26,7 @@ export class CoordinateHelper {
 
   /**
    * Get cartesian from spherical parameters.
-   * This should NOT be necessary - should use native threejs methods such as Vector3.setFromSpherical
+   * Applies the necessary rotations to move from threejs to experimental.
    * @param radius The radius.
    * @param theta Theta angle.
    * @param phi Phi angle.
@@ -36,10 +36,35 @@ export class CoordinateHelper {
     theta: number,
     phi: number
   ): Vector3 {
-    return new Vector3(
-      radius * Math.cos(phi) * Math.sin(theta),
-      radius * Math.sin(phi) * Math.sin(theta),
-      radius * Math.cos(theta)
-    );
+    // Threejs uses theta as azimuthal, so need to reverse.
+    let vector = new Vector3();
+    vector.setFromSphericalCoords(radius, theta, phi);
+    vector.applyQuaternion(CoordinateHelper.atlasQuaternion());
+    return vector;
+  }
+
+  public static etaPhiToCartesian(
+    radius: number,
+    eta: number,
+    phi: number
+  ): Vector3 {
+    let vector = new Vector3();
+    // Threejs uses theta as azimuthal, so need to reverse.
+    vector.setFromSphericalCoords(radius, this.etaToTheta(eta), phi);
+    vector.applyQuaternion(CoordinateHelper.atlasQuaternion());
+    return vector;
+  }
+
+  public static atlasQuaternion(): Quaternion {
+    // With nothing, we have eta=0 on x, and phi=0 on z
+    // Should be eta=0 on y, and phi=0 on x
+    const v1 = new Vector3(0, 1, 0);
+    const v2 = new Vector3(0, 0, 1);
+    const quaternion = new Quaternion();
+    quaternion.setFromUnitVectors(v1, v2); // This puts eta~infinite on z-axis, eta=0 on  but y-positive is phi=PI (and eta=0 on x)
+    const quaternion2 = new Quaternion();
+    quaternion2.setFromAxisAngle(new Vector3(0, 1, 0), Math.PI / 2.0); // Now have eta = 3.0 on -x, eta =0 on +y, and phi = 0 on +z
+    quaternion.multiply(quaternion2);
+    return quaternion;
   }
 }

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -302,7 +302,7 @@ export class PhoenixObjects {
    * @returns Cluster object.
    */
   public static getCluster(clusterParams: any): Object3D {
-    const maxR = 1100.0; // This needs to be configurable.
+    const maxR2 = 1100.0 * 1100.0;
     const maxZ = 3200.0;
     const length = clusterParams.energy * 0.03;
     // geometry
@@ -316,26 +316,26 @@ export class PhoenixObjects {
     const theta = CoordinateHelper.etaToTheta(clusterParams.eta);
     clusterParams.theta = theta;
 
-    const pos = new Vector3(
-      4000.0 * Math.cos(clusterParams.phi) * Math.sin(theta),
-      4000.0 * Math.sin(clusterParams.phi) * Math.sin(theta),
-      4000.0 * Math.cos(theta)
+    let position = CoordinateHelper.sphericalToCartesian(
+      4000,
+      theta,
+      clusterParams.phi
     );
 
-    cube.position.copy(
-      CoordinateHelper.sphericalToCartesian(4000, theta, clusterParams.phi)
-    );
-
-    // FIXME - more elegant way to do this? Maybe natively use cylindrical here?
-    // How to generalise? Pass in limit lambda?
-    if (
-      cube.position.x * cube.position.x + cube.position.y * cube.position.y >
-      maxR * maxR
-    ) {
-      cube.position.x = maxR * Math.cos(clusterParams.phi);
-      cube.position.y = maxR * Math.sin(clusterParams.phi);
+    // How to generalise to other experiments? Pass in limit lambda?
+    let cylRadius2 = position.x * position.x + position.y * position.y;
+    if (cylRadius2 > maxR2) {
+      position.setLength(
+        (position.length() * Math.sqrt(maxR2)) / Math.sqrt(cylRadius2)
+      );
     }
-    cube.position.z = Math.max(Math.min(pos.z, maxZ), -maxZ); // keep in maxZ range.
+
+    if (Math.abs(position.z) > maxZ) {
+      position.setLength((position.length() * maxZ) / position.z);
+    }
+
+    cube.position.copy(position);
+
     cube.lookAt(new Vector3(0, 0, 0));
     cube.userData = Object.assign({}, clusterParams);
     cube.name = 'Cluster';

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -167,7 +167,7 @@ export class PhoenixLoader implements EventDataLoader {
       // (Optional) Cuts can be added to any physics object.
       const cuts = [
         new Cut('phi', -pi, pi, 0.01),
-        new Cut('eta', -5, 5),
+        new Cut('eta', -5.0, 5.0, 0.1),
         new Cut('energy', 0, 100000, 100),
       ];
 
@@ -216,7 +216,7 @@ export class PhoenixLoader implements EventDataLoader {
       // (Optional) Cuts can be added to any physics object.
       const cuts = [
         new Cut('phi', -pi, pi, 0.01),
-        new Cut('eta', -5, 5),
+        new Cut('eta', -5.0, 5.0),
         new Cut('energy', 0, 10000),
       ];
 
@@ -262,7 +262,7 @@ export class PhoenixLoader implements EventDataLoader {
     if (eventData.Muons) {
       const cuts = [
         new Cut('phi', -pi, pi, 0.01),
-        new Cut('eta', -4, 4),
+        new Cut('eta', -4, 4, 0.1),
         new Cut('energy', 0, 10000),
         new Cut('pT', 0, 50),
       ];

--- a/packages/phoenix-event-display/src/ui/index.ts
+++ b/packages/phoenix-event-display/src/ui/index.ts
@@ -977,6 +977,14 @@ export class UIManager {
   }
 
   /**
+   * Set whether to show the eta/phi or not
+   * @param show If the grid is to be shown or not.
+   */
+  public setShowGrid(show: boolean) {
+    this.three.getSceneManager().setEtaPhiGrid(show);
+  }
+
+  /**
    * Get preset views from the configuration.
    * @returns Available preset views.
    */

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/view-options/view-options.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/view-options/view-options.component.html
@@ -2,6 +2,12 @@
   <mat-checkbox
     class="mat-menu-item"
     (click)="$event.stopPropagation()"
+    (change)="setGrid($event)"
+    >Show Grid
+  </mat-checkbox>
+  <mat-checkbox
+    class="mat-menu-item"
+    (click)="$event.stopPropagation()"
     (change)="setAxis($event)"
     >Show axis
   </mat-checkbox>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/view-options/view-options.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/view-options/view-options.component.ts
@@ -26,4 +26,9 @@ export class ViewOptionsComponent implements OnInit {
     const value = change.checked;
     this.eventDisplay.getUIManager().setShowAxis(value);
   }
+
+  setGrid(change: MatCheckboxChange) {
+    const value = change.checked;
+    this.eventDisplay.getUIManager().setShowGrid(value);
+  }
 }


### PR DESCRIPTION
For the simplifying of the coordinate transformation, as discussed in the last Phoenix weekly, this is not the end of this story .. we should make these transformation configurable for other experiments. But it's definitely better (IMO)

Also, tweaked some default cuts.

Finally, this adds a first go at guidelines as discussed in #266

![image](https://user-images.githubusercontent.com/6764617/114896093-5228c100-9e10-11eb-9223-5b48578ac8f4.png)
