### PR TITLE
Add manual inputs for range cuts

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
@@ -108,46 +108,38 @@
                 "
               />
 
-              <p *ngSwitchCase="'rangeSlider'">
-                Min value:
+              <div *ngSwitchCase="'rangeSlider'">
+                Min:
                 <input
                   type="number"
                   [value]="config.value ? config.value : config.min"
-                  (input)="
-                    config.onChange($event.value);
-                    config.value = $event.value;
-                  "
+                  (input)="config.value = $event.value; config.onChange(config)"
                 />
-              </p>
-              <p *ngSwitchCase="'rangeSlider'">
-                Max value:
+                Max:
                 <input
                   type="number"
                   [value]="config.highValue ? config.highValue : config.max"
                   (input)="
-                    config.onChange($event.highValue);
-                    config.highValue = $event.highValue
+                    config.highValue = $event.highValue; config.onChange(config)
                   "
                 />
-              </p>
-
-              <ngx-slider
-                *ngSwitchCase="'rangeSlider'"
-                class="range-slider"
-                [value]="config.value ? config.value : config.min"
-                [highValue]="config.highValue ? config.highValue : config.max"
-                (userChange)="
-                  config.onChange($event);
-                  config.value = $event.value;
-                  config.highValue = $event.highValue
-                "
-                [options]="{
-                  floor: config.min,
-                  ceil: config.max,
-                  step: config.step,
-                  animate: false
-                }"
-              ></ngx-slider>
+                <ngx-slider
+                  class="range-slider"
+                  [value]="config.value ? config.value : config.min"
+                  [highValue]="config.highValue ? config.highValue : config.max"
+                  (userChange)="
+                    config.onChange($event);
+                    config.value = $event.value;
+                    config.highValue = $event.highValue
+                  "
+                  [options]="{
+                    floor: config.min,
+                    ceil: config.max,
+                    step: config.step,
+                    animate: false
+                  }"
+                ></ngx-slider>
+              </div>
 
               <select
                 *ngSwitchCase="'select'"

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
@@ -108,33 +108,33 @@
                 "
               />
 
-              <div *ngSwitchCase="'rangeSlider'">
-                Min:
-                <input
-                  type="number"
-                  [value]="config.value ? config.value : config.min"
-                  (input)="
-                    config.value = $event.target.value; config.onChange(config)
-                  "
-                />
-                Max:
-                <input
-                  type="number"
-                  [value]="config.highValue ? config.highValue : config.max"
-                  (input)="
-                    config.highValue = $event.target.value;
-                    config.onChange(config)
-                  "
-                />
+              <div *ngSwitchCase="'rangeSlider'" class="range-slider">
+                <div class="range-slider-inputs d-flex justify-content-between">
+                  <input
+                    type="number"
+                    placeholder="Min"
+                    class="form-control form-control-sm"
+                    [value]="config.value"
+                    (input)="
+                      config.value = $event.target.value;
+                      config.onChange(config)
+                    "
+                  />
+                  <input
+                    type="number"
+                    placeholder="Max"
+                    class="form-control form-control-sm"
+                    [value]="config.highValue"
+                    (input)="
+                      config.highValue = $event.target.value;
+                      config.onChange(config)
+                    "
+                  />
+                </div>
                 <ngx-slider
-                  class="range-slider"
-                  [value]="config.value ? config.value : config.min"
-                  [highValue]="config.highValue ? config.highValue : config.max"
-                  (userChange)="
-                    config.onChange($event);
-                    config.value = $event.value;
-                    config.highValue = $event.highValue
-                  "
+                  [(value)]="config.value"
+                  [(highValue)]="config.highValue"
+                  (userChange)="config.onChange($event)"
                   [options]="{
                     floor: config.min,
                     ceil: config.max,

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
@@ -113,14 +113,17 @@
                 <input
                   type="number"
                   [value]="config.value ? config.value : config.min"
-                  (input)="config.value = $event.value; config.onChange(config)"
+                  (input)="
+                    config.value = $event.target.value; config.onChange(config)
+                  "
                 />
                 Max:
                 <input
                   type="number"
                   [value]="config.highValue ? config.highValue : config.max"
                   (input)="
-                    config.highValue = $event.highValue; config.onChange(config)
+                    config.highValue = $event.target.value;
+                    config.onChange(config)
                   "
                 />
                 <ngx-slider

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
@@ -108,6 +108,29 @@
                 "
               />
 
+              <p *ngSwitchCase="'rangeSlider'">
+                Min value:
+                <input
+                  type="number"
+                  [value]="config.value ? config.value : config.min"
+                  (input)="
+                    config.onChange($event.value);
+                    config.value = $event.value;
+                  "
+                />
+              </p>
+              <p *ngSwitchCase="'rangeSlider'">
+                Max value:
+                <input
+                  type="number"
+                  [value]="config.highValue ? config.highValue : config.max"
+                  (input)="
+                    config.onChange($event.highValue);
+                    config.highValue = $event.highValue
+                  "
+                />
+              </p>
+
               <ngx-slider
                 *ngSwitchCase="'rangeSlider'"
                 class="range-slider"

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
@@ -153,34 +153,40 @@
   border-left: 1px solid var(--phoenix-accent);
 }
 
-.range-slider.ngx-slider {
-  .ngx-slider-bar {
-    background: var(--phoenix-text-color-secondary);
-    height: 0.2rem;
+.range-slider {
+  .range-slider-inputs {
+    gap: 20%;
   }
 
-  .ngx-slider-selection {
-    background: var(--phoenix-accent);
-  }
-
-  .ngx-slider-pointer {
-    width: 1rem;
-    height: 1rem;
-    top: -0.45rem;
-    bottom: 0;
-    background-color: var(--phoenix-accent);
-
-    &:after {
-      display: none;
+  .ngx-slider {
+    .ngx-slider-bar {
+      background: var(--phoenix-text-color-secondary);
+      height: 0.2rem;
     }
-  }
 
-  .ngx-slider-bubble {
-    color: var(--phoenix-text-color);
-    font-size: 0.8rem;
+    .ngx-slider-selection {
+      background: var(--phoenix-accent);
+    }
 
-    &.ngx-slider-limit {
-      color: var(--phoenix-text-color-secondary);
+    .ngx-slider-pointer {
+      width: 1rem;
+      height: 1rem;
+      top: -0.45rem;
+      bottom: 0;
+      background-color: var(--phoenix-accent);
+
+      &:after {
+        display: none;
+      }
+    }
+
+    .ngx-slider-bubble {
+      color: var(--phoenix-text-color);
+      font-size: 0.8rem;
+
+      &.ngx-slider-limit {
+        color: var(--phoenix-text-color-secondary);
+      }
     }
   }
 }


### PR DESCRIPTION
Within ATLAS we have had issues where the jets or cells aren't visible because the upper bound range is too low. We can change this in the code, but that's not very helpful if we have a special event. Also, it's quite fiddly to do cuts with the slider sometimes.

So this is a WIP to add manual entries. Currently it looks like (you can see I haven't worried about styling yet).

![image](https://user-images.githubusercontent.com/6764617/179778261-147ecd0b-e7e1-436d-bc59-06477187c27d.png)


Currently, this isn't really working anyway - entered values don't move the slider or update the display, so the link isn't working.

I tried moving to use ` <input type="number" [(ngModel)]="value">` in `phoenix-menu-item.component.html, but then I get:
```
Error: projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html:126:32 - error TS2339: Property 'value' does not exist on type 'PhoenixMenuItemComponent'.

126                   [(ngModel)]="value">
```

I think I need help @9inpachi ! ;-)