### PR TITLE
Fix a bit the performance of the LHCb geometry, some small bugs

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
@@ -103,20 +103,20 @@ export class LHCbComponent implements OnInit {
     );
     this.eventDisplay.loadGLTFGeometry(
       'assets/geometry/LHCb/LHCb_run3_Rich_AfterMagnet.gltf',
-      'Rich',
+      'Rich2',
       'AfterMagnetRegion',
       1,
       true
     );
     this.eventDisplay.loadGLTFGeometry(
       'assets/geometry/LHCb/LHCb_run3_Rich_BeforeMagnet.gltf',
-      'Rich',
+      'Rich1',
       'BeforeMagnetRegion',
       1,
       true
     );
     this.eventDisplay.loadGLTFGeometry(
-      'assets/geometry/LHCb/LHCb_run3_VP.gltf',
+      'assets/geometry/LHCb/LHCb_run3_VP_better_Performance',
       'VP',
       'BeforeMagnetRegion',
       1,

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
@@ -116,7 +116,7 @@ export class LHCbComponent implements OnInit {
       true
     );
     this.eventDisplay.loadGLTFGeometry(
-      'assets/geometry/LHCb/LHCb_run3_VP_better_Performance',
+      'assets/geometry/LHCb/LHCb_run3_VP_better_Performance.gltf',
       'VP',
       'BeforeMagnetRegion',
       1,


### PR DESCRIPTION
Greetings, 

So in these 2 commits I fix a bit the performance of the geometry caused by the VP subdetector because of it's many many layers of complexity from the .root level. I tried to remove all the volumes from the root file that would not harm the 3D modeling of the particular subdetector and right now as it is anything else can't be removed without having a visual impact on the actual geometry model. The minor fps boost is right now on my machine at around 14 fps on a laptop without a GPU. Disabling the VP geometry from the menu makes it 40 fps. But even on 14 fps it is pretty usable and fast, significantly faster than the previous 3-5 fps 😝 . 

I also fixed a bug in the Rich geometry, in particular there are 2 Rich subdetectors in LHCb and when disabling them in the menu on the right only 1 of the 2 was being disabled. Now they do work properly. 

That's all for now. 

P.S. I still need to write my updates on the documentation part, I got the notes but didn't find the time to implement them yet, please do excuse me. I will though! 

Thank you. 