### PR TITLE
Use full path for object names

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
@@ -300,11 +300,12 @@ export class ImportManager {
   private processGLTFSceneName(sceneName?: string, menuNodeName?: string) {
     if (sceneName) {
       const nodes = sceneName.split('_>_');
-      const name = nodes.pop();
       menuNodeName && nodes.unshift(menuNodeName);
-      const nodeName = nodes.join(' > ');
+      const fullNodeName = nodes.join(' > ');
+      nodes.pop();
+      const menuName = nodes.join(' > ');
 
-      return { name, menuNodeName: nodeName };
+      return { name: fullNodeName, menuNodeName: menuName };
     }
   }
 

--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts
@@ -125,9 +125,20 @@ export class PhoenixMenuUI implements PhoenixUI<PhoenixMenuNode> {
       parentNode = this.geomFolder.findInTreeOrCreate(menuSubfolder);
     }
 
-    const objFolder = parentNode.addChild(name, (value: boolean) => {
-      this.sceneManager.objectVisibility(object, value);
-    });
+    // find out where the actual object name starts, providing that the name
+    // is hierarchical and contents higher level menu names too
+    var nameStart = name.lastIndexOf(' > ');
+    if (nameStart < 0) {
+      nameStart = 0; // case where there is no hierarchy
+    } else {
+      nameStart += 3; // skip the last ' > '
+    }
+    const objFolder = parentNode.addChild(
+      name.substring(nameStart),
+      (value: boolean) => {
+        this.sceneManager.objectVisibility(object, value);
+      }
+    );
 
     objFolder.toggleState = visible;
 


### PR DESCRIPTION
In case of 2 objects with identical name "Mirror" living in 2 different menus "Rich1" and "Rich2", it was so far impossible to identify them uniquely, as both names were just "Mirror".
With this change, the names are "Rich1 > Mirror" and "Rich2 > Mirror". Menu display has been adapted so that it stays the same