### PR TITLE
Make Vertices support both pos and x/y/z definitions + updated doc

### DIFF
--- a/guides/developers/event_data_format.md
+++ b/guides/developers/event_data_format.md
@@ -129,8 +129,10 @@ PlanarCaloCells is an object with the following attributes :
 
 #### 'Vertices
 'Vertices are a list of Vertex objects with the following attributes :
-* `x`, `y`, `z` : describing the position of the vertex
 * `color` (opt) - Hexadecimal string representing the color to draw the vertex.
+* one of the 2 following sets of attributes 
+  * `x`, `y`, `z` : describing the position of the vertex
+  * `pos` : array of 3 numbers (x, y, z) describing the position of the vertex
 
 #### MissingEnergy
 This is a list of objects, displayed as dashed lines starting from 0 and staying in the plane z=0. Each object has the following attributes :

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -700,10 +700,15 @@ export class PhoenixObjects {
     });
     // object
     const sphere = new Mesh(geometry, material);
-    sphere.position.x = vertexParams.pos[0];
-    sphere.position.y = vertexParams.pos[1];
-    sphere.position.z = vertexParams.pos[2];
-
+    if ('pos' in vertexParams) {
+      sphere.position.x = vertexParams.pos[0];
+      sphere.position.y = vertexParams.pos[1];
+      sphere.position.z = vertexParams.pos[2];
+    } else {
+      sphere.position.x = vertexParams.x;
+      sphere.position.y = vertexParams.y;
+      sphere.position.z = vertexParams.z;
+    }
     sphere.userData = Object.assign({}, vertexParams);
     sphere.name = 'Vertex';
     // Setting uuid for selection from collections info


### PR DESCRIPTION
It seems different experiments started with different conventions here. It was simple enough to support both, so I implemented it