### PR TITLE
feat(app): Display Phoenix Version in Info Panel

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/info-panel/info-panel-overlay/info-panel-overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/info-panel/info-panel-overlay/info-panel-overlay.component.html
@@ -5,6 +5,10 @@
   [active]="showInfoPanel"
 >
   <ul class="list-group list-group-flush">
+    <li class="list-group-item">
+      <!-- Show Phoenix Current Version (ON by Default) -->
+      Phoenix Version: {{version.version}}
+    </li>
     <li class="list-group-item" *ngIf="actionsList.length === 0">
       No actions.
     </li>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/info-panel/info-panel-overlay/info-panel-overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/src/components/ui-menu/info-panel/info-panel-overlay/info-panel-overlay.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { EventDisplayService } from '../../../../services/event-display.service';
+import version from './../../../../../package.json';
 
 /**
  * Component for displaying information from the logger
@@ -14,6 +15,8 @@ export class InfoPanelOverlayComponent implements OnInit {
   @Input() showInfoPanel: boolean;
   /** List of actions to be displayed in the info panel */
   actionsList = [];
+  /** Get Phoenix Version */
+  version = version;
 
   /**
    * Create the information panel overlay

--- a/packages/phoenix-ng/tsconfig.json
+++ b/packages/phoenix-ng/tsconfig.json
@@ -9,6 +9,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "importHelpers": true,
     "target": "es2015",


### PR DESCRIPTION
Hello all, 

As, Dear @EdwardMoyse requested here are the appropriate changes for the current Phoenix Version to be displayed in the Info Panel in the Phoenix UI Menu as shown in the image below. 

![pic-selected-211005-1823-47](https://user-images.githubusercontent.com/68736032/136053377-62af4c17-2770-4978-a2b5-805675c15ea7.png)
