### PR TITLE
Show hit color back in the Phoenix menu

### DIFF
--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -1,4 +1,4 @@
-import { Group, Object3D, Vector3 } from 'three';
+import { Group, Object3D, Vector3, Color } from 'three';
 import { GUI } from 'dat.gui';
 import type { EventDataLoader } from './event-data-loader';
 import { UIManager } from '../managers/ui-manager/index';
@@ -470,7 +470,9 @@ export class PhoenixLoader implements EventDataLoader {
       );
 
       if (objectCollection.length == 0) {
-        console.log('Skipping');
+        console.log(
+          `Skipping ${typeName} collection ${collectionName} since it is empty.`,
+        );
         continue;
       }
 
@@ -487,7 +489,18 @@ export class PhoenixLoader implements EventDataLoader {
       const collectionCuts = newCuts?.filter(
         (cut) => cut.field in objectCollection[0],
       );
-      this.ui.addCollection(typeName, collectionName, collectionCuts);
+
+      const collectionColor = new Color(
+        object[collectionName][0].color
+          ? object[collectionName][0].color
+          : 0xffffff,
+      );
+      this.ui.addCollection(
+        typeName,
+        collectionName,
+        collectionCuts,
+        collectionColor,
+      );
     }
 
     const eventDataTypeFolderDatGUI = this.ui

--- a/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
@@ -7,8 +7,11 @@ import {
   Material,
   type Object3DEventMap,
   Line,
+  Points,
 } from 'three';
 import { SceneManager } from './scene-manager';
+import { PhoenixMenuNode } from '../ui-manager/phoenix-menu/phoenix-menu-node';
+import { type ConfigColor } from '../ui-manager/phoenix-menu/config-types';
 
 /**
  * Color manager for three.js functions related to coloring of objects.
@@ -64,8 +67,12 @@ export class ColorManager {
   /**
    * Changes the color of all objects inside an event data collection to some random color.
    * @param collectionName Name of the collection.
+   * @param optionsFolder Reporting random color back to the menu color box.
    */
-  public collectionColorRandom(collectionName: string) {
+  public collectionColorRandom(
+    collectionName: string,
+    optionsFolder?: PhoenixMenuNode,
+  ) {
     if (!this.sceneManager || !this.sceneManager.getScene()) {
       return;
     }
@@ -77,8 +84,19 @@ export class ColorManager {
       if (collection) {
         for (const child of Object.values(collection.children)) {
           child.traverse((object) => {
-            const randomColor = Math.random() * 0xffffff;
+            const randomColor = Math.floor(Math.random() * 0xffffff);
             setColorForObject(object, randomColor);
+            if (typeof optionsFolder === 'undefined') {
+              return;
+            }
+            if (optionsFolder.configs.length < 1) {
+              return;
+            }
+            if (optionsFolder.configs[0].type !== 'color') {
+              return;
+            }
+            const configColor = optionsFolder.configs[0] as ConfigColor;
+            configColor.color = `#${randomColor.toString(16)}`;
           });
         }
       }
@@ -138,6 +156,12 @@ function setColorForObject(object: Object3D<Object3DEventMap>, color: any) {
   } else if (object instanceof Line) {
     const line = object as Line;
     const material = line.material;
+    if ('color' in material) {
+      (material.color as Color).set(color);
+    }
+  } else if (object instanceof Points) {
+    const points = object as Points;
+    const material = points.material;
     if ('color' in material) {
       (material.color as Color).set(color);
     }

--- a/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
@@ -77,6 +77,7 @@ export class ColorOptions {
    * Create the color options.
    * @param colorManager Color manager for three.js functions related to coloring of objects.
    * @param collectionFolder Collection folder to add the color by options to.
+   * @param collectionColor Initial collection color.
    * @param colorByOptionsToInclude Options to include for this collection to color event data by.
    */
   constructor(
@@ -102,7 +103,10 @@ export class ColorOptions {
       type: 'button',
       label: 'Random',
       onClick: () =>
-        this.colorManager.collectionColorRandom(this.collectionName),
+        this.colorManager.collectionColorRandom(
+          this.collectionName,
+          this.colorOptionsFolder,
+        ),
     });
 
     // Check which color by options are to be included.
@@ -293,7 +297,7 @@ export class ColorOptions {
   /**
    * Get momentum from object parameters.
    * @param objectParams Parameters associated to the 3D object.
-   * @returns THe momentum value.
+   * @returns The momentum value.
    */
   private getMomentum(objectParams: any) {
     return objectParams?.dparams?.[4]

--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -208,6 +208,7 @@ export class UIManager {
    * @param eventDataType Name of the event data type.
    * @param collectionName Name of the collection to be added in the type of event data (tracks, hits etc.).
    * @param cuts Cuts to the collection of event data that are to be made configurable to filter event data.
+   * @param collectionColor initial color of the collection.
    */
   public addCollection(
     eventDataType: string,


### PR DESCRIPTION
Fixes issue, where hit color is not reflected in the phoenix menu.
From:
![image](https://github.com/user-attachments/assets/047364ec-22c6-4e38-bae7-b48dba157d1a)
To:
![image](https://github.com/user-attachments/assets/66574a71-9916-4829-8ec1-18a555b98e80)

Fixes also the random button.