### PR TITLE
Fixing loading of EDM4hep event data files

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -117,7 +117,7 @@ export class IOOptionsDialogComponent implements OnInit {
       edm4hepJsonLoader.processEventData();
       this.eventDisplay.parsePhoenixEvents(edm4hepJsonLoader.getEventData());
     };
-    this.handleFileInput(files[0], 'json', callback);
+    this.handleFileInput(files[0], 'edm4hep.json', callback);
   }
 
   handleJiveXMLDataInput(files: FileList) {


### PR DESCRIPTION
The edm4hep.json files report this error otherwise:
```
Error: Invalid file format!
```