### PR TITLE
Add LHCb SciFi hits event data visualization

### DIFF
--- a/packages/phoenix-event-display/src/helpers/constants.ts
+++ b/packages/phoenix-event-display/src/helpers/constants.ts
@@ -10,4 +10,5 @@ export const EVENT_DATA_TYPE_COLORS = {
   Vertices: new Color(0xffd166),
   MissingEnergy: new Color(0xffffff),
   PlanarCaloCells: new Color(0xfff69a),
+  Fibers: new Color(0xe35d46),
 };

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -586,4 +586,22 @@ export class PhoenixObjects {
 
     return object;
   }
+
+  /**
+   * Process the Fibers (a.k.a reconstructed line from points / hits) from the given parameters and get it as a geometry.
+   * @param Fiber Parameters for the SciFi Calorimeter.
+   * @returns Fiber object.
+   */
+  public static getFibers(FiberParams: any): Object3D {
+    /// retrieve and store the data
+    const fiberHits = [];
+    fiberHits.push(new Vector3(0, 0, 0));
+    fiberHits.push(new Vector3(fiberHits.x0, fiberHits.z0, fiberHits.dxDy));
+
+    /// for my 6 coords to draw the line: 
+    /// (x0, y[0], z0, x0+dxDy*(y[1]-y[0]),y[1],z0)
+
+    /// return (FiberObject)
+    return new Object3D();
+  }
 }

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -593,15 +593,39 @@ export class PhoenixObjects {
    * @returns Fiber object.
    */
   public static getFibers(FiberParams: any): Object3D {
-    /// retrieve and store the data
-    const fiberHits = [];
-    fiberHits.push(new Vector3(0, 0, 0));
-    fiberHits.push(new Vector3(fiberHits.x0, fiberHits.z0, fiberHits.dxDy));
+    /// retrieve and store the coords to draw the fibers
+    const x0 = FiberParams.x0;
+    const y0 = FiberParams.y[0];
+    const y1 = FiberParams.y[1];
+    const z0 = FiberParams.z0;
+    const dxDy = FiberParams.dxDy;
 
-    /// for my 6 coords to draw the line: 
+    /// we need 6 coords to draw the line:
     /// (x0, y[0], z0, x0+dxDy*(y[1]-y[0]),y[1],z0)
 
+    const fiberHits = [];
+    fiberHits.push(new Vector3(0, 0, 0));
+    fiberHits.push(new Vector3(x0, y0, z0));
+    fiberHits.push(new Vector3(x0 + dxDy * (y1 - y0), y1, z0));
+
+    /// geometry
+    const geometry = new BufferGeometry().setFromPoints(fiberHits);
+
+    /// material
+    const material = new LineBasicMaterial({
+      linewidth: 2,
+      color: FiberParams.color ?? EVENT_DATA_TYPE_COLORS.Fibers,
+    });
+
+    /// object
+    const fiberLines = new LineSegments(geometry, material);
+
+    fiberLines.userData = Object.assign({}, FiberParams);
+    fiberLines.name = 'FiberLine';
+    /// Setting uuid for selection from collections info
+    FiberParams.uuid = fiberLines.uuid;
+
     /// return (FiberObject)
-    return new Object3D();
+    return fiberLines;
   }
 }

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -604,7 +604,7 @@ export class PhoenixObjects {
     /// (x0, y[0], z0, x0+dxDy*(y[1]-y[0]),y[1],z0)
 
     const fiberHits = [];
-    fiberHits.push(new Vector3(0, 0, 0));
+    // fiberHits.push(new Vector3(0, 0, 0));
     fiberHits.push(new Vector3(x0, y0, z0));
     fiberHits.push(new Vector3(x0 + dxDy * (y1 - y0), y1, z0));
 

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -290,6 +290,16 @@ export class PhoenixLoader implements EventDataLoader {
       );
     }
 
+    if (eventData.Fibers) {
+      // Cannot currently cut on just a position array.
+      this.addObjectType(
+        eventData.Fibers,
+        PhoenixObjects.getFibers,
+        'Fibers',
+        false
+      );
+    }
+
     if (eventData.Muons) {
       const cuts = [
         new Cut('phi', -pi, pi, 0.01),

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
@@ -54,7 +54,7 @@ export class LHCbComponent implements OnInit {
       defaultView: [-800, 300, -1000],
       phoenixMenuRoot: this.phoenixMenuRoot,
       defaultEventFile: {
-        eventFile: 'assets/files/lhcb/LHCbEventDataV2.json',
+        eventFile: 'assets/files/lhcb/LHCb_EventDataset.json',
         eventType: 'json',
       },
     };


### PR DESCRIPTION
Hi all, 

As promised here is the pull request for the SciFi hits data visualization. 

It seems that I'm in a good way to finish it, since the data are being read and stored properly and I got to the point into visualising "something". Now, that "something" is not what I was expecting. Probably Mr. @sponce can help me a bit more on this, since I think I'm manipulating the data in a wrong way. Please do review the following part of the code in the file path: `packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts` lines: `606 - 609`

```javascript
     /// we need 6 coords to draw the line:
    /// (x0, y[0], z0, x0+dxDy*(y[1]-y[0]),y[1],z0)

    const fiberHits = [];
    fiberHits.push(new Vector3(0, 0, 0));
    fiberHits.push(new Vector3(x0, y0, z0));
    fiberHits.push(new Vector3(x0 + dxDy * (y1 - y0), y1, z0));
```

First of all the position that the "lines" a.k.a fibers are being displayed is way out of the FT detector and along that I'm not sure they are being visualized in the correct direction as well. You can see what I mean in the picture below: 

![Screenshot 2022-03-13 at 3 41 16 PM](https://user-images.githubusercontent.com/68736032/158062503-a3ebd98d-c727-43a0-9591-3a5e29c7451b.png)

So yeah I will try to fix that, and then another concern I have is, (and on that maybe you can help me a bit more dear @9inpachi) wether the way I've written the code is the proper way to go, and by that I mean that this particular code is not generic to be used by others even though I'm adding it in the global Phoenix physics objects, it is LHCb specific I think. If there is a way to make it generic and keep it there, I'm glad to make it, but I'll need some help on that, or if you think that it should be moved somewhere else, please do ping me and I'll fix it asap. 

Thank you all! 