### PR TITLE
Add Animations to configuration

### DIFF
--- a/packages/phoenix-event-display/src/lib/types/configuration.ts
+++ b/packages/phoenix-event-display/src/lib/types/configuration.ts
@@ -1,6 +1,7 @@
 import { PresetView } from '../models/preset-view.model';
 import { EventDataLoader } from '../../loaders/event-data-loader';
 import { PhoenixMenuNode } from '../../managers/ui-manager/phoenix-menu/phoenix-menu-node';
+import { AnimationPreset } from '../../managers/three-manager/animations-manager';
 
 /**
  * Configuration of the event display.
@@ -10,6 +11,8 @@ export interface Configuration {
   defaultView?: number[];
   /** Preset views for switching event display camera. */
   presetViews?: PresetView[];
+  /** Preset views for switching event display camera. */
+  presetAnimations?: AnimationPreset[];
   /** Event data loader responsible for processing and loading event data. */
   eventDataLoader?: EventDataLoader;
   /** Root node of the phoenix menu. */

--- a/packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts
@@ -27,6 +27,8 @@ export interface AnimationPreset {
   animateEventAfterInterval?: number;
   /** Duration of the event collision. */
   collisionDuration?: number;
+  /** Name of the Animation */
+  name: string;
 }
 
 /**

--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -17,6 +17,53 @@ import {
   setToLocalStorage,
 } from '../../helpers/browser-storage';
 import { PhoenixUI } from './phoenix-ui';
+import { AnimationPreset } from '../../managers/three-manager/animations-manager';
+
+const defaultAnimationPresets: AnimationPreset[] = [
+  {
+    name: 'Cavern to ID',
+    positions: [
+      {
+        position: [66388.95051168812, 5264.228603228927, -46910.7848593543],
+        duration: 1000,
+      },
+      {
+        position: [12834.18729094943, 677.7571205763458, 135.68755273443463],
+        duration: 2000,
+      },
+      {
+        position: [312.02688693297375, 25.884223757326, 270.10019006776236],
+        duration: 3500,
+      },
+      {
+        position: [263.3640855132258, 19.874838262525053, -318.16541790248885],
+        duration: 3000,
+      },
+      {
+        position: [5534.140362338047, 234.03507981484574, -2933.619479808285],
+        duration: 2000,
+      },
+      {
+        position: [2681.277288705242, 646.5795158318147, 5628.5248735111745],
+        duration: 1000,
+      },
+      {
+        position: [-6062.586283740076, 790.5876682946184, 1381.1675900848818],
+        duration: 1000,
+      },
+      {
+        position: [-1766.7693725879053, 1007.1048030984678, -5928.901341784575],
+        duration: 1000,
+      },
+      {
+        position: [12814.982506255355, 2516.987185037266, -22891.902734328327],
+        duration: 1000,
+      },
+    ],
+    animateEventAfterInterval: 5000,
+    collisionDuration: 6000,
+  },
+];
 
 /**
  * Manager for UI related operations including the dat.GUI menu, stats-js and theme settings.
@@ -350,6 +397,18 @@ export class UIManager {
    */
   public getPresetViews(): PresetView[] {
     return this.configuration?.presetViews;
+  }
+
+  /**
+   * Get preset animations from the configuration.
+   * @returns Available preset animations.
+   */
+  public getPresetAnimations(): AnimationPreset[] {
+    if (this.configuration?.presetAnimations) {
+      return this.configuration?.presetAnimations;
+    } else {
+      return defaultAnimationPresets;
+    }
   }
 
   /**

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/animations-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/animations-manager.test.ts
@@ -83,6 +83,7 @@ describe('AnimationsManager', () => {
     it('should animate scene by animating camera through the scene and animating event collision', () => {
       jest.spyOn(animationsManager, 'getCameraTween');
       const animationPreset: AnimationPreset = {
+        name: 'test',
         positions: [
           {
             position: [0, 0, 0],

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/animate-camera.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/animate-camera.component.ts
@@ -5,30 +5,43 @@ import { EventDisplayService } from '../../../services/event-display.service';
 export const defaultAnimationPresets: {
   [key: string]: AnimationPreset;
 } = {
-  'Preset 1': {
+  'Cavern to ID': {
+    name: 'Cavern to ID',
     positions: [
       {
-        position: [11976, 7262, 11927],
+        position: [66388.95051168812, 5264.228603228927, -46910.7848593543],
         duration: 1000,
       },
       {
-        position: [-1000, 0, 11927],
+        position: [12834.18729094943, 677.7571205763458, 135.68755273443463],
         duration: 2000,
       },
       {
-        position: [2000, 500, 1000],
+        position: [312.02688693297375, 25.884223757326, 270.10019006776236],
         duration: 3500,
       },
       {
-        position: [5000, 2000, 1000],
+        position: [263.3640855132258, 19.874838262525053, -318.16541790248885],
         duration: 3000,
       },
       {
-        position: [5000, 2000, 1000],
+        position: [5534.140362338047, 234.03507981484574, -2933.619479808285],
         duration: 2000,
       },
       {
-        position: [11976, 7262, 11927],
+        position: [2681.277288705242, 646.5795158318147, 5628.5248735111745],
+        duration: 1000,
+      },
+      {
+        position: [-6062.586283740076, 790.5876682946184, 1381.1675900848818],
+        duration: 1000,
+      },
+      {
+        position: [-1766.7693725879053, 1007.1048030984678, -5928.901341784575],
+        duration: 1000,
+      },
+      {
+        position: [12814.982506255355, 2516.987185037266, -22891.902734328327],
         duration: 1000,
       },
     ],
@@ -47,7 +60,12 @@ export class AnimateCameraComponent {
   animationPresetsKeys = Object.keys(this.animationPresets);
   isAnimating = false;
 
-  constructor(private eventDisplay: EventDisplayService) {}
+  constructor(private eventDisplay: EventDisplayService) {
+    // this.animationPresets = this.eventDisplay
+    //   .getUIManager()
+    //   .getPresetAnimations();
+    // This is too late to fill the UI! FIXME. EJWM
+  }
 
   animatePreset(preset: string) {
     this.setDetectorOpacity(0.2);


### PR DESCRIPTION
Ideally it will be possible to pass animations in the configuration. This is a step in that direction (and as a workaround, updates the default animation for the benefit of ATLAS).

- Add name to AnimationPreset, since it really is a properly of the animation
- Workaround to UI init failures for the moment.
- Fix test for AnimationPreset changes