### PR TITLE
Fix: capitalization of "yarn" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can see the stable version at [https://hepsoftwarefoundation.org/phoenix](ht
 
 ## Development
 
-For running both the event display and the Angular app, you will need [Node.js](https://nodejs.org/en/download/) and yarn.
+For running both the event display and the Angular app, you will need [Node.js](https://nodejs.org/en/download/) and Yarn.
 
 Once you have Node.js and npm (npm comes with Node.js), install Yarn.
 


### PR DESCRIPTION
This pull request addresses a minor issue in the README.md file where the word "yarn" was not capitalized. 