### PR TITLE
Auto reload feature for cycle-event component

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.html
@@ -1,7 +1,16 @@
-<app-menu-toggle
+<button
+  class="cycle-events"
+  [ngClass]=""
+  [matTooltip]="tooltip"
+  matTooltipPosition="above"
+  matTooltipTouchGestures="off"
   tooltip="Cycle through events"
-  [active]="active"
-  icon="cycle-events"
   (click)="toggleCycle()"
 >
-</app-menu-toggle>
+  <svg
+    class="cycle-events-icon"
+    [ngClass]="{ 'active-icon': active, 'reload-icon': reloading }"
+  >
+    <use href="assets/icons/cycle-events.svg#cycle-events"></use>
+  </svg>
+</button>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.scss
@@ -1,0 +1,41 @@
+:host {
+  display: flex;
+  margin: 0 0.6rem;
+
+  .cycle-events {
+    display: flex;
+    background: unset;
+    border: none;
+    height: 2.5rem;
+    width: 2.5rem;
+    min-height: 2.5rem;
+    min-width: 2.5rem;
+    padding: 0.65rem;
+    cursor: pointer;
+    align-self: center;
+    transition: all 0.4s;
+
+    &-icon {
+      width: 100%;
+      height: 100%;
+
+      &.active-icon {
+        --phoenix-options-icon-path: #00bcd4;
+      }
+      &.reload-icon {
+        --phoenix-options-icon-path: #77dd77;
+      }
+    }
+
+    &:hover {
+      background-color: var(--phoenix-options-icon-bg);
+      border-radius: 40%;
+      transition: all 0.4s;
+    }
+
+    &.disabled {
+      cursor: not-allowed;
+      opacity: 0.4;
+    }
+  }
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.test.ts
@@ -46,15 +46,17 @@ describe('CycleEventsComponent', () => {
     jest.clearAllTimers();
     jest.useFakeTimers();
     component.interval = 1000;
-
     component.toggleCycle();
-
     expect(component.active).toBeTruthy();
-
+    expect(component.reloading).toBeFalsy();
     jest.advanceTimersByTime(1200);
-
     expect(mockEventDisplay.loadEvent).toHaveBeenCalledWith('eventKey2');
-
+    component.toggleCycle();
+    expect(component.active).toBeTruthy();
+    expect(component.reloading).toBeTruthy();
+    component.toggleCycle();
+    expect(component.active).toBeFalsy();
+    expect(component.reloading).toBeFalsy();
     jest.clearAllTimers();
   });
 });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.ts
@@ -1,43 +1,73 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { EventDisplayService } from '../../../services/event-display.service';
+import { FileLoaderService } from '../../../services/file-loader.service';
 
 @Component({
   selector: 'app-cycle-events',
   templateUrl: './cycle-events.component.html',
+  styleUrls: ['./cycle-events.component.scss'],
 })
 export class CycleEventsComponent implements OnInit {
-  @Input()
-  interval: number;
+  @Input() interval: number;
+  @Input() tooltip: string;
+  @Input() icon: string;
 
+  // There are actually 3 states we go through when clicking this component :
+  //  - not active : so we are not cycling throught events
+  //  - active and not reloading : cycling over the events stored in events
+  //  - active and reloading : cycling and reloading the events when reaching the end
+  // Last state is useful e.g. for live feed of events
   active: boolean = false;
+  reloading: boolean = false;
 
   private intervalId: NodeJS.Timer;
 
   private events: string[];
 
-  constructor(private eventDisplay: EventDisplayService) {}
+  constructor(
+    private eventDisplay: EventDisplayService,
+    private fileLoader: FileLoaderService
+  ) {}
 
   ngOnInit() {
-    this.eventDisplay.listenToLoadedEventsChange(
-      (events) => (this.events = events)
-    );
+    this.eventDisplay.listenToLoadedEventsChange((events) => {
+      this.events = events;
+      if (this.active) {
+        // restart cycling from first event
+        clearInterval(this.intervalId);
+        this.startCycleInterval();
+      }
+    });
   }
 
   toggleCycle() {
-    this.active = !this.active;
+    this.reloading = this.active && !this.reloading;
+    this.active = !this.active || this.reloading;
+    console.log(this.active, this.reloading);
     clearInterval(this.intervalId);
-
     if (this.active) {
       this.startCycleInterval();
     }
   }
 
   private startCycleInterval(startIndex: number = 0) {
+    // load immediately first event
     let index = startIndex;
-
+    this.eventDisplay.loadEvent(this.events[index]);
+    index = index + 1 >= this.events.length ? -1 : index + 1;
+    // launch automatic cycling
     this.intervalId = setInterval(() => {
-      index = index >= this.events.length ? 0 : index + 1;
+      // special value -1 is used to denote wrapping of the current set of events
+      if (index == -1) {
+        if (this.reloading) {
+          // reload the current events
+          this.fileLoader.reloadLastEvents(this.eventDisplay);
+        }
+        // put back index to 0 to start with first event anyway
+        index = 0;
+      }
       this.eventDisplay.loadEvent(this.events[index]);
+      index = index + 1 >= this.events.length ? -1 : index + 1;
     }, this.interval);
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component.test.ts
@@ -3,6 +3,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EventDisplayService } from '../../../../services/event-display.service';
 import { FileNode } from '../../../file-explorer/file-explorer.component';
+import { FileLoaderService } from '../../../../services/file-loader.service';
 import { PhoenixUIModule } from '../../../phoenix-ui.module';
 import { EventDataExplorerDialogData } from '../event-data-explorer.component';
 import {
@@ -16,6 +17,10 @@ describe.skip('EventDataExplorerDialogComponent', () => {
 
   const mockStateManager = {
     loadStateFromJSON: jest.fn(),
+  };
+
+  const mockFileLoaderService = {
+    loadEvent: jest.fn(),
   };
 
   const mockEventDisplay = {};
@@ -97,31 +102,30 @@ describe.skip('EventDataExplorerDialogComponent', () => {
 
   it('should load event based on file type', () => {
     jest
-      .spyOn(EventDataExplorerDialogComponent.prototype, 'makeRequest')
+      .spyOn(FileLoaderService.prototype, 'loadEvent')
       .mockImplementation(
-        (_arg1: string, _arg2: string, onData: (data: string) => void) =>
-          onData('test')
+        (_arg1: string, eventDisplay: EventDisplayService) => true
       );
 
-    jest.spyOn(component as any, 'loadJSONEvent');
+    jest.spyOn(FileLoaderService.prototype, 'loadEvent');
     component.loadEvent('https://example.com/event_data/test.json');
-    expect((component as any).loadJSONEvent).toHaveBeenCalled();
-
-    jest.spyOn(component as any, 'loadJiveXMLEvent');
-    component.loadEvent('https://example.com/event_data/test.xml');
-    expect((component as any).loadJiveXMLEvent).toHaveBeenCalled();
+    expect(mockFileLoaderService.loadEvent).toHaveBeenCalled();
   });
 
   it('should load config', () => {
     jest
-      .spyOn(EventDataExplorerDialogComponent.prototype, 'makeRequest')
+      .spyOn(FileLoaderService.prototype, 'makeRequest')
       .mockImplementation(
-        (_arg1: string, _arg2: string, onData: (data: string) => void) =>
-          onData('{}')
+        (
+          _arg1: string,
+          _arg2: 'json' | 'blob' | 'text',
+          onData: (data: any) => void
+        ) => {
+          onData('{}');
+          return true;
+        }
       );
-
     component.loadConfig('https://example.com/config_data/test.json');
-
     expect(mockStateManager.loadStateFromJSON).toHaveBeenCalledWith({});
   });
 });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component.ts
@@ -1,10 +1,9 @@
 import { Component, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { JiveXMLLoader } from 'phoenix-event-display';
 import { EventDisplayService } from '../../../../services/event-display.service';
 import { FileNode } from '../../../file-explorer/file-explorer.component';
+import { FileLoaderService } from '../../../../services/file-loader.service';
 import { EventDataExplorerDialogData } from '../event-data-explorer.component';
-import JSZip from 'jszip';
 
 const supportFileTypes = ['json', 'xml'];
 
@@ -26,20 +25,25 @@ export class EventDataExplorerDialogComponent {
 
   constructor(
     private eventDisplay: EventDisplayService,
+    private fileLoader: FileLoaderService,
     private dialogRef: MatDialogRef<EventDataExplorerDialogComponent>,
     @Inject(MAT_DIALOG_DATA) private dialogData: EventDataExplorerDialogData
   ) {
     // Event data
-    this.makeRequest(this.dialogData.apiURL, 'json', (res: FileResponse[]) => {
-      const filePaths = res.filter((file) =>
-        supportFileTypes.includes(file.name.split('.').pop())
-      );
+    fileLoader.makeRequest(
+      this.dialogData.apiURL,
+      'json',
+      (res: FileResponse[]) => {
+        const filePaths = res.filter((file) =>
+          supportFileTypes.includes(file.name.split('.').pop())
+        );
 
-      this.eventDataFileNode = this.buildFileNode(filePaths);
-    });
+        this.eventDataFileNode = this.buildFileNode(filePaths);
+      }
+    );
 
     // Config
-    this.makeRequest(
+    fileLoader.makeRequest(
       `${this.dialogData.apiURL}?type=config`,
       'json',
       (res: FileResponse[]) => {
@@ -53,96 +57,29 @@ export class EventDataExplorerDialogComponent {
   }
 
   loadEvent(file: string) {
-    const isZip = file.split('.').pop() === 'zip';
-    const rawfile = isZip ? file.substring(0, file.length - 4) : file;
-    this.makeRequest(file, isZip ? 'blob' : 'text', (eventData) => {
-      switch (rawfile.split('.').pop()) {
-        case 'xml':
-          this.loadJiveXMLEvent(eventData);
-          break;
-        case 'json':
-          this.loadJSONEvent(eventData);
-          break;
-      }
-    });
-  }
-
-  private loadJSONEvent(eventData: string) {
-    this.eventDisplay.parsePhoenixEvents(JSON.parse(eventData));
-    this.onClose();
-  }
-
-  private loadJiveXMLEvent(eventData: string) {
-    const jiveXMLLoader = new JiveXMLLoader();
-    jiveXMLLoader.process(eventData);
-    const processedEventData = jiveXMLLoader.getEventData();
-    this.eventDisplay.buildEventDataFromJSON(processedEventData);
-    this.onClose();
+    this.loading = true;
+    this.error = this.fileLoader.loadEvent(file, this.eventDisplay);
+    this.loading = false;
+    if (!this.error) this.onClose();
   }
 
   loadConfig(file: string) {
-    this.makeRequest(
+    this.loading = true;
+    this.error = this.fileLoader.makeRequest(
       `${this.dialogData.apiURL}?type=config&f=${file}`,
       'text',
       (config) => {
         const stateManager = this.eventDisplay.getStateManager();
         stateManager.loadStateFromJSON(JSON.parse(config));
-
         this.onClose();
       }
     );
+    this.loading = false;
   }
 
   // Helpers
-
   onClose() {
     this.dialogRef.close();
-  }
-
-  private async unzip(data: ArrayBuffer) {
-    const archive = new JSZip();
-    await archive.loadAsync(data);
-    let fileData = '';
-    let multiFile = false;
-    for (const filePath in archive.files) {
-      if (multiFile) {
-        console.error(
-          'Zip archive contains more than one file. Ignoring all but first'
-        );
-        break;
-      }
-      fileData = await archive.file(filePath).async('string');
-      multiFile = true;
-    }
-    return fileData;
-  }
-
-  makeRequest(
-    urlPath: string,
-    responseType: 'json' | 'text' | 'blob',
-    onData: (data: any) => void
-  ) {
-    this.loading = true;
-    fetch(urlPath)
-      .then((res) => res[responseType]())
-      .then((data) => {
-        if (responseType === 'blob') {
-          data
-            .arrayBuffer()
-            .then((buf) => this.unzip(buf))
-            .then((d) => onData(d));
-        } else {
-          onData(data);
-        }
-        this.error = false;
-      })
-      .catch((error) => {
-        console.error(error);
-        this.error = true;
-      })
-      .finally(() => {
-        this.loading = false;
-      });
   }
 
   private buildFileNode(filePaths: FileResponse[]): FileNode {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.component.test.ts
@@ -1,0 +1,51 @@
+import { FileLoaderService } from './file-loader.service';
+import { EventDisplayService } from './event-display.service';
+
+describe.skip('FileLoaderService', () => {
+  let service: FileLoaderService;
+  let mockEventDisplay: any;
+
+  const mockFileLoaderService = {
+    loadEvent: jest.fn(),
+    loadJSONEvent: jest.fn(),
+    loadJiveXMLEvent: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockEventDisplay = {};
+  });
+
+  it('should load event based on file type', () => {
+    jest
+      .spyOn(FileLoaderService.prototype, 'makeRequest')
+      .mockImplementation(
+        (
+          _arg1: string,
+          _arg2: 'json' | 'text' | 'blob',
+          onData: (data: any) => void
+        ) => {
+          onData('test');
+          return true;
+        }
+      );
+    jest.spyOn(FileLoaderService.prototype, 'loadJSONEvent');
+    service.loadEvent(
+      'https://example.com/event_data/test.json',
+      mockEventDisplay
+    );
+    expect(mockFileLoaderService.loadJSONEvent).toHaveBeenCalled();
+
+    jest.spyOn(FileLoaderService.prototype, 'loadJiveXMLEvent');
+    service.loadEvent(
+      'https://example.com/event_data/test.xml',
+      mockEventDisplay
+    );
+    expect(mockFileLoaderService.loadJiveXMLEvent).toHaveBeenCalled();
+
+    jest.spyOn(FileLoaderService.prototype, 'loadEvent');
+    service.reloadLastEvents(mockEventDisplay);
+    expect(mockFileLoaderService.loadEvent).toHaveBeenCalledWith(
+      'https://example.com/event_data/test.xml'
+    );
+  });
+});

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@angular/core';
+import JSZip from 'jszip';
+import { EventDisplayService } from './event-display.service';
+import { JiveXMLLoader } from 'phoenix-event-display';
+
+/**
+ * Service makeing file loading easier
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class FileLoaderService {
+  private lastEventsURL: string = '';
+
+  async unzip(data: ArrayBuffer) {
+    const archive = new JSZip();
+    await archive.loadAsync(data);
+    let fileData = '';
+    let multiFile = false;
+    for (const filePath in archive.files) {
+      if (multiFile) {
+        console.error(
+          'Zip archive contains more than one file. Ignoring all but first'
+        );
+        break;
+      }
+      fileData = await archive.file(filePath).async('string');
+      multiFile = true;
+    }
+    return fileData;
+  }
+
+  // returns whether an error was found
+  makeRequest(
+    urlPath: string,
+    responseType: 'json' | 'text' | 'blob',
+    onData: (data: any) => void
+  ) {
+    fetch(urlPath)
+      .then((res) => res[responseType]())
+      .then((data) => {
+        if (responseType === 'blob') {
+          data
+            .arrayBuffer()
+            .then((buf) => this.unzip(buf))
+            .then((d) => onData(d));
+        } else {
+          onData(data);
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+        return true;
+      });
+    return false;
+  }
+
+  loadJSONEvent(eventData: string, eventDisplay: EventDisplayService) {
+    eventDisplay.parsePhoenixEvents(JSON.parse(eventData));
+  }
+
+  loadJiveXMLEvent(eventData: string, eventDisplay: EventDisplayService) {
+    const jiveXMLLoader = new JiveXMLLoader();
+    jiveXMLLoader.process(eventData);
+    const processedEventData = jiveXMLLoader.getEventData();
+    eventDisplay.buildEventDataFromJSON(processedEventData);
+  }
+
+  loadEvent(file: string, eventDisplay: EventDisplayService) {
+    this.lastEventsURL = file;
+    const isZip = file.split('.').pop() === 'zip';
+    const rawfile = isZip ? file.substring(0, file.length - 4) : file;
+    return this.makeRequest(file, isZip ? 'blob' : 'text', (eventData) => {
+      switch (rawfile.split('.').pop()) {
+        case 'xml':
+          this.loadJiveXMLEvent(eventData, eventDisplay);
+          break;
+        case 'json':
+          this.loadJSONEvent(eventData, eventDisplay);
+          break;
+      }
+    });
+  }
+
+  reloadLastEvents(eventDisplay: EventDisplayService) {
+    if (this.lastEventsURL.length > 0) {
+      this.loadEvent(this.lastEventsURL, eventDisplay);
+    }
+  }
+}


### PR DESCRIPTION
First moved file loading code from the ui component event-data-explorer-dialog to the dedicated service file-loader, for easier reuse

Then added auto reload event features to the cycle-event component

The component now toggles between 3 modes :
  - no cycle
  - cycle as before over existing events
  - cycle and reload events when reaching the end
Last mode allows for easy live feed providing the source is a URL

On the way, 2 little bugs have been fixed :
  - start the cycle on first event and not a random number that may be past the last event and fail
  - not mess up with event numbers when changing the set of events, again could lead to be past last event and fail
  - immediately start the cycle when clicking, not waiting for a first interval

