### PR TITLE
Fix failing tests for ThreeManager and UIManager for stable CI job

### DIFF
--- a/packages/phoenix-event-display/src/tests/managers/three-manager/index.spec.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/index.spec.ts
@@ -68,7 +68,7 @@ describe('ThreeManager', () => {
     });
 
     it('should rotate clipping', () => {
-      three.rotateClipping(90);
+      three.setClippingAngle(0, 90);
       expect(threePrivate.clipPlanes[0]).toBeTruthy();
     });
 

--- a/packages/phoenix-event-display/src/tests/managers/ui-manager/index.spec.ts
+++ b/packages/phoenix-event-display/src/tests/managers/ui-manager/index.spec.ts
@@ -97,9 +97,9 @@ describe('UIManager', () => {
       ui.geometryVisibility('TestGeometry', false);
       expect(three.getSceneManager().objectVisibility).toHaveBeenCalled();
 
-      spyOn(three, 'rotateClipping').and.stub();
-      ui.rotateClipping(90);
-      expect(three.rotateClipping).toHaveBeenCalled();
+      spyOn(three, 'setClippingAngle').and.stub();
+      ui.rotateOpeningAngleClipping(90);
+      expect(three.setClippingAngle).toHaveBeenCalled();
 
       spyOn(three, 'setClipping').and.stub();
       ui.setClipping(true);

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.spec.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.spec.ts
@@ -11,7 +11,8 @@ describe('ObjectClippingComponent', () => {
   let fixture: ComponentFixture<ObjectClippingComponent>;
 
   const mockUIManager = jasmine.createSpyObj('UIManager', [
-    'rotateClipping',
+    'rotateStartAngleClipping',
+    'rotateOpeningAngleClipping',
     'setClipping',
   ]);
 


### PR DESCRIPTION
This PR addresses: https://github.com/HSF/phoenix/runs/5775474777?check_suite_focus=true

Ran checks locally after doing the changes -

![Screenshot 2022-04-01 011840](https://user-images.githubusercontent.com/62954367/161137888-97b8edc2-db94-4565-8925-08d879d33246.jpg)

![Screenshot 2022-04-01 011900](https://user-images.githubusercontent.com/62954367/161137901-2473a4a7-8c5f-4398-8128-fd30db2af8e4.jpg)


Please let me know if something needs to change. 🙂