### PR TITLE
Fix: restrict simultaneous grid translation, both by pointer and by values

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.html
@@ -45,6 +45,7 @@
       <button
         mat-stroked-button
         (click)="onSave(xPos.value, yPos.value, zPos.value)"
+        [disabled]="shiftGrid"
       >
         Save
       </button>


### PR DESCRIPTION
Disabled the grid translation, while the translation using mouse click is active.