### PR TITLE
feat(event-display): calo cell opacity

### DIFF
--- a/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
@@ -427,6 +427,7 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
         const eta = Math.asinh(z / rho);
         const phi = Math.acos(x / rho) * Math.sign(y);
         const cellLightness = this.valToLightness(rawCell.energy, 1e-3, 1);
+        const cellOpacity = this.valToOpacity(rawCell.energy, 1e-3, 1);
 
         const cell = {
           eta: eta,
@@ -436,6 +437,7 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
           side: cellSide,
           length: cellSide, // expecting cells in multiple layers
           color: '#' + this.convHSLtoHEX(cellsHue, 90, cellLightness),
+          opacity: cellOpacity,
         };
         cells.push(cell);
       });
@@ -655,6 +657,19 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
     }
 
     return lightness;
+  }
+
+  /** Return a opacity value from the passed number and range */
+  private valToOpacity(v: number, min: number, max: number): number {
+    let opacity = 0.2 + ((v - min) * 0.65) / (max - min);
+    if (opacity < 0.2) {
+      opacity = 0.2;
+    }
+    if (opacity > 0.8) {
+      opacity = 0.8;
+    }
+
+    return opacity;
   }
 
   /** Get the required collection */

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -612,6 +612,7 @@ export class PhoenixObjects {
       length?: number;
       side?: number;
       color?: string;
+      opacity?: number;
     },
     defaultCellWidth: number = 30,
     defaultCellLength: number = 30,
@@ -628,6 +629,8 @@ export class PhoenixObjects {
     // material
     const material = new MeshPhongMaterial({
       color: clusterParams.color ?? EVENT_DATA_TYPE_COLORS.CaloClusters,
+      opacity: clusterParams.opacity ?? 1.0,
+      transparent: (clusterParams.opacity ?? 1.0) == 1.0 ? false : true,
     });
 
     // object
@@ -648,6 +651,7 @@ export class PhoenixObjects {
     z?: number;
     theta?: number;
     color?: string;
+    opacity?: number;
     side?: number;
     length?: number;
     uuid: string;


### PR DESCRIPTION
Adding possibility to specify opacity for a calorimeter cell.