### PR TITLE
EDM4hep loader: Allowing new style of links (to, from)

### DIFF
--- a/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
@@ -120,8 +120,14 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
     }
 
     mcRecoAssocs.forEach((mcRecoAssoc: any) => {
-      const recoIndex = mcRecoAssoc['rec']['index'];
-      const mcIndex = mcRecoAssoc['sim']['index'];
+      const recoIndex =
+        typeof mcRecoAssoc['rec'] !== 'undefined'
+          ? mcRecoAssoc['rec']['index']
+          : mcRecoAssoc['from']['index'];
+      const mcIndex =
+        typeof mcRecoAssoc['sim'] !== 'undefined'
+          ? mcRecoAssoc['sim']['index']
+          : mcRecoAssoc['to']['index'];
 
       const pdgid = mcParticles[mcIndex]['PDG'];
       const trackRefs = recoParticles[recoIndex]['tracks'];


### PR DESCRIPTION
The associations or links in EDM4hep have now `from` and `to` instead of `sim` and `rec`. This PR allows both of the link types.