### PR TITLE
Split EDM4hep tracker hits into several collections

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20500,7 +20500,7 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>, typescript@patch:typescript@~5.5.4#~builtin<compat/typescript>":
   version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=5da071"
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#~builtin<compat/typescript>::version=5.5.4&hash=ad5954"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
Hi,

When EDM4hep event data file is being loaded, the tracker hits are split into several collections. First, the overlay (pile-up) hits and hits produced by secondaries are separated. Afterward, the remaining hits are split into: electrons, muons, pions, kaons, protons and others.

Best,
Juraj