### PR TITLE
Noticed that when we load a new JiveXML file, the loader configuration is lost

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -29,7 +29,7 @@ declare global {
  */
 export class EventDisplay {
   /** Configuration for preset views and event data loader. */
-  private configuration: Configuration;
+  public configuration: Configuration;
   /** An object containing event data. */
   private eventsData: any;
   /** Array containing callbacks to be called when events change. */

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas/atlas.component.ts
@@ -48,7 +48,12 @@ export class AtlasComponent implements OnInit {
 
     // Define the configuration
     const configuration: Configuration = {
-      eventDataLoader: new JiveXMLLoader(['CombinedMuonTracks']),
+      eventDataLoader: new JiveXMLLoader([
+        'CombinedMuonTracks',
+        'MuonSpectrometerTracks',
+        'CombinedInDetTracks',
+        'Muons_xAOD',
+      ]),
       presetViews: [
         new PresetView('Left View', [0, 0, -12000], [0, 0, 0], 'left-cube'),
         new PresetView('Center View', [-500, 12000, 0], [0, 0, 0], 'top-cube'),

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -121,12 +121,22 @@ export class IOOptionsDialogComponent implements OnInit {
 
   handleJiveXMLDataInput(files: FileList) {
     const callback = (content: any) => {
-      const jiveloader = new JiveXMLLoader();
+      const jiveloader = this.getJiveXMLLoader();
       jiveloader.process(content);
       const eventData = jiveloader.getEventData();
       this.eventDisplay.buildEventDataFromJSON(eventData);
     };
     this.handleFileInput(files[0], 'xml', callback);
+  }
+
+  private getJiveXMLLoader(): JiveXMLLoader {
+    if (
+      this.eventDisplay.configuration.eventDataLoader instanceof JiveXMLLoader
+    ) {
+      return this.eventDisplay.configuration.eventDataLoader as JiveXMLLoader;
+    } else {
+      return new JiveXMLLoader();
+    }
   }
 
   handleOBJInput(files: FileList) {
@@ -219,7 +229,8 @@ export class IOOptionsDialogComponent implements OnInit {
       });
 
     // JiveXML event data
-    const jiveloader = new JiveXMLLoader();
+    const jiveloader = this.getJiveXMLLoader();
+
     Object.keys(filesWithData)
       .filter((fileName) => {
         return fileName.endsWith('.xml') || fileName.startsWith('JiveXML');

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
@@ -62,7 +62,15 @@ export class FileLoaderService {
   }
 
   loadJiveXMLEvent(eventData: string, eventDisplay: EventDisplayService) {
-    const jiveXMLLoader = new JiveXMLLoader();
+    let jiveXMLLoader = undefined;
+
+    if (eventDisplay.configuration.eventDataLoader instanceof JiveXMLLoader) {
+      jiveXMLLoader = eventDisplay.configuration
+        .eventDataLoader as JiveXMLLoader;
+    } else {
+      jiveXMLLoader = new JiveXMLLoader();
+    }
+
     jiveXMLLoader.process(eventData);
     const processedEventData = jiveXMLLoader.getEventData();
     eventDisplay.buildEventDataFromJSON(processedEventData);


### PR DESCRIPTION
Fixes this problem.

This requires access to EventDisplay configuration, so make this public. Also, make sure that we handle the possibility that the configuration.eventDataLoader is not the correct type.

(Incidentally, I am making this PR at 10km up, flying over the med and on to Africa)