### PR TITLE
Disable angular change check at every frame

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-app/src/polyfills.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/polyfills.ts
@@ -52,6 +52,9 @@
  *
  */
 
+// Disable the angular change detection on requestAnimation frame in order to speed up rendering
+import './zone-flags.ts';
+
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */

--- a/packages/phoenix-ng/projects/phoenix-app/src/zone-flags.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/zone-flags.ts
@@ -1,0 +1,7 @@
+// Disable the angular change detection on requestAnimation frame in order to speed up rendering
+(window as any).__Zone_disable_requestAnimationFrame = true;
+(window as any).__zone_symbol__BLACK_LISTED_EVENTS = [
+  'scroll',
+  'mousemove',
+  'touchmove',
+];

--- a/packages/phoenix-ng/projects/phoenix-app/tsconfig.app.json
+++ b/packages/phoenix-ng/projects/phoenix-app/tsconfig.app.json
@@ -4,6 +4,6 @@
     "outDir": "../../out-tsc/app",
     "types": []
   },
-  "files": ["src/main.ts", "src/polyfills.ts"],
+  "files": ["src/main.ts", "src/polyfills.ts", "src/zone-flags.ts"],
   "include": ["src/**/*.d.ts", "event-config.json"]
 }


### PR DESCRIPTION
This is a first attempt to optimize the rendering speed of phoneix.
Due to other issues, it's not really making an immediate difference, but it removes a first show stopper

All credits go to Arthur Hennequin of the LHCb experiment