### PR TITLE
Resurrected (and improved) tooltip for cycle event tool

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/cycle-events/cycle-events.component.html
@@ -1,10 +1,8 @@
 <button
   class="cycle-events"
-  [ngClass]=""
-  [matTooltip]="tooltip"
+  matTooltip="Cycle (off/on/on+reload)"
   matTooltipPosition="above"
   matTooltipTouchGestures="off"
-  tooltip="Cycle through events"
   (click)="toggleCycle()"
 >
   <svg


### PR DESCRIPTION
This has been broken when the cycle+reload state was added