### PR TITLE
Add forceColourTheme configuration option

### DIFF
--- a/packages/phoenix-event-display/src/lib/types/configuration.ts
+++ b/packages/phoenix-event-display/src/lib/types/configuration.ts
@@ -2,6 +2,7 @@ import { PresetView } from '../models/preset-view.model';
 import { EventDataLoader } from '../../loaders/event-data-loader';
 import { PhoenixMenuNode } from '../../managers/ui-manager/phoenix-menu/phoenix-menu-node';
 import { AnimationPreset } from '../../managers/three-manager/animations-manager';
+import { DepthPackingStrategies } from 'three';
 
 /**
  * Configuration of the event display.
@@ -11,7 +12,7 @@ export interface Configuration {
   defaultView?: number[];
   /** Preset views for switching event display camera. */
   presetViews?: PresetView[];
-  /** Preset views for switching event display camera. */
+  /** Preset animations for switching event display camera. */
   presetAnimations?: AnimationPreset[];
   /** Event data loader responsible for processing and loading event data. */
   eventDataLoader?: EventDataLoader;
@@ -25,4 +26,6 @@ export interface Configuration {
   defaultEventFile?: { eventFile: string; eventType: string };
   /** Whether to allow URL options or not (true by default). */
   allowUrlOptions?: boolean;
+  /** Whether to force a theme ('dark' or 'light' are current options) */
+  forceColourTheme?: string;
 }

--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -116,9 +116,14 @@ export class UIManager {
         new PhoenixMenuUI(configuration.phoenixMenuRoot, this.three)
       );
     }
-
-    // Detect UI color scheme
-    this.detectColorScheme();
+    if (!configuration.forceColourTheme) {
+      // Detect UI color scheme
+      this.detectColorScheme();
+    } else {
+      this.setDarkTheme(
+        configuration.forceColourTheme.toLocaleLowerCase() == 'dark'
+      );
+    }
     // State manager
     this.stateManager = new StateManager();
     this.stateManager.setPhoenixMenuRoot(configuration.phoenixMenuRoot);


### PR DESCRIPTION
One request we had from ATLAS was to be able to force the colour scheme. Since (I think) we don't save the status of the configuration bar in the 'save state' json, I figured this was the only other work around.