### PR TITLE
Fix failing tests for ThreeManager

### DIFF
--- a/packages/phoenix-event-display/src/tests/managers/three-manager/index.spec.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/index.spec.ts
@@ -124,7 +124,7 @@ describe('ThreeManager', () => {
     it('should load glTF geometry', () => {
       spyOn(threePrivate.importManager, 'loadGLTFGeometry').and.callThrough();
 
-      three.loadGLTFGeometry(GLTF_FILE, 'Test glTF', 1);
+      three.loadGLTFGeometry(GLTF_FILE, 'Test glTF');
       expect(threePrivate.importManager.loadGLTFGeometry).toHaveBeenCalled();
     });
 
@@ -155,7 +155,8 @@ describe('ThreeManager', () => {
             'parseGLTFGeometry'
           ).and.callThrough();
 
-          three.parseGLTFGeometry(res, 'TEST_GLTF_FILE');
+          const callback = () => {};
+          three.parseGLTFGeometry(res, 'TEST_GLTF_FILE', callback);
           expect(
             threePrivate.importManager.parseGLTFGeometry
           ).toHaveBeenCalled();


### PR DESCRIPTION
Context: https://github.com/HSF/phoenix/pull/435#issuecomment-1122124434

Although, that one got fixed. I'm still seeing one more error here in the `phoenix-ng` package:   
`Chrome Headless 101.0.4951.54 (Windows 10) IoOptionsDialogComponent should handle zipped event data FAILED`.  

After this change, full stack trace 👇  

```  
$ lerna run test:coverage
lerna notice cli v4.0.0
lerna info Executing command in 2 packages: "yarn run test:coverage"
phoenix-ng: $ rimraf ./coverage && ng test phoenix-ui-components --no-watch --code-coverage --no-progress --browsers=ChromeHeadlessCI --source-map=false
phoenix-event-display: $ yarn test
phoenix-event-display: $ karma start configs/karma.conf.js --browsers=ChromeHeadlessCI
phoenix-event-display: DATETIME:INFO [compiler.karma-typescript]: Compiling project using Typescript 4.5.5
phoenix-event-display: DATETIME:INFO [compiler.karma-typescript]: Compiled 61 files in 9589 ms.
phoenix-ng: 10 05 2022 16:28:33.996:INFO [karma-server]: Karma v6.3.16 server started at http://localhost:9877/
phoenix-ng: 10 05 2022 16:28:33.999:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
phoenix-ng: 10 05 2022 16:28:34.019:INFO [launcher]: Starting browser ChromeHeadless
phoenix-ng: 10 05 2022 16:28:34.739:INFO [Chrome Headless 101.0.4951.54 (Windows 10)]: Connected on socket wwQk2bhiHVbzfv8WAAAB with id 84275633
            Chrome Headless 101.0.4951.54 (Windows 10): Executed 3 of 114 SUCCESS (0 secs / 0.444 secs)
            Chrome Headless 101.0.4951.54 (Windows 10) IoOptionsDialogComponent should handle zipped event data FAILED
phoenix-ng:     Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
phoenix-ng:         at <Jasmine>
            ERROR: 'Error: Invalid file format!'
            ERROR: 'Error: Invalid file format!'
            LOG: 'Processing JiveXML event data'
            LOG: 'WARNING the track collection InDetTrackParticles_xAOD has no line information. Will rely on Phoenix to extrapolate.'
            LOG: 'WARNING the track collection CombinedMuonTrackParticles_xAOD has no line information. Will rely on Phoenix to extrapolate.'
            LOG: 'WARNING the track collection GSFTrackParticles_xAOD has no line information. Will rely on Phoenix to extrapolate.'
            Chrome Headless 101.0.4951.54 (Windows 10): Executed 22 of 114 (1 FAILED) (0 secs / 6.099 secs)
            Chrome Headless 101.0.4951.54 (Windows 10): Executed 30 of 114 (1 FAILED) (0 secs / 6.302 secs)
            ERROR: 'NG0304: 'mat-menu' is not a known element:
phoenix-ng: 1. If 'mat-menu' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'mat-menu' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0304: 'app-menu-toggle' is not a known element:
phoenix-ng: 1. If 'app-menu-toggle' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-menu-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0303: Can't bind to 'matMenuTriggerFor' since it isn't a known property of 'app-menu-toggle'.'
            ERROR: 'NG0303: Can't bind to 'disabled' since it isn't a known property of 'app-menu-toggle'.'
            ERROR: 'NG0303: Can't bind to 'active' since it isn't a known property of 'app-menu-toggle'.'
            ERROR: 'NG0303: Can't bind to 'tooltip' since it isn't a known property of 'app-menu-toggle'.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            ERROR: 'NG0304: 'app-dark-theme' is not a known element:
phoenix-ng: 1. If 'app-dark-theme' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-dark-theme' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0304: 'app-auto-rotate' is not a known element:
phoenix-ng: 1. If 'app-auto-rotate' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-auto-rotate' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0304: 'app-main-view-toggle' is not a known element:
phoenix-ng: 1. If 'app-main-view-toggle' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-main-view-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0304: 'app-animate-event' is not a known element:
phoenix-ng: 1. If 'app-animate-event' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-animate-event' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0304: 'app-animate-camera' is not a known element:
phoenix-ng: 1. If 'app-animate-camera' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-animate-camera' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0304: 'app-experiment-link' is not a known element:
phoenix-ng: 1. If 'app-experiment-link' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-experiment-link' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            LOG: 'THREE.WebGLRenderer: Context Lost.'
            ERROR: 'NG0304: 'app-menu-toggle' is not a known element:
phoenix-ng: 1. If 'app-menu-toggle' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-menu-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            ERROR: 'NG0304: 'app-menu-toggle' is not a known element:
phoenix-ng: 1. If 'app-menu-toggle' is an Angular component, then verify that it is part of this module.
phoenix-ng: 2. If 'app-menu-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
            LOG: 'hi! it's TestNode'
            LOG: 'hi! it's TestNode'
            Chrome Headless 101.0.4951.54 (Windows 10): Executed 114 of 114 (1 FAILED) (9.087 secs / 8.027 secs)
phoenix-ng: TOTAL: 1 FAILED, 113 SUCCESS
phoenix-ng: =============================== Coverage summary ===============================
phoenix-ng: Statements   : 82.4% ( 534/648 )
phoenix-ng: Branches     : 67.21% ( 82/122 )
phoenix-ng: Functions    : 77.27% ( 187/242 )
phoenix-ng: Lines        : 82.39% ( 496/602 )
phoenix-ng: ================================================================================
phoenix-ng: error Command failed with exit code 1.
phoenix-ng: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run test:coverage exited 1 in 'phoenix-ng'
lerna ERR! yarn run test:coverage stdout:
$ rimraf ./coverage && ng test phoenix-ui-components --no-watch --code-coverage --no-progress --browsers=ChromeHeadlessCI --source-map=false
10 05 2022 16:28:33.996:INFO [karma-server]: Karma v6.3.16 server started at http://localhost:9877/
10 05 2022 16:28:33.999:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
10 05 2022 16:28:34.019:INFO [launcher]: Starting browser ChromeHeadless
10 05 2022 16:28:34.739:INFO [Chrome Headless 101.0.4951.54 (Windows 10)]: Connected on socket wwQk2bhiHVbzfv8WAAAB with id 84275633
Chrome Headless 101.0.4951.54 (Windows 10) IoOptionsDialogComponent should handle zipped event data FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
ERROR: 'Error: Invalid file format!'
ERROR: 'Error: Invalid file format!'
LOG: 'Processing JiveXML event data'
LOG: 'WARNING the track collection InDetTrackParticles_xAOD has no line information. Will rely on Phoenix to extrapolate.'
LOG: 'WARNING the track collection CombinedMuonTrackParticles_xAOD has no line information. Will rely on Phoenix to extrapolate.'
LOG: 'WARNING the track collection GSFTrackParticles_xAOD has no line information. Will rely on Phoenix to extrapolate.'
Chrome Headless 101.0.4951.54 (Windows 10): Executed 30 of 114 (1 FAILED) (0 secs / 6.302 secs)
ERROR: 'NG0304: 'mat-menu' is not a known element:
1. If 'mat-menu' is an Angular component, then verify that it is part of this module.
2. If 'mat-menu' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-menu-toggle' is not a known element:
1. If 'app-menu-toggle' is an Angular component, then verify that it is part of this module.
2. If 'app-menu-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0303: Can't bind to 'matMenuTriggerFor' since it isn't a known property of 'app-menu-toggle'.'
ERROR: 'NG0303: Can't bind to 'disabled' since it isn't a known property of 'app-menu-toggle'.'
ERROR: 'NG0303: Can't bind to 'active' since it isn't a known property of 'app-menu-toggle'.'
ERROR: 'NG0303: Can't bind to 'tooltip' since it isn't a known property of 'app-menu-toggle'.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
ERROR: 'NG0304: 'app-dark-theme' is not a known element:
1. If 'app-dark-theme' is an Angular component, then verify that it is part of this module.
2. If 'app-dark-theme' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-auto-rotate' is not a known element:
1. If 'app-auto-rotate' is an Angular component, then verify that it is part of this module.
2. If 'app-auto-rotate' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-main-view-toggle' is not a known element:
1. If 'app-main-view-toggle' is an Angular component, then verify that it is part of this module.
2. If 'app-main-view-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-animate-event' is not a known element:
1. If 'app-animate-event' is an Angular component, then verify that it is part of this module.
2. If 'app-animate-event' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-animate-camera' is not a known element:
1. If 'app-animate-camera' is an Angular component, then verify that it is part of this module.
2. If 'app-animate-camera' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-experiment-link' is not a known element:
1. If 'app-experiment-link' is an Angular component, then verify that it is part of this module.
2. If 'app-experiment-link' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
LOG: 'THREE.WebGLRenderer: Context Lost.'
ERROR: 'NG0304: 'app-menu-toggle' is not a known element:
1. If 'app-menu-toggle' is an Angular component, then verify that it is part of this module.
2. If 'app-menu-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-menu-toggle' is not a known element:
1. If 'app-menu-toggle' is an Angular component, then verify that it is part of this module.
2. If 'app-menu-toggle' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
LOG: 'hi! it's TestNode'
LOG: 'hi! it's TestNode'
Chrome Headless 101.0.4951.54 (Windows 10): Executed 114 of 114 (1 FAILED) (9.087 secs / 8.027 secs)
TOTAL: 1 FAILED, 113 SUCCESS

=============================== Coverage summary ===============================
Statements   : 82.4% ( 534/648 )
Branches     : 67.21% ( 82/122 )
Functions    : 77.27% ( 187/242 )
Lines        : 82.39% ( 496/602 )
================================================================================
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run test:coverage stderr:
error Command failed with exit code 1.
lerna ERR! yarn run test:coverage exited 1 in 'phoenix-ng'
lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Your thoughts? Is this a priority fix for us? 🤔