### PR TITLE
Adding support for edm4hep tracker hits

### DIFF
--- a/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
@@ -345,6 +345,7 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
           type: 'CircularPoint',
           pos: position,
           color: '#' + hitColor,
+          size: 2,
         };
         hits.push(hit);
       });

--- a/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
@@ -304,7 +304,55 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
 
   /** Not implemented */
   private getHits(event: any) {
-    return {};
+    const allHits: any[] = [];
+
+    for (const collName in event) {
+      if (event[collName].constructor != Object) {
+        continue;
+      }
+
+      const collDict = event[collName];
+
+      if (!('collType' in collDict)) {
+        continue;
+      }
+
+      if (!collDict['collType'].includes('edm4hep::')) {
+        continue;
+      }
+
+      if (!collDict['collType'].includes('TrackerHitCollection')) {
+        continue;
+      }
+
+      if (!('collection' in collDict)) {
+        continue;
+      }
+
+      const rawHits = collDict['collection'];
+      const hits: any[] = [];
+      const hitColor = this.randomColor();
+
+      rawHits.forEach((rawHit: any) => {
+        const position: any[] = [];
+        if ('position' in rawHit) {
+          position.push(rawHit['position']['x'] * 0.1);
+          position.push(rawHit['position']['y'] * 0.1);
+          position.push(rawHit['position']['z'] * 0.1);
+        }
+
+        const hit = {
+          type: 'CircularPoint',
+          pos: position,
+          color: '#' + hitColor,
+        };
+        hits.push(hit);
+      });
+
+      allHits[collName] = hits;
+    }
+
+    return allHits;
   }
 
   /** Returns the cells */

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -398,7 +398,7 @@ export class PhoenixObjects {
     const texture = new CanvasTexture(canvas);
 
     const material = new PointsMaterial({
-      size: 10,
+      size: hitsParams[0].size ?? 10,
       color: hitsParams[0].color ?? EVENT_DATA_TYPE_COLORS.Hits,
       map: texture,
       alphaMap: texture,


### PR DESCRIPTION
Adding support for the edm4hep (sim)trackerhits to be visualized as circular points.

Also: adds `uuid` to the irregular calo cells object