### PR TITLE
Fix color by vertex and add option to randomly color collections

### DIFF
--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -358,7 +358,7 @@ export class PhoenixLoader implements EventDataLoader {
         };
         if (typeFolder) {
           const sizeMenu = typeFolder
-            .add({ jetsScale: 100 }, 'Scale', 1, 200)
+            .add({ jetsScale: 100 }, 'jetsScale', 1, 200)
             .name('Size (%)');
           sizeMenu.onChange(scaleMET);
         }

--- a/packages/phoenix-event-display/src/managers/state-manager.ts
+++ b/packages/phoenix-event-display/src/managers/state-manager.ts
@@ -97,7 +97,7 @@ export class StateManager {
   loadStateFromJSON(json: string | object) {
     const jsonData: object = typeof json === 'string' ? JSON.parse(json) : json;
 
-    if (jsonData['phoenixMenu']) {
+    if (jsonData['phoenixMenu'] && this.phoenixMenuRoot) {
       this.phoenixMenuRoot.loadStateFromJSON(jsonData['phoenixMenu']);
       this.phoenixMenuRoot.configActive = false;
     }

--- a/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
@@ -1,4 +1,4 @@
-import { Color } from 'three';
+import { Color, MeshPhongMaterial } from 'three';
 import { SceneManager } from './scene-manager';
 
 /**
@@ -49,6 +49,23 @@ export class ColorManager {
   }
 
   /**
+   * Changes the color of all objects inside an event data collection to some random color.
+   * @param collectionName Name of the collection.
+   */
+  public collectionColorRandom(collectionName: string) {
+    const collection = this.sceneManager
+      .getScene()
+      .getObjectByName(SceneManager.EVENT_DATA_ID)
+      .getObjectByName(collectionName);
+
+    for (const child of Object.values(collection.children)) {
+      child.traverse((object) => {
+        (object['material']?.color as Color)?.set(Math.random() * 0xffffff);
+      });
+    }
+  }
+
+  /**
    * Randomly color tracks by the vertex they are associated with.
    * @param collectionName Name of the collection.
    */
@@ -63,8 +80,8 @@ export class ColorManager {
         linkedTrackCollection === collectionName &&
         linkedTracks
       ) {
-        const colorForTracksVertex = new Color(Math.random() * 0xffffff);
-
+        const colorForTracksVertex = (object['material'] as MeshPhongMaterial)
+          .color;
         const trackCollection = scene.getObjectByName(linkedTrackCollection);
 
         linkedTracks.forEach((trackIndex: number) => {

--- a/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
@@ -93,9 +93,14 @@ export class ColorOptions {
       color: collectionColor
         ? `#${collectionColor?.getHexString()}`
         : undefined,
-      onChange: (value) => {
-        this.colorManager.collectionColor(this.collectionName, value);
-      },
+      onChange: (value) =>
+        this.colorManager.collectionColor(this.collectionName, value),
+    });
+
+    this.colorOptionsFolder.addConfig('button', {
+      label: 'Random',
+      onClick: () =>
+        this.colorManager.collectionColorRandom(this.collectionName),
     });
 
     // Check which color by options are to be included.

--- a/packages/phoenix-event-display/src/managers/ui-manager/dat-gui-ui.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/dat-gui-ui.ts
@@ -249,12 +249,15 @@ export class DatGUIMenuUI {
       this.guiParameters[collectionName] = {
         show: true,
         color: 0x000000,
+        randomColor: () =>
+          this.three.getColorManager().collectionColorRandom(collectionName),
         resetCut: () =>
           this.three
             .getSceneManager()
             .groupVisibility(collectionName, true, SceneManager.EVENT_DATA_ID),
       };
       const collFolder = typeFolder.addFolder(collectionName);
+
       // A boolean toggle for showing/hiding the collection is added to its folder
       const showMenu = collFolder
         .add(this.guiParameters[collectionName], 'show')
@@ -265,6 +268,7 @@ export class DatGUIMenuUI {
           .getSceneManager()
           .objectVisibility(collectionName, value, SceneManager.EVENT_DATA_ID)
       );
+
       // A color picker is added to the collection's folder
       const colorMenu = collFolder
         .addColor(this.guiParameters[collectionName], 'color')
@@ -273,12 +277,17 @@ export class DatGUIMenuUI {
         this.three.getColorManager().collectionColor(collectionName, value)
       );
       colorMenu.setValue(collectionColor?.getHex());
+      collFolder
+        .add(this.guiParameters[collectionName], 'randomColor')
+        .name('Random Color');
+
       // Cuts menu
       if (cuts) {
         const cutsFolder = collFolder.addFolder('Cuts');
         cutsFolder
           .add(this.guiParameters[collectionName], 'resetCut')
           .name('Reset cuts');
+
         for (const cut of cuts) {
           const minCut = cutsFolder
             .add(cut, 'minValue', cut.minValue, cut.maxValue)

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/index.spec.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/index.spec.ts
@@ -162,7 +162,7 @@ describe('ThreeManager', () => {
 
           done();
         });
-    });
+    }, 10000);
 
     it('should load JSON geometry', (done) => {
       spyOn(threePrivate.importManager, 'loadJSONGeometry').and.callThrough();

--- a/packages/phoenix-ng/projects/phoenix-ui-components/_theming.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/_theming.scss
@@ -24,7 +24,7 @@ $light-theme: mat-light-theme($primary, $accent, $warn);
   --phoenix-options-icon-path: #777777;
   --phoenix-icon-shadow: 0px 3px 6px rgba(0, 0, 0, 0.11);
   --phoenix-accent: #1fa7a0;
-  --phoenix-border: #dddddd;
+  --phoenix-border: #c5c5c5;
   --dat-background-primary: #f9f9f9;
   --dat-background-secondary: #efefef;
   --dat-background-tertiary: #e9e9e9;
@@ -50,7 +50,7 @@ $light-theme: mat-light-theme($primary, $accent, $warn);
   --phoenix-options-icon-path: #fff;
   --phoenix-icon-shadow: 0px 4px 8px rgba(0, 0, 0, 0.22);
   --phoenix-accent: #1cfff4;
-  --phoenix-border: #525252;
+  --phoenix-border: #5c5c5c;
   --dat-background-primary: #1a1a1a;
   --dat-background-secondary: #292929;
   --dat-background-tertiary: #363636;
@@ -65,6 +65,10 @@ $light-theme: mat-light-theme($primary, $accent, $warn);
     .optionsButton.activeIcon {
       --phoenix-options-icon-path: #1cfff4;
     }
+  }
+
+  .mat-dialog-container {
+    background: var(--phoenix-background-color-secondary);
   }
 }
 
@@ -120,7 +124,7 @@ canvas {
 select {
   border-radius: 30px;
   padding: 0.125rem 0.25rem;
-  background-color: var(--phoenix-background-color-secondary);
+  background-color: var(--phoenix-background-color-tertiary);
   color: var(--phoenix-text-color-secondary);
   outline: none;
   border: none;
@@ -203,6 +207,6 @@ select {
 .form-control,
 .form-control:focus {
   color: var(--phoenix-text-color);
-  background-color: var(--phoenix-background-color-secondary);
+  background-color: var(--phoenix-background-color-tertiary);
   border: 1px solid var(--phoenix-border);
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/_theming.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/_theming.scss
@@ -120,7 +120,7 @@ canvas {
 select {
   border-radius: 30px;
   padding: 0.125rem 0.25rem;
-  background-color: var(--phoenix-background-color-tertiary);
+  background-color: var(--phoenix-background-color-secondary);
   color: var(--phoenix-text-color-secondary);
   outline: none;
   border: none;
@@ -203,6 +203,6 @@ select {
 .form-control,
 .form-control:focus {
   color: var(--phoenix-text-color);
-  background-color: var(--phoenix-background-color-tertiary);
+  background-color: var(--phoenix-background-color-secondary);
   border: 1px solid var(--phoenix-border);
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/phoenix-menu/pheonix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/phoenix-menu/pheonix-menu-item/phoenix-menu-item.component.html
@@ -55,7 +55,11 @@
             >
               {{ config.label }}
             </span>
-            <div class="item-config-data" *ngIf="config.type !== 'label'">
+            <div
+              class="item-config-data"
+              [ngClass]="{ 'p-0': config.type === 'button' }"
+              *ngIf="config.type !== 'label'"
+            >
               <mat-checkbox
                 *ngSwitchCase="'checkbox'"
                 [checked]="config.isChecked"

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/share-link/share-link-dialog/share-link-dialog.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/share-link/share-link-dialog/share-link-dialog.component.scss
@@ -2,7 +2,7 @@
   width: 30rem;
   max-width: 100%;
   position: relative;
-  background: var(--phoenix-background-color-secondary);
+  background: var(--phoenix-background-color-tertiary);
   border: 1px solid var(--phoenix-border);
   border-radius: 0.5rem;
   padding: 1.25rem;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/share-link/share-link-dialog/share-link-dialog.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/share-link/share-link-dialog/share-link-dialog.component.scss
@@ -2,7 +2,7 @@
   width: 30rem;
   max-width: 100%;
   position: relative;
-  background: var(--phoenix-background-color-tertiary);
+  background: var(--phoenix-background-color-secondary);
   border: 1px solid var(--phoenix-border);
   border-radius: 0.5rem;
   padding: 1.25rem;


### PR DESCRIPTION
Closes #311 

Hi,

## Description

This fixes the the color by vertex option and colors tracks associated with vertices based on the vertex color instead of a random color.

## Changes

* Added button in color options to randomly color collections
* Tracks associated with vertices are now colored the same as the vertices
* Fix bug in scaling of Jets in dat.GUI menu
* Fix bug in trying to load configuration without Phoenix menu
* Improve styling and colors for dialogs