### PR TITLE
Allow to specify default opacity in GLTF files

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
@@ -395,6 +395,7 @@ export class ImportManager {
             color: color,
             shininess: 0,
             side: side,
+            opacity: geometry.userData.opacity,
           });
           // Setting up the clipping planes
           child.material.clippingPlanes = this.clipPlanes;


### PR DESCRIPTION
This is done via an "opacity" entry in the userData fields of a geometry