### PR TITLE
Adding support for IrregularCaloCells physics objects

### DIFF
--- a/guides/users.md
+++ b/guides/users.md
@@ -226,6 +226,16 @@ PlanarCaloCells is an object with the following attributes :
   * `pos` - position of the cell within the calo plane given as a pair [x, y]
   * `color` (opt) - Hexadecimal string representing the color to draw the cell.
 
+#### 'IrregularCaloCells'
+Calorimeter cells with arbitrary polyhedron-type geometry. 
+Each cell is represented by 8 (x,y,z) vertices connected using a convex hull from the [ConvexGeometry](https://threejs.org/docs/#examples/en/geometries/ConvexGeometry) class.
+
+IrregularCaloCells is a list of objects with the following attributes :
+   * `layer` - the Calorimeter layer
+   * `vtx` - a flattened list of 8 vertex coordinates (24 floats)
+   * `color` - an integer list of [R,G,B] values
+   * `opacity` - value from 0 to 1
+
 #### 'Vertices
 'Vertices are a list of Vertex objects with the following attributes :
 * `x`, `y`, `z` : describing the position of the vertex

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -1,6 +1,7 @@
 import {
   Vector3,
   Object3D,
+  Color,
   CatmullRomCurve3,
   TubeGeometry,
   MeshToonMaterial,
@@ -21,6 +22,7 @@ import {
   LineSegments,
   LineDashedMaterial,
 } from 'three';
+import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js';
 import { EVENT_DATA_TYPE_COLORS } from '../../helpers/constants';
 import { RKHelper } from '../../helpers/rk-helper';
 import { CoordinateHelper } from '../../helpers/coordinate-helper';

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -782,4 +782,43 @@ export class PhoenixObjects {
 
     return object;
   }
+
+  /**
+   * Type for drawing irregular calorimeter cell comprising 8 xyz vertices in arbitrary geometry.
+   * @param layer Calorimeter layer
+   * @param vtx Flattened list of 8 vertex coordinates (24 floats)
+   * @param color [R,G,B] integer list
+   * @param opacity value from 0 to 1
+   * @returns the cell
+   */
+   public static getIrregularCaloCell(irrCells: {    
+    type: any,
+    layer: number,
+    vtx: any,
+    color: string,
+    opacity: any,
+   }): Object3D {
+
+    const verticesOfCube = [];
+    for (let i = 0; i < 24; i += 3) {
+      verticesOfCube.push( new Vector3(irrCells.vtx[i],irrCells.vtx[i+1],irrCells.vtx[i+2]));
+    }
+    const geometry = new ConvexGeometry(verticesOfCube);
+    const cell_color = new Color("rgb(" + irrCells.color[0].toString() + "," + irrCells.color[1].toString() + "," + irrCells.color[2].toString() + ")");
+
+    // material
+    const material = new MeshPhongMaterial({
+      color: cell_color,
+      transparent: true,
+      opacity: irrCells.opacity
+      // wireframe: true
+    });
+
+    // object
+    const cell = new Mesh(geometry, material);
+    cell.userData = Object.assign({});
+    cell.name = 'IrregularCaloCell';
+
+    return cell;
+  }
 }

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -785,12 +785,13 @@ export class PhoenixObjects {
     return object;
   }
 
-  /**
+/**
    * Type for drawing irregular calorimeter cell comprising 8 xyz vertices in arbitrary geometry.
-   * @param layer Calorimeter layer
-   * @param vtx Flattened list of 8 vertex coordinates (24 floats)
-   * @param color [R,G,B] integer list
-   * @param opacity value from 0 to 1
+   * @param irrCells Properties of irregular calo cell.
+   * @param irrCells.layer Calorimeter layer
+   * @param irrCells.vtx Flattened list of 8 vertex coordinates (24 floats)
+   * @param irrCells.color [R,G,B] integer list
+   * @param irrCells.opacity value from 0 to 1
    * @returns the cell
    */
    public static getIrregularCaloCell(irrCells: {    
@@ -813,13 +814,15 @@ export class PhoenixObjects {
       color: cell_color,
       transparent: true,
       opacity: irrCells.opacity
-      // wireframe: true
     });
 
     // object
     const cell = new Mesh(geometry, material);
-    cell.userData = Object.assign({});
+    cell.userData = Object.assign({}, irrCells);
     cell.name = 'IrregularCaloCell';
+  
+    // Setting uuid for selection from collections info
+    irrCells.uuid = cell.uuid;
 
     return cell;
   }

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -785,7 +785,7 @@ export class PhoenixObjects {
     return object;
   }
 
-/**
+  /**
    * Type for drawing irregular calorimeter cell comprising 8 xyz vertices in arbitrary geometry.
    * @param irrCells Properties of irregular calo cell.
    * @param irrCells.layer Calorimeter layer
@@ -794,33 +794,42 @@ export class PhoenixObjects {
    * @param irrCells.opacity value from 0 to 1
    * @returns the cell
    */
-   public static getIrregularCaloCell(irrCells: {    
-    type: any,
-    layer: number,
-    vtx: any,
-    color: string,
-    opacity: any,
-   }): Object3D {
-
+  public static getIrregularCaloCell(irrCells: {
+    type: any;
+    layer: number;
+    vtx: any;
+    color: string;
+    opacity: any;
+  }): Object3D {
     const verticesOfCube = [];
     for (let i = 0; i < 24; i += 3) {
-      verticesOfCube.push( new Vector3(irrCells.vtx[i],irrCells.vtx[i+1],irrCells.vtx[i+2]));
+      verticesOfCube.push(
+        new Vector3(irrCells.vtx[i], irrCells.vtx[i + 1], irrCells.vtx[i + 2])
+      );
     }
     const geometry = new ConvexGeometry(verticesOfCube);
-    const cell_color = new Color("rgb(" + irrCells.color[0].toString() + "," + irrCells.color[1].toString() + "," + irrCells.color[2].toString() + ")");
+    const cell_color = new Color(
+      'rgb(' +
+        irrCells.color[0].toString() +
+        ',' +
+        irrCells.color[1].toString() +
+        ',' +
+        irrCells.color[2].toString() +
+        ')'
+    );
 
     // material
     const material = new MeshPhongMaterial({
       color: cell_color,
       transparent: true,
-      opacity: irrCells.opacity
+      opacity: irrCells.opacity,
     });
 
     // object
     const cell = new Mesh(geometry, material);
     cell.userData = Object.assign({}, irrCells);
     cell.name = 'IrregularCaloCell';
-  
+
     // Setting uuid for selection from collections info
     irrCells.uuid = cell.uuid;
 

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -301,9 +301,7 @@ export class PhoenixLoader implements EventDataLoader {
 
     if (eventData.IrregularCaloCells) {
       // (Optional) Cuts can be added to any physics object.
-      const cuts = [
-        new Cut('layer', 0, 10),
-      ];
+      const cuts = [new Cut('layer', 0, 10), new Cut('energy', 0, 10000)];
 
       const scaleIrregularCaloCells = (value: number) => {
         this.graphicsLibrary

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -299,6 +299,33 @@ export class PhoenixLoader implements EventDataLoader {
       );
     }
 
+    if (eventData.IrregularCaloCells) {
+      // (Optional) Cuts can be added to any physics object.
+      const cuts = [
+        new Cut('layer', 0, 10),
+      ];
+
+      const scaleIrregularCaloCells = (value: number) => {
+        this.graphicsLibrary
+          .getSceneManager()
+          .scaleChildObjects('IrregularCaloCells', value, 'z');
+      };
+      const addIrregularCaloCellOptions = this.addScaleOptions(
+        'IrregularCaloCellsScale',
+        'IrregularCaloCells Scale',
+        scaleIrregularCaloCells
+      );
+
+      this.addObjectType(
+        eventData.IrregularCaloCells,
+        PhoenixObjects.getIrregularCaloCell,
+        'IrregularCaloCells',
+        false,
+        cuts,
+        addIrregularCaloCellOptions
+      );
+    }
+
     if (eventData.Muons) {
       const cuts = [
         new Cut('phi', -pi, pi, 0.01),


### PR DESCRIPTION
Calorimeter cells with arbitrary polyhedron-type geometry. 
Each cell is represented by 8 (x,y,z) vertices connected using a convex hull from the [ConvexGeometry](https://threejs.org/docs/#examples/en/geometries/ConvexGeometry) class.

IrregularCaloCells is a list of objects with the following attributes :
   * `layer` - the Calorimeter layer
   * `vtx` - a flattened list of 8 vertex coordinates (24 floats)
   * `color` - an integer list of [R,G,B] values
   * `opacity` - value from 0 to 1