### PR TITLE
Set transparency to false by default for LHCb

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
@@ -93,7 +93,7 @@ export class LHCbComponent implements OnInit {
       undefined, // menuNodeName
       1, // scale
       true, // initiallyVisible
-      true // transparent
+      false // transparent
     );
 
     this.eventDisplay


### PR DESCRIPTION
This actually fixes most of the problems of objects not shown inside a transparent volume.

@9inpachi @EdwardMoyse  Out of curiosity : is there really a reason to have this default transparency explicit, and be able to set it to true ? It kind of breaks the attempts of three.js of rendering things properly by rendering non transparent objects first and transparent ones only after.