### PR TITLE
Fix for "TypeScript: Illegal constructor"

### DIFF
--- a/packages/phoenix-event-display/src/helpers/file.ts
+++ b/packages/phoenix-event-display/src/helpers/file.ts
@@ -39,7 +39,8 @@ export const loadFile = (
         onFileRead?.(e.target.result.toString());
       }
       inputFile.remove();
-      inputFile = new HTMLInputElement();
+      inputFile = document.createElement('input');
+      // For explanation, see https://stackoverflow.com/a/26221525
     };
     reader.readAsText(configFile);
   };

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.ts
@@ -10,7 +10,6 @@ export class HomeComponent implements AfterViewInit {
   year: number;
 
   constructor(private eventDisplay: EventDisplayService) {
-    console.log('Home component created');
     this.year = new Date().getFullYear();
     this.eventDisplay.getThreeManager().stopAnimationLoop();
   }


### PR DESCRIPTION
Whilst investigating the various reports of issues with loading configs, I saw that we have an error reporting in `file.ts` "TypeScript: Illegal constructor"

As explained in https://stackoverflow.com/a/26221525, we cannot use constructors for DOM elements