### PR TITLE
Implemented size checking in make-picture

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -97,25 +97,6 @@ export class EventDisplay {
   }
 
   /**
-   * Takes a screen shot of the current view
-   * @param width the width of the picture to be created
-   * @param height the height of the picture to be created
-   * @param fitting the type of fitting to use in case width and height
-   * ratio do not match the current screen ratio. Posible values are
-   *    - Crop : current view is cropped on both side or up and done to fit ratio
-   *             thus it is not stretched, but some parts are lost
-   *    - Stretch : current view is stretched to given format
-   *               this is the default and used also for any other value given to fitting
-   */
-  public makeScreenShot(
-    width: number,
-    height: number,
-    fitting: string = 'Stretch',
-  ) {
-    this.graphicsLibrary.makeScreenShot(width, height, fitting);
-  }
-
-  /**
    * Initialize XR.
    * @param xrSessionType Type of the XR session. Either AR or VR.
    * @param onSessionEnded Callback when the XR session ends.

--- a/packages/phoenix-event-display/src/managers/three-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/index.ts
@@ -795,7 +795,7 @@ export class ThreeManager {
   public checkScreenShotCanvasSize(
     width: number,
     height: number,
-    fitting: string = 'Strech'
+    fitting: string = 'Stretch',
   ) {
     // compute actual size of screen shot, based on current view and requested size
     const mainRenderer = this.rendererManager.getMainRenderer();
@@ -805,7 +805,7 @@ export class ThreeManager {
       width,
       height,
       originalSize.width,
-      originalSize.height
+      originalSize.height,
     );
     // Deal with devices having special devicePixelRatio (retina screens in particular)
     const scale = window.devicePixelRatio;
@@ -840,7 +840,7 @@ export class ThreeManager {
       width,
       height,
       originalSize.width,
-      originalSize.height
+      originalSize.height,
     );
     const heightShift = (scaledSize.height - height) / 2;
     const widthShift = (scaledSize.width - width) / 2;
@@ -868,7 +868,7 @@ export class ThreeManager {
     mainRenderer.setSize(
       scaledSize.width / scale,
       scaledSize.height / scale,
-      false
+      false,
     );
     this.render();
     ctx.drawImage(

--- a/packages/phoenix-event-display/src/managers/three-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/index.ts
@@ -772,6 +772,51 @@ export class ThreeManager {
   })();
 
   /**
+   * crops the size of an image to fit the ratio of the given screen size
+   * That way the final image won't be streched
+   */
+  private croppedSize(width, height, screenWidth, screenHeight) {
+    let croppedHeight = height;
+    let croppedWidth = width;
+    if (screenWidth * height < screenHeight * width) {
+      croppedHeight = (screenHeight * width) / screenWidth;
+    } else {
+      croppedWidth = (screenWidth * height) / screenHeight;
+    }
+    return { width: croppedWidth, height: croppedHeight };
+  }
+
+  /**
+   * checks whether the size of the canvas required to build the required
+   * screenshot (based on the desired size and the fitting parameter) does
+   * matches the maximum allowed canvas size
+   * See makeScreenShot for the description of fitting
+   */
+  public checkScreenShotCanvasSize(
+    width: number,
+    height: number,
+    fitting: string = 'Strech'
+  ) {
+    // compute actual size of screen shot, based on current view and requested size
+    const mainRenderer = this.rendererManager.getMainRenderer();
+    const originalSize = new Vector2();
+    mainRenderer.getSize(originalSize);
+    const scaledSize = this.croppedSize(
+      width,
+      height,
+      originalSize.width,
+      originalSize.height
+    );
+    // Deal with devices having special devicePixelRatio (retina screens in particular)
+    const scale = window.devicePixelRatio;
+    const gl = mainRenderer.getContext();
+    const maxSize = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
+    return (
+      scaledSize.width / scale < maxSize && scaledSize.height / scale < maxSize
+    );
+  }
+
+  /**
    * Takes a screen shot of the current view
    * @param width the width of the picture to be created
    * @param height the height of the picture to be created
@@ -787,23 +832,18 @@ export class ThreeManager {
     height: number,
     fitting: string = 'Strech',
   ) {
-    // compute actual size of screen shot, based on current view and reuested size
+    // compute actual size of screen shot, based on current view and requested size
     const mainRenderer = this.rendererManager.getMainRenderer();
     const originalSize = new Vector2();
     mainRenderer.getSize(originalSize);
-    let scaledHeight = height;
-    let scaledWidth = width;
-    if (fitting == 'Crop') {
-      // Massage width and height so that we keep the screen ratio
-      // and thus the image from the screen is not streched
-      if (originalSize.width * height < originalSize.height * width) {
-        scaledHeight = (originalSize.height * width) / originalSize.width;
-      } else {
-        scaledWidth = (originalSize.width * height) / originalSize.height;
-      }
-    }
-    const heightShift = (scaledHeight - height) / 2;
-    const widthShift = (scaledWidth - width) / 2;
+    const scaledSize = this.croppedSize(
+      width,
+      height,
+      originalSize.width,
+      originalSize.height
+    );
+    const heightShift = (scaledSize.height - height) / 2;
+    const widthShift = (scaledSize.width - width) / 2;
 
     // get background color to be used
     const bkgColor = getComputedStyle(document.body).getPropertyValue(
@@ -825,7 +865,11 @@ export class ThreeManager {
     ctx.fillStyle = bkgColor;
     ctx.fillRect(0, 0, width, height);
     // draw main image on our output canvas, with right size
-    mainRenderer.setSize(scaledWidth / scale, scaledHeight / scale, false);
+    mainRenderer.setSize(
+      scaledSize.width / scale,
+      scaledSize.height / scale,
+      false
+    );
     this.render();
     ctx.drawImage(
       mainRenderer.domElement,
@@ -846,9 +890,9 @@ export class ThreeManager {
     if (infoPanel != null) {
       // Compute size of info panel on final picture
       const infoHeight =
-        (infoPanel.clientHeight * scaledHeight) / originalSize.height;
+        (infoPanel.clientHeight * scaledSize.height) / originalSize.height;
       const infoWidth =
-        (infoPanel.clientWidth * scaledWidth) / originalSize.width;
+        (infoPanel.clientWidth * scaledSize.width) / originalSize.width;
 
       // Add info panel to output. This is HTML, so first convert it to canvas,
       // and then draw to our output canvas

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.html
@@ -8,6 +8,7 @@
       [value]="3840"
       (change)="setWidth(width.value)"
       (click)="$event.stopPropagation()"
+      [class.badSize]="disabled"
     />
   </button>
   <button mat-menu-item (click)="$event.stopPropagation()" class="size-input">
@@ -19,6 +20,7 @@
       [value]="2610"
       (change)="setHeight(height.value)"
       (click)="$event.stopPropagation()"
+      [class.badSize]="disabled"
     />
   </button>
   <button mat-menu-item (click)="$event.stopPropagation()">
@@ -28,8 +30,13 @@
       </mat-radio-button>
     </mat-radio-group>
   </button>
-  <button mat-menu-item class="make-picture" (click)="makePicture()">
-    Create picture
+  <button
+    mat-menu-item
+    [disabled]="disabled"
+    class="make-picture"
+    (click)="makePicture()"
+  >
+    {{ buttonText() }}
   </button>
 </mat-menu>
 <app-menu-toggle

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.scss
@@ -14,6 +14,10 @@
   width: 80px;
 }
 
+.badSize {
+  border-color: red;
+}
+
 .make-picture {
   text-align: center;
   display: block;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.test.ts
@@ -10,6 +10,8 @@ describe('MakePictureComponent', () => {
 
   const mockEventDisplay = {
     makeScreenShot: jest.fn(),
+    getThreeManager: jest.fn().mockReturnThis(),
+    checkScreenShotCanvasSize: jest.fn().mockResolvedValue(true),
   };
 
   beforeEach(() => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/make-picture/make-picture.component.ts
@@ -13,16 +13,28 @@ export class MakePictureComponent implements OnInit {
   fitting: string = 'Crop';
   width: number = 3840;
   height: number = 2160;
+  disabled: boolean = false;
   constructor(private eventDisplay: EventDisplayService) {}
   ngOnInit() {}
+  private checkSize() {
+    return this.eventDisplay
+      .getThreeManager()
+      .checkScreenShotCanvasSize(this.width, this.height, this.fitting);
+  }
   setWidth(value) {
     this.width = value;
+    this.disabled = !this.checkSize();
   }
   setHeight(value) {
     this.height = value;
+    this.disabled = !this.checkSize();
   }
-
+  buttonText() {
+    return this.disabled ? 'Size too large' : 'Create picture';
+  }
   makePicture() {
-    this.eventDisplay.makeScreenShot(this.width, this.height, this.fitting);
+    this.eventDisplay
+      .getThreeManager()
+      .makeScreenShot(this.width, this.height, this.fitting);
   }
 }


### PR DESCRIPTION
If the size requested is too high, one can no more create the picture. This avoids distorded picture, waiting for a proper implementation for huge pictures.

This implements the first point of #581