### PR TITLE
Add a reference to the Belle II event display in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Phoenix is also used by [Future Circular Collider](https://fcc.web.cern.ch), see
 ### LHCb
 Phoenix is also used by [LHCb](http://lhcb.web.cern.ch), see [here](https://lhcb-eventdisplay.web.cern.ch/)
 
+### Belle II
+Phoenix is also used by [Belle II](https://www.belle2.org), see [here](https://display.belle2.org/)
+
 
 ## Contact
 The best way to contact us is to either open an issue in GitHub, start a [discussion](https://github.com/HSF/phoenix/discussions) or talk to us on our [gitter channel](https://gitter.im/phoenix-developers/community) (though this is not used as much these days).


### PR DESCRIPTION
As you know, thanks to the `Belle II Event Display with Phoenix` project during the Google Summer of Code 2023, in Belle II we now have a shiny new event display based on Phoenix: https://display.belle2.org/

If you don't mind, I would like to mention it in the README file of this project.

(In case you are curious, the code is publicly available on GitHub: https://github.com/belle2/display)