### PR TITLE
feat: support per-track linewidth in TracksMesh

### DIFF
--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -83,7 +83,7 @@ export class PhoenixObjects {
         ? parseInt(track.color, 16)
         : EVENT_DATA_TYPE_COLORS.Tracks.getHex();
 
-      track.tid = tracksMesh.addTrack(vertices, color);
+      track.tid = tracksMesh.addTrack(vertices, color, track.linewidth);
       track.material = tracksMaterial;
     }
     tracksMesh.process();

--- a/packages/phoenix-event-display/src/loaders/objects/tracks.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/tracks.ts
@@ -25,6 +25,8 @@ export class TracksMesh extends BufferGeometry {
   colors: number[];
   /** Counter. */
   counter: number[];
+  /** Linewidths. */
+  linewidths: number[];
   /** Track ID. */
   track_id: any[];
   /** Side. */
@@ -47,6 +49,7 @@ export class TracksMesh extends BufferGeometry {
     this.counter = [];
     this.track_id = [];
     this.colors = [];
+    this.linewidths = [];
     this.indices_array = [];
     this.next_track_id = 0;
   }
@@ -55,9 +58,14 @@ export class TracksMesh extends BufferGeometry {
    * Add a track to the tracks mesh.
    * @param points Points for constructing the track.
    * @param color Color of the track.
+   * @param linewidth Width of the track line.
    * @returns ID of the track.
    */
-  addTrack(points: Vector3[], color: ColorRepresentation) {
+  addTrack(
+    points: Vector3[],
+    color: ColorRepresentation,
+    linewidth: number = 1.0,
+  ) {
     const id = this.next_track_id++;
 
     const col = new Color(color);
@@ -75,6 +83,8 @@ export class TracksMesh extends BufferGeometry {
       this.track_id.push(id, id);
       this.colors.push(col.r, col.g, col.b);
       this.colors.push(col.r, col.g, col.b);
+      this.colors.push(col.r, col.g, col.b);
+      this.linewidths.push(linewidth, linewidth);
       this.counter.push(i / points.length, i / points.length);
 
       if (i < points.length - 1) {
@@ -111,6 +121,7 @@ export class TracksMesh extends BufferGeometry {
         side: new BufferAttribute(new Float32Array(this.side), 1),
         track_id: new BufferAttribute(new Int32Array(this.track_id), 1),
         color: new BufferAttribute(new Float32Array(this.colors), 3),
+        linewidth: new BufferAttribute(new Float32Array(this.linewidths), 1),
         counter: new BufferAttribute(new Float32Array(this.counter), 1),
         index: new BufferAttribute(new Uint32Array(this.indices_array), 1),
       };
@@ -139,6 +150,10 @@ export class TracksMesh extends BufferGeometry {
         new Float32Array(this.colors),
       );
       this._attributes.color.needsUpdate = true;
+      (this._attributes.linewidth as BufferAttribute).copyArray(
+        new Float32Array(this.linewidths),
+      );
+      this._attributes.linewidth.needsUpdate = true;
       (this._attributes.counter as BufferAttribute).copyArray(
         new Float32Array(this.counter),
       );
@@ -155,6 +170,7 @@ export class TracksMesh extends BufferGeometry {
     this.setAttribute('side', this._attributes.side);
     this.setAttribute('track_id', this._attributes.track_id);
     this.setAttribute('color', this._attributes.color);
+    this.setAttribute('linewidth', this._attributes.linewidth);
     this.setAttribute('counter', this._attributes.counter);
 
     this.setIndex(this._attributes.index as BufferAttribute);
@@ -171,6 +187,7 @@ const tracks_vert = [
   'attribute int track_id;',
   'attribute float side;',
   'attribute vec3 color;',
+  'attribute float linewidth;',
   'attribute float counter;',
 
   'varying vec3 v_color;',
@@ -178,7 +195,7 @@ const tracks_vert = [
   'flat varying int v_track_id;',
 
   'uniform vec2 resolution;',
-  'uniform float lineWidth;',
+  // 'uniform float lineWidth;',
   'void main() {',
   '  vec2 aspect = vec2(resolution.x / resolution.y, 1.0);',
   '',
@@ -201,7 +218,7 @@ const tracks_vert = [
   '  else dir = normalize(curP - prevP);',
   '',
   '  vec2 normal = vec2(-dir.y, dir.x);',
-  '  normal.xy *= .5 * lineWidth;',
+  '  normal.xy *= .5 * linewidth;',
   '  normal.x /= aspect.x;',
   '  normal.xy *= finalPosition.w * 0.001;',
 
@@ -242,7 +259,7 @@ export class TracksMaterial extends ShaderMaterial {
       uniforms: Object.assign(
         {},
         {
-          lineWidth: { value: 1 },
+          // lineWidth: { value: 1 },
           resolution: { value: new Vector2(1, 1) },
           progress: { value: 1 },
         },
@@ -253,15 +270,15 @@ export class TracksMaterial extends ShaderMaterial {
     this.isTracksMaterial = true;
 
     Object.defineProperties(this, {
-      lineWidth: {
-        enumerable: true,
-        get: function () {
-          return this.uniforms.lineWidth.value;
-        },
-        set: function (value) {
-          this.uniforms.lineWidth.value = value;
-        },
-      },
+      // lineWidth: {
+      //   enumerable: true,
+      //   get: function () {
+      //     return this.uniforms.lineWidth.value;
+      //   },
+      //   set: function (value) {
+      //     this.uniforms.lineWidth.value = value;
+      //   },
+      // },
       resolution: {
         enumerable: true,
         get: function () {

--- a/packages/phoenix-event-display/src/tests/loaders/objects/tracks.test.ts
+++ b/packages/phoenix-event-display/src/tests/loaders/objects/tracks.test.ts
@@ -1,0 +1,44 @@
+import { Vector3, Color } from 'three';
+import { TracksMesh } from '../../../loaders/objects/tracks';
+
+describe('TracksMesh', () => {
+  let tracksMesh: TracksMesh;
+
+  beforeEach(() => {
+    tracksMesh = new TracksMesh();
+  });
+
+  it('should create an instance', () => {
+    expect(tracksMesh).toBeTruthy();
+  });
+
+  it('should add a track with default linewidth', () => {
+    const points = [new Vector3(0, 0, 0), new Vector3(1, 0, 0)];
+    const color = new Color(0xff0000);
+    tracksMesh.addTrack(points, color);
+    tracksMesh.process();
+
+    const linewidthAttribute = tracksMesh.getAttribute('linewidth');
+    expect(linewidthAttribute).toBeTruthy();
+    // 2 points * 2 vertices per point = 4 vertices
+    expect(linewidthAttribute.count).toBe(4);
+    for (let i = 0; i < linewidthAttribute.count; i++) {
+      expect(linewidthAttribute.getX(i)).toBe(1.0);
+    }
+  });
+
+  it('should add a track with custom linewidth', () => {
+    const points = [new Vector3(0, 0, 0), new Vector3(1, 0, 0)];
+    const color = new Color(0xff0000);
+    const linewidth = 5.0;
+    tracksMesh.addTrack(points, color, linewidth);
+    tracksMesh.process();
+
+    const linewidthAttribute = tracksMesh.getAttribute('linewidth');
+    expect(linewidthAttribute).toBeTruthy();
+    expect(linewidthAttribute.count).toBe(4);
+    for (let i = 0; i < linewidthAttribute.count; i++) {
+      expect(linewidthAttribute.getX(i)).toBe(linewidth);
+    }
+  });
+});


### PR DESCRIPTION
The idea is that this replaces #747, where the git history has got a bit complicated.

All I did was make a new branch from `main` then cherry-picked  joyy-7921@6bf74553cbec0f9b952483e251c2cd1d8d0d85fd

Original description follows.
---

### Description
Modified [TracksMesh](cci:2://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/objects/tracks.ts:14:0-180:1) to support a `linewidth` attribute per track, allowing for variable line widths as set by [JiveXMLLoader](cci:2://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/jivexml-loader.ts:6:0-1093:1).

### Changes
**packages/phoenix-event-display**
- [tracks.ts](cci:7://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/objects/tracks.ts:0:0-0:0):
  - Added `linewidths` array to [TracksMesh](cci:2://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/objects/tracks.ts:14:0-180:1).
  - Updated [addTrack](cci:1://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/objects/tracks.ts:56:2-106:3) to accept `linewidth` and store it.
  - Updated [process](cci:1://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/objects/tracks.ts:108:2-179:3) to create a `linewidth` BufferAttribute.
  - Updated `tracks_vert` shader to use `attribute float linewidth` instead of `uniform`.
- [phoenix-objects.ts](cci:7://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts:0:0-0:0):
  - Updated [getTracks](cci:1://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts:37:2-96:3) to pass `track.linewidth` to `tracksMesh.addTrack`.

### Verification Results
**Automated Tests**
- Ran existing tests in [phoenix-objects.test.ts](cci:7://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/tests/loaders/objects/phoenix-objects.test.ts:0:0-0:0): **PASSED**
- Created and ran new tests in [tracks.test.ts](cci:7://file:///home/joy-vardhan-yalla/phoenix-1/packages/phoenix-event-display/src/tests/loaders/objects/tracks.test.ts:0:0-0:0): **PASSED**

```bash
yarn workspace phoenix-event-display test src/tests/loaders/objects/tracks.test.ts
```