### PR TITLE
Fix overlay view resizing issue

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay-view/overlay-view-window/overlay-view-window.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay-view/overlay-view-window/overlay-view-window.component.html
@@ -4,6 +4,7 @@
   [resizable]="true"
   [transparentBody]="transparentBody"
   [active]="showOverlay"
+  [keepAspectRatioFixed]="true"
 >
   <div class="overlay-view-wrapper">
     <canvas #overlayWindow id="overlay-canvas" [hidden]="!showOverlay">

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
@@ -89,9 +89,6 @@ export class OverlayComponent implements AfterViewInit {
       } else {
         overlayCardElement.style.height = height + 'px';
       }
-      else {
-        overlayCardElement.style.height = height + 'px';
-      }
     }
   }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
@@ -28,8 +28,12 @@ export class OverlayComponent implements AfterViewInit {
   @Input() resizable: boolean = false;
   /** If the overlay body is transparent or not. */
   @Input() transparentBody: boolean = false;
+  /** If the aspect ratio is kept fixed or not. */
+  @Input() keepAspectRatioFixed: boolean = false;
   /** If the overlay body is visible or not. */
   showBody: boolean = true;
+  /** Aspect ratio of the overlay view. */
+  aspectRatio: number = window.innerWidth / window.innerHeight;
 
   // ********************************************************************************
   // * Below code is specific to the overlay resize feature. (LOOK INTO CSS RESIZE) *
@@ -81,6 +85,9 @@ export class OverlayComponent implements AfterViewInit {
     if (width > this.MIN_RES_WIDTH && height > this.MIN_RES_HEIGHT) {
       overlayCardElement.style.width = width + 'px';
       overlayCardElement.style.height = height + 'px';
+      if (this.keepAspectRatioFixed) {
+        overlayCardElement.style.height = width / this.aspectRatio + 30 + 'px';
+      }
     }
   }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
@@ -84,9 +84,10 @@ export class OverlayComponent implements AfterViewInit {
 
     if (width > this.MIN_RES_WIDTH && height > this.MIN_RES_HEIGHT) {
       overlayCardElement.style.width = width + 'px';
-      overlayCardElement.style.height = height + 'px';
       if (this.keepAspectRatioFixed) {
         overlayCardElement.style.height = width / this.aspectRatio + 30 + 'px';
+      } else {
+        overlayCardElement.style.height = height + 'px';
       }
     }
   }


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/77807055/222970800-cdc298f8-4437-49ac-b5f9-a1d2fe7704a1.png)

Fixed issue [Overlay resize not fully working #467](https://github.com/HSF/phoenix/issues/467). When switching to overlay view, resizing the overlay view window poses an issue by keeping some blank space in the vertical direction. It has been fixed by locking the aspect ratio of the overlay window as shown below.

https://user-images.githubusercontent.com/77807055/222975101-e13b09af-1378-44de-b950-2cc205ff16d2.mp4