### PR TITLE
misc (event-display): Add jet origin

### DIFF
--- a/guides/users.md
+++ b/guides/users.md
@@ -192,6 +192,7 @@ Jets are a list of Jet objects with the following attributes :
 * `energy`, `et` (opt) - energy of the Jets, used to set its length
 * `coneR` (opt) - the radius of the jet cone. If not given, radius is 10% of the length
 * `color` (opt) - Hexadecimal string representing the color to draw the jet.
+* `origin_X`, `origin_Y`, `origin_Z` (opt) - Origin of the jet
 
 #### 'Hits'
 Hits can be defined in 2 ways. Either as an array of positions or as an array of Hit objects.

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -208,15 +208,23 @@ export class PhoenixObjects {
     // Jet energy parameter can either be 'energy' or 'et'
     const length = (jetParams.energy ? jetParams.energy : jetParams.et) * 0.2;
 
+    // Add displacement of the origin of the jet
+    // If x is given else jet is at origin
+    const origin_X = jetParams.origin_X ? jetParams.origin_X : 0;
+    // If y is given else jet is at origin
+    const origin_Y = jetParams.origin_Y ? jetParams.origin_Y : 0;
+    // If z is given else jet is at origin
+    const origin_Z = jetParams.origin_Z ? jetParams.origin_Z : 0;
+
     const sphi = Math.sin(phi);
     const cphi = Math.cos(phi);
     const stheta = Math.sin(theta);
     const ctheta = Math.cos(theta);
     //
     const translation = new Vector3(
-      0.5 * length * cphi * stheta,
-      0.5 * length * sphi * stheta,
-      0.5 * length * ctheta,
+      0.5 * length * cphi * stheta + origin_X,
+      0.5 * length * sphi * stheta + origin_Y,
+      0.5 * length * ctheta + origin_Z,
     );
 
     const width = jetParams.coneR


### PR DESCRIPTION
Add origin for displaced jets. User's guide was updated as well. This pull request arose from question [Displaced jets #691](https://github.com/HSF/phoenix/discussions/691). As an example, here is an events.json with three jets:

`
{
     "1": {
          "Jets": {
               "three_displaced_jets": [
                    {    
                         "origin_Z" : -1000,
                         "origin_Y" : 1000,
                         "origin_X" : -1000,
                         "pos": [
                              [
                                   -0.4987947940826416,
                                   -0.49609166383743286,
                                   -80.730889320373535
                              ],
                              [
                                   0.5028243660926819,
                                   -0.8267080187797546,
                                   -80.741073608398438
                              ]
                         ],
                         "eta": -0.8143964409828186,
                         "phi": -2.9927451610565186,
                         "energy": 326618.375
                    },
                    {
                         "eta": -0.40384864807128906,
                         "phi": 0.24317990243434906,
                         "energy": 245776.171875
                    },
                    {
                         "origin_Z" : 1000,
                         "eta": 2.8462071418762207,
                         "phi": 2.033921003341675,
                         "energy": 135842.859375
                    }
               ]
          }
     }
}
`

The resulting event looks like this:

<img width="1470" alt="Screenshot 2024-12-26 at 10 51 59 AM" src="https://github.com/user-attachments/assets/ada345ec-7c8d-47e1-9ea8-e5881f41258c" />
