### PR TITLE
Support for loading progress

### DIFF
--- a/packages/phoenix-event-display/src/managers/loading-manager.ts
+++ b/packages/phoenix-event-display/src/managers/loading-manager.ts
@@ -35,6 +35,7 @@ export class LoadingManager {
    */
   public addLoadableItem(id: string = '') {
     this.toLoad.push(id);
+    this.progressItems[id] = 0;
   }
 
   /**
@@ -43,6 +44,8 @@ export class LoadingManager {
    */
   public itemLoaded(id: string = '') {
     this.loaded.push(id);
+    this.onProgress(id, 100);
+
     if (
       this.toLoad.length === this.loaded.length &&
       this.toLoad.sort().join(',') === this.loaded.sort().join(',')
@@ -54,11 +57,11 @@ export class LoadingManager {
 
   /**
    * When an item loading progresses.
-   * @param itemName Name of the item with the progress.
+   * @param id ID of the item with the progress.
    * @param progress Progress of the item.
    */
-  public onProgress(itemName: string, progress: number) {
-    this.progressItems[itemName] = progress;
+  public onProgress(id: string, progress: number) {
+    this.progressItems[id] = progress;
 
     let totalProgress = Object.values(this.progressItems).reduce(
       (acc, val) => acc + val,

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.html
@@ -1,4 +1,4 @@
-<app-loader [loaded]="loaded"></app-loader>
+<app-loader [loaded]="loaded" [progress]="loadingProgress"></app-loader>
 <app-nav></app-nav>
 <app-ui-menu
   [eventDataImportOptions]="['JSON', 'JIVEXML', 'ZIP']"

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
@@ -21,6 +21,7 @@ import phoenixMenuConfig from '../../../assets/files/config/atlas-config.json';
 export class AtlasComponent implements OnInit {
   phoenixMenuRoot = new PhoenixMenuNode('Phoenix Menu', 'phoenix-menu');
   loaded = false;
+  loadingProgress = 0;
 
   constructor(private eventDisplay: EventDisplayService) {}
 
@@ -262,6 +263,10 @@ export class AtlasComponent implements OnInit {
       1000,
       false
     );
+
+    this.eventDisplay
+      .getLoadingManager()
+      .addProgressListener((progress) => (this.loadingProgress = progress));
 
     // Load the default configuration
     this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.html
@@ -1,4 +1,4 @@
-<app-loader [loaded]="loaded"></app-loader>
+<app-loader [loaded]="loaded" [progress]="loadingProgress"></app-loader>
 <app-nav></app-nav>
 <app-ui-menu [eventDataImportOptions]="['JSON', 'IG']"></app-ui-menu>
 <app-experiment-info

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.ts
@@ -19,6 +19,7 @@ export class CMSComponent implements OnInit {
     'phoenix-menu'
   );
   loaded = false;
+  loadingProgress = 0;
 
   constructor(private eventDisplay: EventDisplayService) {}
 
@@ -57,8 +58,12 @@ export class CMSComponent implements OnInit {
       }
     );
 
-    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
-      this.loaded = true;
-    });
+    this.eventDisplay
+      .getLoadingManager()
+      .addProgressListener((progress) => (this.loadingProgress = progress));
+
+    this.eventDisplay
+      .getLoadingManager()
+      .addLoadListenerWithCheck(() => (this.loaded = true));
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.html
@@ -1,4 +1,4 @@
-<app-loader [loaded]="loaded"></app-loader>
+<app-loader [loaded]="loaded" [progress]="loadingProgress"></app-loader>
 <app-nav></app-nav>
 <div class="demo-info">
   <p><b>Geometry Demo</b></p>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
@@ -8,6 +8,7 @@ import { EventDisplayService } from 'phoenix-ui-components';
 })
 export class GeometryComponent implements OnInit {
   loaded = false;
+  loadingProgress = 0;
 
   constructor(private eventDisplay: EventDisplayService) {}
 
@@ -30,9 +31,13 @@ export class GeometryComponent implements OnInit {
     };
     this.eventDisplay.buildGeometryFromParameters(parameters);
 
-    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
-      this.loaded = true;
-    });
+    this.eventDisplay
+      .getLoadingManager()
+      .addProgressListener((progress) => (this.loadingProgress = progress));
+
+    this.eventDisplay
+      .getLoadingManager()
+      .addLoadListenerWithCheck(() => (this.loaded = true));
   }
 
   copyCode() {

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.html
@@ -1,4 +1,4 @@
-<app-loader [loaded]="loaded"></app-loader>
+<app-loader [loaded]="loaded" [progress]="loadingProgress"></app-loader>
 <app-nav></app-nav>
 <app-ui-menu [eventDataImportOptions]="['JSON', lhcbImporter]"></app-ui-menu>
 <app-experiment-info

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
@@ -20,6 +20,7 @@ export class LHCbComponent implements OnInit {
     'phoenix-menu'
   );
   loaded = false;
+  loadingProgress = 0;
 
   lhcbImporter = new ImportOption(
     'JSON (LHCb)',
@@ -57,9 +58,13 @@ export class LHCbComponent implements OnInit {
         this.loadEventData(eventData);
       });
 
-    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
-      this.loaded = true;
-    });
+    this.eventDisplay
+      .getLoadingManager()
+      .addProgressListener((progress) => (this.loadingProgress = progress));
+
+    this.eventDisplay
+      .getLoadingManager()
+      .addLoadListenerWithCheck(() => (this.loaded = true));
   }
 
   handleLHCbJSONImport(files: FileList) {

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/playground/playground.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/playground/playground.component.html
@@ -1,4 +1,4 @@
-<app-loader [loaded]="loaded"></app-loader>
+<app-loader [loaded]="loaded" [progress]="loadingProgress"></app-loader>
 <app-nav></app-nav>
 <app-ui-menu></app-ui-menu>
 <div id="eventDisplay"></div>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/playground/playground.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/playground/playground.component.ts
@@ -10,6 +10,7 @@ import { HttpClient } from '@angular/common/http';
 })
 export class PlaygroundComponent implements OnInit {
   loaded = false;
+  loadingProgress = 0;
 
   constructor(
     protected eventDisplay: EventDisplayService,
@@ -26,8 +27,12 @@ export class PlaygroundComponent implements OnInit {
     };
     this.eventDisplay.init(configuration);
 
-    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
-      this.loaded = true;
-    });
+    this.eventDisplay
+      .getLoadingManager()
+      .addProgressListener((progress) => (this.loadingProgress = progress));
+
+    this.eventDisplay
+      .getLoadingManager()
+      .addLoadListenerWithCheck(() => (this.loaded = true));
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.html
@@ -1,4 +1,4 @@
-<app-loader [loaded]="loaded"></app-loader>
+<app-loader [loaded]="loaded" [progress]="loadingProgress"></app-loader>
 <app-nav></app-nav>
 <app-ui-menu></app-ui-menu>
 <app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/trackml/trackml.component.ts
@@ -29,6 +29,7 @@ export class TrackmlComponent implements OnInit {
     'phoenix-menu'
   );
   loaded = false;
+  loadingProgress = 0;
 
   constructor(
     private eventDisplay: EventDisplayService,
@@ -87,9 +88,13 @@ export class TrackmlComponent implements OnInit {
     );
     this.loadTrackMLData();
 
-    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
-      this.loaded = true;
-    });
+    this.eventDisplay
+      .getLoadingManager()
+      .addProgressListener((progress) => (this.loadingProgress = progress));
+
+    this.eventDisplay
+      .getLoadingManager()
+      .addLoadListenerWithCheck(() => (this.loaded = true));
   }
 
   private loadTrackMLData() {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/_theming.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/_theming.scss
@@ -10,6 +10,8 @@ $light-theme: mat-light-theme($primary, $accent, $warn);
 @include angular-material-theme($light-theme);
 
 :root {
+  --phoenix-primary: #118ab2;
+  --phoenix-secondary: #f1e833;
   --phoenix-background-color: #ffffff;
   --phoenix-background-color-secondary: #f5f5f5;
   --phoenix-background-color-tertiary: #e6e6e6;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.html
@@ -1,12 +1,13 @@
 <div
-  class="loader-wrapper d-flex justify-content-center align-items-center text-center"
+  class="loader-wrapper d-flex position-absolute flex-column justify-content-center align-items-center w-100 h-100 text-center"
   [ngClass]="{ 'load-complete': loaded }"
 >
-  <div>
-    <img src="assets/images/logo-small.svg" alt="Loader" />
-    <p class="mt-5">
-      Loading...<br />
-      <small class="text-muted">(This may take a while)</small>
-    </p>
+  <img src="assets/images/logo-small.svg" alt="Loader" />
+  <p class="mt-5">
+    Loading...<br />
+    <small class="text-muted">(This may take a while)</small>
+  </p>
+  <div class="loading-bar" *ngIf="progress">
+    <span [style]="{ width: progress + '%' }"></span>
   </div>
 </div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.html
@@ -7,7 +7,7 @@
     Loading...<br />
     <small class="text-muted">(This may take a while)</small>
   </p>
-  <div class="loading-bar" *ngIf="progress">
+  <div class="loading-bar" *ngIf="progress !== undefined">
     <span [style]="{ width: progress + '%' }"></span>
   </div>
 </div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.scss
@@ -33,8 +33,7 @@
         var(--phoenix-primary),
         var(--phoenix-secondary)
       );
-
-      transition: width 0.5s;
+      transition: all 0.5s;
     }
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.scss
@@ -1,11 +1,10 @@
 .loader-wrapper {
-  position: absolute;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 100%;
   background: var(--phoenix-background-color);
   z-index: 9998;
+
+  &.load-complete {
+    display: none !important;
+  }
 
   img {
     width: 5rem;
@@ -17,8 +16,26 @@
     color: var(--phoenix-text-color);
   }
 
-  &.load-complete {
-    display: none !important;
+  .loading-bar {
+    width: 15rem;
+    max-width: 90%;
+    height: 0.5rem;
+    background: var(--phoenix-background-color-tertiary);
+    border-radius: 2.5rem;
+    overflow: hidden;
+
+    span {
+      display: block;
+      height: 100%;
+      border-radius: 2.5rem;
+      background: linear-gradient(
+        to right,
+        var(--phoenix-primary),
+        var(--phoenix-secondary)
+      );
+
+      transition: width 0.5s;
+    }
   }
 }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/loader/loader.component.ts
@@ -7,4 +7,5 @@ import { Component, Input } from '@angular/core';
 })
 export class LoaderComponent {
   @Input() loaded = false;
+  @Input() progress: number;
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ui-menu.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ui-menu.component.html
@@ -11,58 +11,61 @@
     </svg>
   </button>
   <div id="optionsPanel" [hidden]="hideUIMenu">
-    <!-- Toggle for shareable link constructor modal-->
-    <app-share-link></app-share-link>
+    <!-- Event selector -->
+    <app-event-selector></app-event-selector>
+
+    <!-- Zoom in and zoom out controls -->
+    <app-zoom-controls></app-zoom-controls>
+
+    <app-view-options></app-view-options>
+
+    <app-auto-rotate></app-auto-rotate>
+
+    <!-- Dark theme toggle -->
+    <app-dark-theme></app-dark-theme>
+
+    <!-- Toggle for clipping geometries -->
+    <app-object-clipping></app-object-clipping>
+
+    <!-- Main view toggle -->
+    <app-main-view-toggle></app-main-view-toggle>
+
+    <!-- Toggle for overlay panel -->
+    <app-overlay-view></app-overlay-view>
+
+    <!-- Toggle for selected object panel -->
+    <app-object-selection></app-object-selection>
+
+    <!-- Info panel -->
+    <app-info-panel></app-info-panel>
+
+    <!-- Toggle for animating the event data -->
+    <app-animate-event></app-animate-event>
+
+    <!-- Toggle for animating camera through event -->
+    <app-animate-camera></app-animate-camera>
+
+    <!-- Toggle for collections info -->
+    <app-collections-info></app-collections-info>
+
+    <!-- Toggle for performance -->
+    <app-performance-toggle></app-performance-toggle>
+
+    <!-- Toggle for VR -->
+    <app-vr-toggle></app-vr-toggle>
+
+    <!-- Toggle for screenshot mode -->
+    <app-ss-mode></app-ss-mode>
 
     <!-- Toggle for loading geometries modal-->
     <app-io-options
       [eventDataImportOptions]="eventDataImportOptions"
     ></app-io-options>
 
-    <!-- Toggle for screenshot mode -->
-    <app-ss-mode></app-ss-mode>
+    <!-- Toggle for shareable link constructor modal-->
+    <app-share-link></app-share-link>
 
-    <!-- Toggle for VR -->
-    <app-vr-toggle></app-vr-toggle>
-
-    <!-- Toggle for performance -->
-    <app-performance-toggle></app-performance-toggle>
-
-    <!-- Toggle for collections info -->
-    <app-collections-info></app-collections-info>
-
-    <!-- Toggle for animating camera through event -->
-    <app-animate-camera></app-animate-camera>
-
-    <!-- Toggle for animating the event data -->
-    <app-animate-event></app-animate-event>
-
-    <!-- Info panel -->
-    <app-info-panel></app-info-panel>
-
-    <!-- Toggle for selected object panel -->
-    <app-object-selection></app-object-selection>
-
-    <!-- Toggle for overlay panel -->
-    <app-overlay-view></app-overlay-view>
-
-    <!-- Main view toggle -->
-    <app-main-view-toggle></app-main-view-toggle>
-
-    <!-- Toggle for clipping geometries -->
-    <app-object-clipping></app-object-clipping>
-
-    <!-- Dark theme toggle -->
-    <app-dark-theme></app-dark-theme>
-
-    <app-auto-rotate></app-auto-rotate>
-
-    <app-view-options></app-view-options>
-
-    <!-- Zoom in and zoom out controls -->
-    <app-zoom-controls></app-zoom-controls>
-
-    <!-- Event selector -->
-    <app-event-selector></app-event-selector>
+    <!-- Extra options -->
+    <ng-content></ng-content>
   </div>
 </div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ui-menu.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/ui-menu.component.scss
@@ -10,7 +10,6 @@
 
 #optionsPanel {
   display: flex;
-  flex-direction: row-reverse;
   justify-content: center;
   align-items: center;
   background: var(--phoenix-background-color-secondary);


### PR DESCRIPTION
## Description

This adds a loading progress bar based on the number of items loaded. A next step would be to use `LoadingManager.onProgress(id: string, progress: number)` to supply progress of each geometry loaded if the geometry loader supports it.

## Changes

* Allow content in UI menu for displaying custom menu items
* Use linear row for UI menu items
* Add loading progress in `LoadingManager` based on number of items loaded
* Add loading progress to all experiments.