### PR TITLE
Use relative import for config-types

### DIFF
--- a/packages/phoenix-event-display/src/lib/models/cut.model.ts
+++ b/packages/phoenix-event-display/src/lib/models/cut.model.ts
@@ -1,5 +1,5 @@
 import { PrettySymbols } from '../../helpers/pretty-symbols';
-import { ConfigRangeSlider } from 'src/managers/ui-manager/phoenix-menu/config-types';
+import { ConfigRangeSlider } from '../../managers/ui-manager/phoenix-menu/config-types';
 
 /**
  * Cut for specifying filters on event data attribute.


### PR DESCRIPTION
As discussed here https://github.com/HSF/phoenix/issues/694#issuecomment-2490188465

The releases seem to be broken. Hopefully this will fix.
