### PR TITLE
Optionally draw some tracks with thicker lines

### DIFF
--- a/packages/phoenix-event-display/src/loaders/jivexml-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/jivexml-loader.ts
@@ -7,13 +7,17 @@ import { CoordinateHelper } from '../helpers/coordinate-helper.js';
 export class JiveXMLLoader extends PhoenixLoader {
   /** Event data in JiveXML data format */
   private data: any;
+  /** List of tracks to draw with thicker tubes */
+  thickTrackCollections: string[];
 
   /**
    * Constructor for the JiveXMLLoader.
+   * @param thickTrackCollections A list of names of track collections which should be drawn thicker
    */
-  constructor() {
+  constructor(thickTrackCollections: string[] = []) {
     super();
     this.data = {};
+    this.thickTrackCollections = thickTrackCollections;
   }
 
   /**
@@ -173,6 +177,15 @@ export class JiveXMLLoader extends PhoenixLoader {
         trackCollectionName = 'Tracks_'; //We have problems if the name of the collection is a type
       }
 
+      let thickTracks = false;
+      if (
+        this.thickTrackCollections.find(
+          (collection) => collection === trackCollectionName,
+        )
+      ) {
+        thickTracks = true;
+      }
+
       // if (!trackCollectionName.includes('MuonSpectrometer')) continue;
       const numOfTracks = Number(collection.getAttribute('count'));
       const jsontracks = [];
@@ -265,6 +278,7 @@ export class JiveXMLLoader extends PhoenixLoader {
           hits: {},
           author: {},
           badtrack: [] as string[],
+          linewidth: thickTracks ? 20.0 : undefined,
         };
         if (chi2.length >= i) track.chi2 = chi2[i];
         if (numDoF.length >= i) track.dof = numDoF[i];

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -140,6 +140,7 @@ export class PhoenixObjects {
       ? parseInt(trackParams.color, 16)
       : EVENT_DATA_TYPE_COLORS.Tracks.getHex();
 
+    const linewidth = trackParams.linewidth ? trackParams.linewidth : 2;
     const points = [];
 
     for (let i = 0; i < positions.length; i++) {
@@ -162,7 +163,7 @@ export class PhoenixObjects {
     const curve = new CatmullRomCurve3(points);
 
     // TubeGeometry
-    const geometry = new TubeGeometry(curve, undefined, 2);
+    const geometry = new TubeGeometry(curve, undefined, linewidth);
     const material = new MeshToonMaterial({ color: objectColor });
     const tubeObject = new Mesh(geometry, material);
 
@@ -171,7 +172,7 @@ export class PhoenixObjects {
     const lineGeometry = new BufferGeometry().setFromPoints(vertices);
     const lineMaterial = new LineBasicMaterial({
       color: objectColor,
-      linewidth: 2,
+      linewidth: linewidth,
     });
     const lineObject = new Line(lineGeometry, lineMaterial);
     lineObject.name = 'Track';

--- a/packages/phoenix-event-display/src/managers/url-options-manager.ts
+++ b/packages/phoenix-event-display/src/managers/url-options-manager.ts
@@ -142,9 +142,11 @@ export class URLOptionsManager {
    */
   private async handleJiveXMLEvent(fileURL: string) {
     const fileData = await (await fetch(fileURL)).text();
-    const loader = new JiveXMLLoader();
-    this.configuration.eventDataLoader = loader;
+    if (!this.configuration.eventDataLoader) {
+      this.configuration.eventDataLoader = new JiveXMLLoader();
+    }
     // Parse the XML to extract events and their data
+    const loader = this.configuration.eventDataLoader as JiveXMLLoader;
     loader.process(fileData);
     const eventData = loader.getEventData();
     this.eventDisplay.buildEventDataFromJSON(eventData);
@@ -188,7 +190,10 @@ export class URLOptionsManager {
       });
 
     // JiveXML event data
-    const jiveloader = new JiveXMLLoader();
+    const jiveloader =
+      this.configuration.eventDataLoader instanceof JiveXMLLoader
+        ? (this.configuration.eventDataLoader as JiveXMLLoader)
+        : new JiveXMLLoader();
     Object.keys(filesWithData)
       .filter((fileName) => {
         return fileName.endsWith('.xml') || fileName.startsWith('JiveXML');

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.ts
@@ -10,7 +10,6 @@ export class HomeComponent implements AfterViewInit {
   year: number;
 
   constructor(private eventDisplay: EventDisplayService) {
-    console.log('Home component created');
     this.year = new Date().getFullYear();
     this.eventDisplay.getThreeManager().stopAnimationLoop();
   }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
@@ -7,7 +7,7 @@ import {
 import {
   PresetView,
   PhoenixMenuNode,
-  PhoenixLoader,
+  JiveXMLLoader,
   StateManager,
 } from 'phoenix-event-display';
 import type { Configuration } from 'phoenix-event-display';
@@ -48,7 +48,7 @@ export class AtlasComponent implements OnInit {
 
     // Define the configuration
     const configuration: Configuration = {
-      eventDataLoader: new PhoenixLoader(),
+      eventDataLoader: new JiveXMLLoader(['CombinedMuonTracks']),
       presetViews: [
         new PresetView('Left View', [0, 0, -12000], [0, 0, 0], 'left-cube'),
         new PresetView('Center View', [-500, 12000, 0], [0, 0, 0], 'top-cube'),


### PR DESCRIPTION
As discussed in #666 in ATLAS we have requests to draw some tracks (e.g. muons) with a thicker line.

To do this properly, we need to add this to the GUI

This is a simpler work around, where the home component can tell the `JiveXMLLoader` the names of the track collections to draw thicker.