### PR TITLE
Automate the release process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout
+        uses: actions/checkout@main
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@main
         with:
@@ -76,7 +78,7 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
           environment: ${{ steps.deploy.outputs.deployment_env }}
-          required_contexts: "[]"
+          required_contexts: '[]'
           auto_merge: false
 
       - name: Create Deployment Status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,50 @@
-name: phoenix-docker-release
+name: phoenix-release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Type of the next version update to be released.
+        required: true
+        options: [patch, minor, major, pre, graduate]
+        default: patch
 
 jobs:
-  push-to-docker:
+  release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    strategy:
+      matrix:
+        node-version: [18.x]
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@main
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@main
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup
+        run: yarn install
+
+      - name: Release
+        run: yarn release:${{ inputs.release_type }} --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  push-to-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
 
       - name: Release Version
         id: release_version

--- a/guides/release.md
+++ b/guides/release.md
@@ -3,7 +3,7 @@
 This guide highlights the release process for Phoenix packages.\
 If you are not a part of Phoenix on npm and want to make a release, you can ask [9inpachi](https://github.com/9inpachi) or [EdwardMoyse](https://github.com/EdwardMoyse) to add you to the npm org.
 
-We currently publish the packages `phoenix-event-display`and `phoenix-ui-components` to npm.
+We currently publish the packages `phoenix-event-display` and `phoenix-ui-components` to npm.
 
 ## Checklist
 
@@ -30,12 +30,12 @@ Then you need to set the `GH_TOKEN` environment variable in your terminal when r
 The release commands will then be structured like:
 
 ```sh
-GH_TOKEN=<your_gh_token> yarn release:<version_priority>
+GH_TOKEN=<your_gh_token> yarn release:<release_type>
 ```
 
 Here's a list of the release commands.
 
-* `yarn release`
+* `yarn release:patch`
   * Will release a patch version of all the packages. (1.0.x where x will be updated)
 * `yarn release:minor`
   * Will release a minor version of all the packages. (1.x.0 where x will be updated)
@@ -45,7 +45,7 @@ Here's a list of the release commands.
   * Will prerelease a patch version. (1.0.0-alpha-x - alpha suffix will be added and x will be updated with each release)
 * `yarn release:graduate`
   * Will graduate a prerelease (the one we did above) to a full stable version removing the alpha suffix from the version. (If you don't graduate a prerelease, the normal release commands (`yarn release:major`, `yarn release` etc.) will also prerelease with the alpha suffix)
-* All `yarn release:<version_priority>` commands will
+* All `yarn release:<release_type>` commands will
    1) Release all the packages (`phoenix-event-display` and `phoenix-ui-components`).
    2) Deploy the API docs.
    3) Deploy the Angular application.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start:ssl": "yarn workspace phoenix-ng start:ssl",
     "test:ci": "lerna run test:ci",
     "test:coverage": "lerna run test:coverage",
-    "release": "lerna publish patch --create-release github",
+    "release:patch": "lerna publish patch --create-release github",
     "release:graduate": "lerna publish --create-release github --conventional-graduate",
     "release:major": "lerna publish major --create-release github",
     "release:minor": "lerna publish minor --create-release github",


### PR DESCRIPTION
Closes #574 

## Description

Currently, we do the release by following the [release guide](https://github.com/HSF/phoenix/blob/26c507202114625c70f483c5f317fb0f8a089f9b/guides/release.md). With this update, we will be able to automate the release by just having the ability to trigger it as a GitHub action and specifying the type of the next version update.

## Changes

- Some improvements to the main build and test action.
- Add a new job to the release workflow  whcih runs on manual dispatch, publishes the packages to npm and goes through the release process.
- Update the documentation of release process.