### PR TITLE
Improvements in clipping

### DIFF
--- a/packages/phoenix-event-display/src/extras/configuration.ts
+++ b/packages/phoenix-event-display/src/extras/configuration.ts
@@ -1,4 +1,3 @@
-import { Plane } from 'three';
 import { PresetView } from './preset-view.model';
 import { EventDataLoader } from '../loaders/event-data-loader';
 import { PhoenixMenuNode } from '../managers/ui-manager/phoenix-menu/phoenix-menu-node';
@@ -23,6 +22,4 @@ export interface Configuration {
   defaultEventFile?: { eventFile: string; eventType: string };
   /** Whether to allow URL options or not (true by default). */
   allowUrlOptions?: boolean;
-  /** Planes for clipping detector geometry. */
-  clippingPlanes?: Plane[];
 }

--- a/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
@@ -23,6 +23,8 @@ import { LoadingManager } from '../loading-manager';
 export class ImportManager {
   /** Planes for clipping geometry. */
   private clipPlanes: Plane[];
+  /** Is clipping intersection or union. */
+  private clipIntersection: boolean;
   /** Object group ID containing event data. */
   private EVENT_DATA_ID: string;
   /** Object group ID containing detector geometries. */
@@ -38,10 +40,12 @@ export class ImportManager {
    */
   constructor(
     clipPlanes: Plane[],
+    clipIntersection: boolean,
     EVENT_DATA_ID: string,
     GEOMETRIES_ID: string
   ) {
     this.clipPlanes = clipPlanes;
+    this.clipIntersection = clipIntersection;
     this.EVENT_DATA_ID = EVENT_DATA_ID;
     this.GEOMETRIES_ID = GEOMETRIES_ID;
     this.loadingManager = new LoadingManager();
@@ -394,7 +398,7 @@ export class ImportManager {
           });
           // Setting up the clipping planes
           child.material.clippingPlanes = this.clipPlanes;
-          child.material.clipIntersection = true;
+          child.material.clipIntersection = this.clipIntersection;
           child.material.clipShadows = false;
         }
       }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
@@ -58,11 +58,6 @@ export class LHCbComponent implements OnInit {
         eventFile: 'assets/files/lhcb/LHCbEventDataV2.json',
         eventType: 'json',
       },
-      clippingPlanes: [
-        new Plane(new Vector3(0, 1, 0), 0),
-        new Plane(new Vector3(0, -1, 0), 0),
-        new Plane(new Vector3(0, 0, 1), -20000),
-      ],
     };
 
     this.eventDisplay.init(configuration);

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.html
@@ -22,7 +22,7 @@
     <mat-slider
       #startingAngleSlider
       min="0"
-      max="180"
+      max="360"
       step="1"
       thumbLabel
       [value]="startClippingAngle"
@@ -36,7 +36,7 @@
     <mat-slider
       #openingAngleSlider
       min="0"
-      max="180"
+      max="360"
       step="1"
       thumbLabel
       [value]="openingClippingAngle"


### PR DESCRIPTION
A few improvements have been made to clipping : 
  - the user visible clipping planes are no more polluted by the internal clipping implementation
  - the internal clipping implementation supports clipping up to 360 degrees
  - and the gui has been adapted to be able to use it

There is however still a problem in case of user defined clipping when the clipping angle of the internal clipping in > 180 degrees. In such a case, the internal clipping needs to switch to union mode, which will apply to the user clipping and may result in weird behavior. Now it seems that user clipping was only used by LHCb for unknown reasons and I will soon drop it. So maybe we should rather drop that (just introduced) feature for now.