### PR TITLE
Show cuts in collections info panel

### DIFF
--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -152,7 +152,9 @@ export class PhoenixObjects {
       0.5 * length * ctheta
     );
 
-    const width = jetParams.coneR ? length * Math.sin(jetParams.coneR) : length * 0.1;
+    const width = jetParams.coneR
+      ? length * Math.sin(jetParams.coneR)
+      : length * 0.1;
 
     const x = cphi * stheta;
     const y = sphi * stheta;

--- a/packages/phoenix-event-display/src/managers/three-manager/ar-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/ar-manager.ts
@@ -33,11 +33,13 @@ export class ARManager extends XRManager {
     this.previousValues.sceneScale = scene.scale.x;
     this.previousValues.cameraNear = camera.near;
     this.sessionInit = () => {
-      return ARManager.enableDomOverlay ? {
-        optionalFeatures: ['dom-overlay'],
-        domOverlay: { root: document.body },
-      } : {};
-    }
+      return ARManager.enableDomOverlay
+        ? {
+            optionalFeatures: ['dom-overlay'],
+            domOverlay: { root: document.body },
+          }
+        : {};
+    };
   }
 
   /**

--- a/packages/phoenix-event-display/src/managers/three-manager/xr-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/xr-manager.ts
@@ -35,9 +35,7 @@ export class XRManager {
    * @param sessionType Type of the session, either AR or VR.
    * @param sessionInit Other options for the session like optional features.
    */
-  constructor(
-    private sessionType: XRSessionType
-  ) {}
+  constructor(private sessionType: XRSessionType) {}
 
   /**
    * Set and configure the XR session.

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -38,7 +38,9 @@
             <th>No.</th>
             <th>Selection</th>
             <th>Label</th>
-            <th *ngFor="let column of collectionColumns">{{ getPrettySymbol(column) }}</th>
+            <th *ngFor="let column of collectionColumns">
+              {{ getPrettySymbol(column) }}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -47,7 +49,8 @@
             [attr.id]="object.uuid"
             [ngClass]="{
               'active-object':
-                activeObject && activeObject.value === object.uuid
+                activeObject && activeObject.value === object.uuid,
+              'is-cut': object.isCut
             }"
           >
             <td>#{{ i }}</td>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -17,7 +17,7 @@
         <select
           id="collection"
           name="collection"
-          (change)="changeCollection($event)"
+          (change)="changeCollection($event.target.value)"
         >
           <option value="" selected disabled hidden>Choose Collection</option>
           <option *ngFor="let collection of collections" [value]="collection">
@@ -38,7 +38,7 @@
             <th>No.</th>
             <th>Selection</th>
             <th>Label</th>
-            <th *ngFor="let column of collectionColumns">{{ column }}</th>
+            <th *ngFor="let column of collectionColumns">{{ getPrettySymbol(column) }}</th>
           </tr>
         </thead>
         <tbody>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.scss
@@ -49,6 +49,10 @@
     }
   }
 
+  tr.is-cut {
+    opacity: 0.5;
+  }
+
   tr.active-object {
     color: var(--phoenix-background-color);
     background: var(--phoenix-text-color);

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.spec.ts
@@ -59,12 +59,12 @@ describe('CollectionsInfoOverlayComponent', () => {
     spyOn(eventDisplayService, 'getCollection').and.callFake(() => {
       return [{ uuid: 'abcd1234', otherProp: 'testPropValue' }];
     });
-    const mockSelectedValue = { target: { value: 'TestCollection' } };
+    const mockSelectedValue = 'TestCollection';
 
     component.changeCollection(mockSelectedValue);
 
     expect(eventDisplayService.getCollection).toHaveBeenCalledWith(
-      mockSelectedValue.target.value
+      mockSelectedValue
     );
   });
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.spec.ts
@@ -3,8 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CollectionsInfoOverlayComponent } from './collections-info-overlay.component';
 import { EventDisplayService } from '../../../../services/event-display.service';
 import { PhoenixUIModule } from '../../../phoenix-ui.module';
+import { Group, Object3D } from 'three';
 
-describe('CollectionsInfoOverlayComponent', () => {
+fdescribe('CollectionsInfoOverlayComponent', () => {
   let component: CollectionsInfoOverlayComponent;
   let fixture: ComponentFixture<CollectionsInfoOverlayComponent>;
   let eventDisplayService: EventDisplayService;
@@ -15,7 +16,7 @@ describe('CollectionsInfoOverlayComponent', () => {
       providers: [EventDisplayService],
       declarations: [CollectionsInfoOverlayComponent],
     }).compileComponents();
-    eventDisplayService = TestBed.get(EventDisplayService);
+    eventDisplayService = TestBed.inject(EventDisplayService);
   });
 
   beforeEach(() => {
@@ -56,9 +57,19 @@ describe('CollectionsInfoOverlayComponent', () => {
   });
 
   it('should change collection', () => {
-    spyOn(eventDisplayService, 'getCollection').and.callFake(() => {
-      return [{ uuid: 'abcd1234', otherProp: 'testPropValue' }];
-    });
+    const uuid = 'abcd1234';
+    const group = new Object3D();
+    const object = new Object3D();
+    object.uuid = uuid;
+
+    spyOn(
+      eventDisplayService.getThreeManager().getSceneManager().getScene(),
+      'getObjectByName'
+    ).and.callFake(() => group);
+    spyOn(eventDisplayService, 'getCollection').and.callFake(() => [
+      { uuid, otherProp: 'testPropValue' },
+    ]);
+
     const mockSelectedValue = 'TestCollection';
 
     component.changeCollection(mockSelectedValue);

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input, ElementRef } from '@angular/core';
-import { PrettySymbols, ActiveVariable } from 'phoenix-event-display';
+import { PrettySymbols, ActiveVariable, SceneManager } from 'phoenix-event-display';
+import { Object3D } from 'three';
 import { EventDisplayService } from '../../../../services/event-display.service';
 
 @Component({
@@ -13,7 +14,9 @@ export class CollectionsInfoOverlayComponent implements OnInit {
   selectedCollection: string;
   showingCollection: any;
   collectionColumns: string[];
+  getPrettySymbol = PrettySymbols.getPrettySymbol;
   activeObject: ActiveVariable<string>;
+  eventDataGroup: Object3D;
 
   constructor(
     private elementRef: ElementRef,
@@ -22,7 +25,7 @@ export class CollectionsInfoOverlayComponent implements OnInit {
 
   ngOnInit() {
     this.eventDisplay.listenToDisplayedEventChange(
-      (event) => (this.collections = this.eventDisplay.getCollections())
+      (_event) => (this.collections = this.eventDisplay.getCollections())
     );
     this.activeObject = this.eventDisplay.getActiveObjectId();
     this.activeObject.onUpdate((value: string) => {
@@ -30,14 +33,13 @@ export class CollectionsInfoOverlayComponent implements OnInit {
         document.getElementById(value).scrollIntoView(false);
       }
     });
+    this.eventDataGroup = this.eventDisplay.getThreeManager().getSceneManager().getScene().getObjectByName(SceneManager.EVENT_DATA_ID);
   }
 
-  changeCollection(selected: any) {
-    const value = selected.target.value;
-    this.selectedCollection = value;
+  changeCollection(selectedCollection: string) {
+    this.selectedCollection = selectedCollection;
     this.showingCollection = this.eventDisplay
-      .getCollection(value)
-      .map(PrettySymbols.getPrettyParams);
+      .getCollection(selectedCollection);
     this.collectionColumns = Object.keys(this.showingCollection[0]).filter(
       (column) => column !== 'uuid' && column !== 'hits' // FIXME - this is an ugly hack. But currently hits from tracks make track collections unusable. Better to have exlusion list passed in.
     );


### PR DESCRIPTION
Closes #347
Closes #272

## Description

This shows objects that are cut in the collections info panel by decreasing opacity of the rows. @EdwardMoyse, let me know if this is fine by you.

## Changes

* Optimize handling of pretty symbols in collections info panel
* Add functionality to check if the object is hidden in the scene
* Fix and update tests for collections info panel
