### PR TITLE
Fixed bug in phoenix-loader preventing the display of some event data

### DIFF
--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -437,7 +437,7 @@ export class PhoenixLoader implements EventDataLoader {
 
       if (objectCollection.length == 0) {
         console.log('Skipping');
-        return;
+        continue;
       }
 
       this.addCollection(


### PR DESCRIPTION
Basically if a collection was empty, all subsequent collections were ignored