### PR TITLE
Fixed handling of event properties

### DIFF
--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -633,7 +633,7 @@ export class PhoenixLoader implements EventDataLoader {
         for (const eventDataPropKey of eventDataProp.keys) {
           if (
             eventDataKeys.includes(eventDataPropKey) &&
-            this.eventData[eventDataPropKey]
+            eventDataPropKey in this.eventData
           ) {
             combinedProps[eventDataProp.label] =
               this.eventData[eventDataPropKey];


### PR DESCRIPTION
In particular an event with event number 0 had no event number displayed.

Was just a stupid mistake due to javascript lack of type safety

@kjvbrt for info