### PR TITLE
fix: hide labels during animations until event objects fully appear

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
@@ -1051,4 +1051,18 @@ export class SceneManager {
     if (object) return object;
     return new Object3D();
   }
+  /**
+   * Toggle visibility of all labels in the scene.
+   * @param visible If the labels will be visible (true) or hidden (false).
+   */
+  public toggleLables(visible: boolean): void {
+    const labelsGroup = this.getObjectsGroup(SceneManager.LABELS_ID);
+    if (labelsGroup) {
+      labelsGroup.visible = visible;
+
+      labelsGroup.traverse((child: Object3D) => {
+        child.visible = visible;
+      });
+    }
+  }
 }


### PR DESCRIPTION
### Summary

This PR fixes an issue where labels were appearing too early during animations,
causing them to overlap with partially-drawn tracks, jets, hits, and other event
objects. The labels now remain hidden during the animation and correctly reappear
once all animated objects are fully visible.

### Problem

Previously, the `Labels` group was always visible, even while geometry drawRanges,
track propagation, and event-generation animations were still in progress.  
This resulted in:

- Labels floating in empty space before the objects were drawn
- Visual clutter during track growth and hit expansion
- Poor visual coherence during preset camera animations and clipping animations

### Fix

Labels are now toggled via visibility control during animation:

- **Hidden at animation start**
- **Shown again when animation finishes**

This behavior is applied consistently in all animation entrypoints:
- `animateEvent`
- `animateEventWithClipping`
- `animatePreset`

A unified approach is used for all three to ensure consistent UX across all animation modes.

### Implementation Details

- Added label-hide logic at the beginning of each animation function:
  ```ts
  const labelsGroup = this.scene.getObjectByName(SceneManager.LABELS_ID);
  if (labelsGroup) labelsGroup.visible = false;
