### PR TITLE
Update prettier and fix linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jest-environment-jsdom": "~29.6.2",
     "lerna": "^7.1.4",
     "lint-staged": "^13.2.3",
-    "prettier": "^3.0.1",
+    "prettier": "^3.2.5",
     "rimraf": "^5.0.1",
     "ts-jest-mock-import-meta": "^1.0.0",
     "typescript": "~5.1.6"

--- a/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
@@ -111,8 +111,8 @@ export class ColorOptions {
       );
 
       this.initColorByOptions();
-      this.colorByOptions.forEach(
-        (colorByOption) => colorByOption.initialize?.(),
+      this.colorByOptions.forEach((colorByOption) =>
+        colorByOption.initialize?.(),
       );
       this.onlySelectedColorByOption();
     }

--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -271,8 +271,8 @@ export class UIManager {
       this.addLabelsFolder();
     }
 
-    this.uiMenus.forEach(
-      (menu) => menu?.addLabel(labelId, () => this.removeLabel(labelId)),
+    this.uiMenus.forEach((menu) =>
+      menu?.addLabel(labelId, () => this.removeLabel(labelId)),
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17739,12 +17739,12 @@ cors@latest:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "prettier@npm:3.0.1"
+"prettier@npm:^3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: e1f3f16c7fe0495de3faa182597871f74927d787cce3c52095a66ff5d7eacc05173371d5f58bf12141a0a1b6bfe739a338531d6cf18b92c7256c1319f2c84e73
+  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 
@@ -18612,7 +18612,7 @@ proxy-middleware@latest:
     jest-environment-jsdom: ~29.6.2
     lerna: ^7.1.4
     lint-staged: ^13.2.3
-    prettier: ^3.0.1
+    prettier: ^3.2.5
     rimraf: ^5.0.1
     ts-jest-mock-import-meta: ^1.0.0
     typescript: ~5.1.6


### PR DESCRIPTION
Attempt to fix issues making a new release:
https://github.com/HSF/phoenix/actions/runs/8338400002

Specifically:
```
Successfully replaced in file /home/runner/work/phoenix/phoenix/docs/api-docs/index.html
file:///home/runner/work/phoenix/phoenix/node_modules/prettier/index.mjs:16599
        throw new UndefinedParserError(
              ^

UndefinedParserError: No parser could be inferred for file "/home/runner/work/phoenix/phoenix/yarn.lock".
    at normalizeFormatOptions (file:///home/runner/work/phoenix/phoenix/node_modules/prettier/index.mjs:16599:15)
    at formatWithCursor (file:///home/runner/work/phoenix/phoenix/node_modules/prettier/index.mjs:18220:52)
    at file:///home/runner/work/phoenix/phoenix/node_modules/prettier/index.mjs:21420:12
    at async Module.format2 (file:///home/runner/work/phoenix/phoenix/node_modules/prettier/index.mjs:21425:25)
```

(I didn't initially think this was due to prettier, so this might not work, but some internet searching suggested this might be worth a try)