### PR TITLE
Fixed hierarchy support in the phoenix menu when loading from GLTF

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -359,7 +359,7 @@ export class EventDisplay {
   public async loadGLTFGeometry(
     url: any,
     name: string,
-    menuNodeName: string = '',
+    menuNodeName?: string | undefined,
     scale: number = 1.0,
     initiallyVisible: boolean = true,
   ): Promise<void> {


### PR DESCRIPTION
Seems this was broken by mistake in #675