### PR TITLE
docs: start clean Angular 20 upgrade tracking

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -13,26 +13,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build Docker image
-      run: docker build -t phoenix-app .
+      - name: Build Docker image
+        run: docker build -t phoenix-app .
 
-    - name: Run Docker container
-      run: |
-        docker run -d --name phoenix-container -p 3000:80 phoenix-app
-        sleep 10  # Give some time for the container to start
+      - name: Run Docker container
+        run: |
+          docker run -d --name phoenix-container -p 3000:80 phoenix-app
+          sleep 10  # Give some time for the container to start
 
-    - name: Smoke test
-      run: |
-        # Example smoke test using curl
-        curl --fail http://localhost:3000/ || (docker logs phoenix-container && exit 1)
+      - name: Smoke test
+        run: |
+          # Example smoke test using curl
+          curl --fail http://localhost:3000/ || (docker logs phoenix-container && exit 1)
 
-    - name: Cleanup
-      run: |
-        docker stop phoenix-container
-        docker rm phoenix-container
+      - name: Cleanup
+        run: |
+          docker stop phoenix-container
+          docker rm phoenix-container

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,14 +2,14 @@ nodeLinker: node-modules
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
 
 yarnPath: .yarn/releases/yarn-3.3.1.cjs
 
 checksumBehavior: update
 
 packageExtensions:
-  "jsroot@*":
+  'jsroot@*':
     dependencies:
-      jspdf: "*"
-      svg2pdf.js: "*"
+      jspdf: '*'
+      svg2pdf.js: '*'

--- a/ANGULAR_20_UPGRADE.md
+++ b/ANGULAR_20_UPGRADE.md
@@ -1,0 +1,11 @@
+# Angular 20 Upgrade (Clean Restart)
+
+This branch restarts the Angular 20 upgrade from a clean `main` base.
+
+Initial state:
+- No functional changes yet
+- This PR is opened to track progress and discussion
+
+Next steps:
+- Incremental Angular 20 upgrade
+- Fix CI issues as they arise

--- a/ANGULAR_20_UPGRADE.md
+++ b/ANGULAR_20_UPGRADE.md
@@ -3,10 +3,12 @@
 This PR tracks a clean restart of the Angular 20 upgrade.
 
 ## Initial state
+
 - No functional changes yet
 - This PR exists to track progress and discussion
 
 ## Plan
+
 - Incrementally upgrade Angular dependencies
 - Fix CI issues as they arise
 - Keep commits small and reviewable

--- a/ANGULAR_20_UPGRADE.md
+++ b/ANGULAR_20_UPGRADE.md
@@ -1,11 +1,12 @@
 # Angular 20 Upgrade (Clean Restart)
 
-This branch restarts the Angular 20 upgrade from a clean `main` base.
+This PR tracks a clean restart of the Angular 20 upgrade.
 
-Initial state:
+## Initial state
 - No functional changes yet
-- This PR is opened to track progress and discussion
+- This PR exists to track progress and discussion
 
-Next steps:
-- Incremental Angular 20 upgrade
+## Plan
+- Incrementally upgrade Angular dependencies
 - Fix CI issues as they arise
+- Keep commits small and reviewable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,17 @@ yarn lint:fix
 If you're using Visual Studio Code, you can also add the [prettier plugin](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and then choose 'Format Document' with this linting tool.
 
 ### Running linters against staged git files
-We use [lint-staged](https://github.com/okonet/lint-staged) to make sure we are not committing the usually unwanted linting error on the CI and it helps us to focus on the actual problem if we see a failed CI output. It runs our linters everytime we do a `git commit` and automatically fixes any linting errors it sees inside the project. 
+
+We use [lint-staged](https://github.com/okonet/lint-staged) to make sure we are not committing the usually unwanted linting error on the CI and it helps us to focus on the actual problem if we see a failed CI output. It runs our linters everytime we do a `git commit` and automatically fixes any linting errors it sees inside the project.
 
 ### CI tests
+
 We make use of continuous integration (CI) tests for each code change. You can (and should!) run this locally on PRs:
+
 ```sh
 yarn test:ci
 ```
+
 Please see the [relevant part](./guides/developers/test-setup.md) of the [Developer guide](./guides/developers#readme) for more information e.g. how to fix common problems.
 
 ## 3. Commit messages

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ You can see the stable version at [https://hepsoftwarefoundation.org/phoenix](ht
 
 ## Packages
 
-* [`phoenix-event-display`](./packages/phoenix-event-display/)  
+- [`phoenix-event-display`](./packages/phoenix-event-display/)  
   Phoenix event display framework
-* [`phoenix-ng`](./packages/phoenix-ng/)  
+- [`phoenix-ng`](./packages/phoenix-ng/)  
   Phoenix Angular application
 
 ## Development
 
 For running both the event display and the Angular app, you will need [Node.js](https://nodejs.org/en/download/) and Yarn.
 
-* **N.B.** There seems to be a problem with node v21 and ARM devices. See [here](https://github.com/HSF/phoenix/issues/627) for more details.
+- **N.B.** There seems to be a problem with node v21 and ARM devices. See [here](https://github.com/HSF/phoenix/issues/627) for more details.
 
 Once you have Node.js and npm (npm comes with the Node.js), install `corepack`
 (see [Yarn installation instructions](https://yarnpkg.com/getting-started/install))
@@ -84,32 +84,36 @@ Access the app by navigating to [`http://localhost`](http://localhost) on the br
 
 ## Documentation
 
-* [User manual](./guides/users.md)
-* [Developer guide](./guides/developers#readme)
-* [How to contribute](./CONTRIBUTING.md)
-* [API docs](https://hepsoftwarefoundation.org/phoenix/api-docs/)
+- [User manual](./guides/users.md)
+- [Developer guide](./guides/developers#readme)
+- [How to contribute](./CONTRIBUTING.md)
+- [API docs](https://hepsoftwarefoundation.org/phoenix/api-docs/)
 
 ## Phoenix presentations and publications
 
-* Phoenix was presented at the 2020 [HSF/WLCG virtual workshop](https://indico.cern.ch/event/941278/contributions/4084836/) and the presentation can be watched on [YouTube](https://www.youtube.com/watch?v=aFvlf9TpyEc&t=347s)
-* Phoenix was shown at CHEP 2021 ([abstract](https://www.epj-conferences.org/articles/epjconf/pdf/2021/05/epjconf_chep2021_01007.pdf)).
+- Phoenix was presented at the 2020 [HSF/WLCG virtual workshop](https://indico.cern.ch/event/941278/contributions/4084836/) and the presentation can be watched on [YouTube](https://www.youtube.com/watch?v=aFvlf9TpyEc&t=347s)
+- Phoenix was shown at CHEP 2021 ([abstract](https://www.epj-conferences.org/articles/epjconf/pdf/2021/05/epjconf_chep2021_01007.pdf)).
 
 ## Examples of Phoenix in use
 
 ### ATLAS
+
 [PhoenixATLAS](https://github.com/ATLAS-experiment/PhoenixATLAS) is the official web event display of the [ATLAS experiment](https://atlas.cern). It can be used to visualise different versions of ATLAS Geometry, and uploaded events.
 
 ATLAS has also used it for embedded events in Physics briefings, e.g. [Heavyweight champions: a search for new heavy W' bosons with the ATLAS detector](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwi5vtnp8Yr8AhWw9LsIHeSPBRoQFnoECCAQAQ&url=https%3A%2F%2Fatlas.cern%2Fupdates%2Fbriefing%2Fsearch-heavy-W-bosons&usg=AOvVaw3RpPlPkM5i4gdk2S27cX-C)
 
 ### FCC
+
 Phoenix is also used by [Future Circular Collider](https://fcc.web.cern.ch), see [here](https://fccsw.web.cern.ch/fccsw/phoenix/).
 
 ### LHCb
+
 Phoenix is also used by [LHCb](http://lhcb.web.cern.ch), see [here](https://lhcb-eventdisplay.web.cern.ch/)
 
 ### Belle II
+
 Phoenix is also used by [Belle II](https://www.belle2.org), see [here](https://display.belle2.org/)
 
-
 ## Contact
+
 The best way to contact us is to either open an issue in GitHub, start a [discussion](https://github.com/HSF/phoenix/discussions) or talk to us on our [gitter channel](https://gitter.im/phoenix-developers/community) (though this is not used as much these days).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,48 +1,52 @@
-import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import prettier from "eslint-plugin-prettier";
-import tsParser from "@typescript-eslint/parser";
-import { includeIgnoreFile } from "@eslint/compat";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import prettier from 'eslint-plugin-prettier';
+import tsParser from '@typescript-eslint/parser';
+import { includeIgnoreFile } from '@eslint/compat';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import js from '@eslint/js';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
-const gitignorePath = path.resolve(__dirname, ".gitignore");
-
+const gitignorePath = path.resolve(__dirname, '.gitignore');
 
 export default [
-    includeIgnoreFile(gitignorePath),
-    ...compat.extends(
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended",
-    "prettier",
-), {
+  includeIgnoreFile(gitignorePath),
+  ...compat.extends(
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+    'prettier',
+  ),
+  {
     plugins: {
-        "@typescript-eslint": typescriptEslint,
-        prettier,
+      '@typescript-eslint': typescriptEslint,
+      prettier,
     },
     languageOptions: {
-        parser: tsParser,
+      parser: tsParser,
     },
 
     rules: {
-        "prettier/prettier": ["error", {
-            endOfLine: "auto",
-        }],
+      'prettier/prettier': [
+        'error',
+        {
+          endOfLine: 'auto',
+        },
+      ],
 
-        "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-inferrable-types": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/no-this-alias": "off",
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-inferrable-types': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-this-alias': 'off',
     },
-}];
+  },
+];

--- a/guides/developers/README.md
+++ b/guides/developers/README.md
@@ -2,25 +2,25 @@
 
 ## Packages
 
-* [Phoenix event display API](../../packages/phoenix-event-display#readme)
-* [Phoenix application (Angular)](../../packages/phoenix-ng#readme)
+- [Phoenix event display API](../../packages/phoenix-event-display#readme)
+- [Phoenix application (Angular)](../../packages/phoenix-ng#readme)
 
 ## Guides
 
-* [Contribution guidelines](../../CONTRIBUTING.md)
-* [Set up Phoenix for an experiment](./set-up-phoenix.md)
-* [Phoenix event display](./event-display.md)
-* [Event data format](./event_data_format.md)
-* [Event data loader](./event-data-loader.md)
-* [Using JSROOT](./using-jsroot.md)
-* [Running with XR (AR/VR) support](./running-with-xr-support.md)
-* [Convert GDML/ROOT Geometry to GLTF](./convert-gdml-to-gltf.md)
-* [Geometry tips and tricks](./geometry-tips.md)
-* [How to make a Phoenix release](./../release.md)
-* [How Phoenix tests work](./test-setup.md)
+- [Contribution guidelines](../../CONTRIBUTING.md)
+- [Set up Phoenix for an experiment](./set-up-phoenix.md)
+- [Phoenix event display](./event-display.md)
+- [Event data format](./event_data_format.md)
+- [Event data loader](./event-data-loader.md)
+- [Using JSROOT](./using-jsroot.md)
+- [Running with XR (AR/VR) support](./running-with-xr-support.md)
+- [Convert GDML/ROOT Geometry to GLTF](./convert-gdml-to-gltf.md)
+- [Geometry tips and tricks](./geometry-tips.md)
+- [How to make a Phoenix release](./../release.md)
+- [How Phoenix tests work](./test-setup.md)
 
 ## Phoenix architecture
 
 This is an overall model of the architecture of Phoenix. We will try to keep it up to date, but beware that some things may not be completely current.
 
-![Architecture model](../images/architecture.svg "Phoenix architecture")
+![Architecture model](../images/architecture.svg 'Phoenix architecture')

--- a/guides/developers/convert-gdml-to-gltf.md
+++ b/guides/developers/convert-gdml-to-gltf.md
@@ -3,40 +3,40 @@
 Phoenix does not support GDML or ROOT geometry natively. However these can be converted easily to GLTF format supported by Phoenix.
 The idea is to convert GDML to ROOT first if needed and then ROOT to GLTF using the dedicated [Root to GLTF exported](https://github.com/HSF/root_cern-To_gltf-Exporter)
 
-## Convert GDML to ROOT 
+## Convert GDML to ROOT
 
-Root is a C++ Data Analysis Framework. One needs to install it first locally by heading into Root's 👉 [Documentation](https://root.cern/install/) and following the steps listed over there. 
+Root is a C++ Data Analysis Framework. One needs to install it first locally by heading into Root's 👉 [Documentation](https://root.cern/install/) and following the steps listed over there.
 
 Once that is done, one can write a simple C++ function to convert the GDML geometry into ROOT format :
 
 ```c++
-void gdml_to_root_export() 
+void gdml_to_root_export()
 {
     // Loading the library and geometry
     gSystem->Load("libGeom");
     TGeoManager::Import("./path_of_your_gdml_file.gdml");
-    gGeoManager->SetVisLevel(4); /// the number here can be changed based on the depth of the visibility level of your gdml file and the detail that you want to visualize it. 
+    gGeoManager->SetVisLevel(4); /// the number here can be changed based on the depth of the visibility level of your gdml file and the detail that you want to visualize it.
 
     // Export the geometry
     gGeoManager->Export("filename.root");
 }
 ```
 
-> Keep in mind that in order for the above function to work, you should have installed the C++ ROOT Framework on your machine. 
+> Keep in mind that in order for the above function to work, you should have installed the C++ ROOT Framework on your machine.
 
-Compiling and running the above code should result in outputting the .root file from your .gdml input. 
+Compiling and running the above code should result in outputting the .root file from your .gdml input.
 
-> Verify that the .root file is extracted properly. 
+> Verify that the .root file is extracted properly.
 
 One can visualize the .root file itself to be sure that it was extracted properly. Just load it in the [ROOT geometry display](https://root.cern/js/latest/), right click on the top level node and Draw all.
-
 
 ## Concert ROOT to GLTF
 
 [Root to GLTF exported](https://github.com/HSF/root_cern-To_gltf-Exporter) is the tool to use here. Documentation is provided in the project README.
 
 The tool allows to :
-  * convert your geometry to GLTF
-  * simplify your geometry by dropping parts/details you do not want to keep
-  * split your geometry into subparts and map them to entries in the phoenix menu
-  * set the default visibility and transparency of each part
+
+- convert your geometry to GLTF
+- simplify your geometry by dropping parts/details you do not want to keep
+- split your geometry into subparts and map them to entries in the phoenix menu
+- set the default visibility and transparency of each part

--- a/guides/developers/event-data-loader.md
+++ b/guides/developers/event-data-loader.md
@@ -1,11 +1,11 @@
 # Event data loader
 
-* [Introduction](#introduction)
-* [Example loaders](#example-loaders)
-* [Creating a custom event data loader](#creating-a-custom-event-data-loader)
-  * [Handling new physics objects](#handling-new-physics-objects)
-  * [Coding a custom loader](#coding-a-custom-loader)
-  * [Using the custom loader](#using-the-custom-loader)
+- [Introduction](#introduction)
+- [Example loaders](#example-loaders)
+- [Creating a custom event data loader](#creating-a-custom-event-data-loader)
+  - [Handling new physics objects](#handling-new-physics-objects)
+  - [Coding a custom loader](#coding-a-custom-loader)
+  - [Using the custom loader](#using-the-custom-loader)
 
 ## Introduction
 
@@ -17,10 +17,10 @@ The [`EventDataLoader`](../../packages/phoenix-event-display/src/loaders/event-d
 
 ## Example loaders
 
-* [`PhoenixLoader`](../../packages/phoenix-event-display/src/loaders/phoenix-loader.ts)
-* Extended from `PhoenixLoader`
-  * [`JiveXMLLoader`](../../packages/phoenix-event-display/src/loaders/jivexml-loader.ts)
-  * [`CMSLoader`](../../packages/phoenix-event-display/src/loaders/cms-loader.ts)
+- [`PhoenixLoader`](../../packages/phoenix-event-display/src/loaders/phoenix-loader.ts)
+- Extended from `PhoenixLoader`
+  - [`JiveXMLLoader`](../../packages/phoenix-event-display/src/loaders/jivexml-loader.ts)
+  - [`CMSLoader`](../../packages/phoenix-event-display/src/loaders/cms-loader.ts)
 
 ## Creating a custom event data loader
 
@@ -35,14 +35,14 @@ For constructing physics object(s) currently not a part of [`PhoenixObjects`](..
 Currently supported physics objects are:
 
 1. [`PhoenixObjects`](../../packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts) (processed and loaded through `PhoenixLoader`)
-    1. Tracks
-    1. Jets
-    1. Hits
-    1. CaloClusters
-    1. Muons
-    1. Vertices
+   1. Tracks
+   1. Jets
+   1. Hits
+   1. CaloClusters
+   1. Muons
+   1. Vertices
 1. [`CMSObjects`](../../packages/phoenix-event-display/src/loaders/objects/cms-objects.ts) (processed and loaded through `CMSLoader`)
-    1. MuonChambers
+   1. MuonChambers
 
 The following code defines a mechanism to contruct a custom object which is later sent to the event display by the custom loader in the next section.
 
@@ -55,7 +55,9 @@ export class CustomObjects {
   /**
    * Get the 3D custom object contructed from the given parameters.
    */
-  public static getCustomPhysicsObject(customPhysicsObjectParams: any): Object3D {
+  public static getCustomPhysicsObject(
+    customPhysicsObjectParams: any,
+  ): Object3D {
     let customObject: Object3D;
 
     // Logic to construct the 3D object from the given parameters
@@ -120,7 +122,7 @@ export class CustomLoader extends PhoenixLoader {
       this.addObjectType(
         eventData.CustomPhysicsObject,
         CustomObjects.getCustomPhysicsObject,
-        'CustomPhysicsObject'
+        'CustomPhysicsObject',
       );
     }
   }
@@ -160,8 +162,8 @@ const customLoader = new CustomLoader();
 // Specify the configuration and use your custom loader as the event data loader
 const configuration = {
   elementId: '<wrapper_element_id>',
-  eventDataLoader: customLoader
-}
+  eventDataLoader: customLoader,
+};
 
 // Create the event display
 const eventDisplay = new EventDisplay(configuration);
@@ -170,13 +172,11 @@ const eventDisplay = new EventDisplay(configuration);
 fetch('path/to/your/event/file.custom')
   .then((res) => res.text())
   .then((rawEventData) => {
-
     // Set the raw event data in the custom loader
     customLoader.setRawEventData(rawEventData);
     // Process the raw event data and get it in Phoenix format
     const eventData = customLoader.getEventData();
     // Process the converted event data and display it
     eventDisplay.buildEventDataFromJSON(eventData);
-
   });
 ```

--- a/guides/developers/event-display.md
+++ b/guides/developers/event-display.md
@@ -1,13 +1,13 @@
 # Phoenix event display
 
-* [Introduction](#introduction)
-* [Modularity and architectural overview](#modularity-and-architectural-overview)
-* [`ThreeManager`](#threemanager)
-* [`UIManager`](#uimanager)
-  * [`PhoenixUI`](#phoenixui)
-  * [`PhoenixMenuNode`](#phoenixmenunode)
-* [Miscellaneous managers](#miscellaneous-managers)
-* [Event data loaders](#event-data-loaders)
+- [Introduction](#introduction)
+- [Modularity and architectural overview](#modularity-and-architectural-overview)
+- [`ThreeManager`](#threemanager)
+- [`UIManager`](#uimanager)
+  - [`PhoenixUI`](#phoenixui)
+  - [`PhoenixMenuNode`](#phoenixmenunode)
+- [Miscellaneous managers](#miscellaneous-managers)
+- [Event data loaders](#event-data-loaders)
 
 ## Introduction
 
@@ -28,29 +28,29 @@ The `ThreeManager` is responsible for performing all `three.js` related function
 
 Here is a list of sub managers of `ThreeManager`:
 
-* [**`AnimationsManager`**](../../packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts)  
+- [**`AnimationsManager`**](../../packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts)  
   Responsible for animation related operations. For example, animating the camera through the event.
-* [**`ColorManager`**](../../packages/phoenix-event-display/src/managers/three-manager/color-manager.ts)  
+- [**`ColorManager`**](../../packages/phoenix-event-display/src/managers/three-manager/color-manager.ts)  
   Provides functionality for managing coloring of objects in the scene.
-* [**`ControlsManager`**](../../packages/phoenix-event-display/src/managers/three-manager/controls-manager.ts)  
+- [**`ControlsManager`**](../../packages/phoenix-event-display/src/managers/three-manager/controls-manager.ts)  
   Manages all controls related functionality which includes the camera, orbit controls and zoom controls.
-* [**`EffectsManager`**](../../packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts)  
+- [**`EffectsManager`**](../../packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts)  
   Used for managing event display effects like the outline pass for selected object.
-* [**`ExportManager`**](../../packages/phoenix-event-display/src/managers/three-manager/export-manager.ts)  
+- [**`ExportManager`**](../../packages/phoenix-event-display/src/managers/three-manager/export-manager.ts)  
   Manages export related functions like exporting the event display to an `.obj` file or to the `.phnx` (Phoenix scene) file.
-* [**`ImportManager`**](../../packages/phoenix-event-display/src/managers/three-manager/import-manager.ts)  
+- [**`ImportManager`**](../../packages/phoenix-event-display/src/managers/three-manager/import-manager.ts)  
   Manages import related functions like importing different types of 3D geometries (`.gltf`, `.root`, `.obj`, etc.) or event data (`.json`, `.xml`, etc.).
-* [**`RendererManager`**](../../packages/phoenix-event-display/src/managers/three-manager/renderer-manager.ts)  
+- [**`RendererManager`**](../../packages/phoenix-event-display/src/managers/three-manager/renderer-manager.ts)  
   Manages `three.js` renderers used by Phoenix including both the main and overlay renderer (used in the overlay view).
-* [**`SceneManager`**](../../packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts)  
+- [**`SceneManager`**](../../packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts)  
   Used to manage `three.js` scene related operations like traversing through the scene, applying color or opacity to 3D objects, managing scene lights, etc.
-* [**`SelectionManager`**](../../packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts)  
+- [**`SelectionManager`**](../../packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts)  
   Manages selection functionality of the event display like applying outline pass to a selected object or getting selected object info for the object selection overlay.
-* [**`XRManager`**](../../packages/phoenix-event-display/src/managers/three-manager/xr/xr-manager.ts)  
+- [**`XRManager`**](../../packages/phoenix-event-display/src/managers/three-manager/xr/xr-manager.ts)  
   Provides common functionality of AR/VR like setting up the session and XR camera.
-  * [**`ARManager`**](../../packages/phoenix-event-display/src/managers/three-manager/xr/ar-manager.ts)  
+  - [**`ARManager`**](../../packages/phoenix-event-display/src/managers/three-manager/xr/ar-manager.ts)  
     Extended from `XRManager`. Used to manage AR related functions like starting an AR session and showing overlay in AR mode.
-  * [**`VRManager`**](../../packages/phoenix-event-display/src/managers/three-manager/xr/vr-manager.ts)  
+  - [**`VRManager`**](../../packages/phoenix-event-display/src/managers/three-manager/xr/vr-manager.ts)  
     Extended from `XRManager`. Used to manage VR related functions like setting up VR controls and movement.
 
 Currently the sub managers are not big enough to be divided into multiple parts. However, if at some point their code gets large, it should be further divided.
@@ -61,22 +61,22 @@ The `UIManager` is responsible for all the UI aspects of the `EventDisplay`. Thi
 
 It takes care of tasks like:
 
-* Adding configuration options to Phoenix UI on loading geometry or event data.
-* Setting the UI color theme to dark or light.
-* Applying clipping to geometries.
-* Linking UI menu options with the `EventDisplay`.
-* Configuring different color options for event data.
-* etc.
+- Adding configuration options to Phoenix UI on loading geometry or event data.
+- Setting the UI color theme to dark or light.
+- Applying clipping to geometries.
+- Linking UI menu options with the `EventDisplay`.
+- Configuring different color options for event data.
+- etc.
 
 It also has [**`ColorOptions`**](../../packages/phoenix-event-display/src/managers/ui-manager/color-options.ts) which contains logic to color event data.
 
-### [`PhoenixUI`](../../packages/phoenix-event-display/src/managers/ui-manager/phoenix-ui.ts)  
+### [`PhoenixUI`](../../packages/phoenix-event-display/src/managers/ui-manager/phoenix-ui.ts)
 
 `PhoenixUI` is used as a common interface for implementing UI menus in Phoenix. It currently has the following implementations:
 
-* [**`DatGUIMenuUI`**](../../packages/phoenix-event-display/src/managers/ui-manager/dat-gui-ui.ts)
+- [**`DatGUIMenuUI`**](../../packages/phoenix-event-display/src/managers/ui-manager/dat-gui-ui.ts)
   Contains functions for setting up all the options in dat.GUI menu.
-* [**`PhoenixMenuUI`**](../../packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts)  
+- [**`PhoenixMenuUI`**](../../packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts)  
   Contains functions for setting up all the options in Phoenix menu.
 
 ### [`PhoenixMenuNode`](../../packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts)
@@ -86,22 +86,22 @@ It is designed to be adaptable to custom UIs. This class can be used to create a
 
 For an overview, it contains functions for:
 
-* Adding children (of the same `PhoenixMenuNode` type) to a node.
-* Adding custom configuration of different types (like `checkbox`, `slider`, `button`, `label`, etc.) to a node.
-* Getting and loading the state of a node.
-* Removing a single child node, current node, or all child nodes.  
-* Finding a node in tree by name, or create one if not found.
-* etc.  
+- Adding children (of the same `PhoenixMenuNode` type) to a node.
+- Adding custom configuration of different types (like `checkbox`, `slider`, `button`, `label`, etc.) to a node.
+- Getting and loading the state of a node.
+- Removing a single child node, current node, or all child nodes.
+- Finding a node in tree by name, or create one if not found.
+- etc.
 
 ## Miscellaneous managers
 
 These are some independent managers not part of the `ThreeManager` or `UIManager` but used inside the `EventDisplay`.
 
-* [**`LoadingManager`**](../../packages/phoenix-event-display/src/managers/loading-manager.ts)  
+- [**`LoadingManager`**](../../packages/phoenix-event-display/src/managers/loading-manager.ts)  
   Maintains a list of loadable items with addable callbacks that are called when the loading of an item completes.
-* [**`StateManager`**](../../packages/phoenix-event-display/src/managers/state-manager.ts)  
+- [**`StateManager`**](../../packages/phoenix-event-display/src/managers/state-manager.ts)  
   Manages the state of the `EventDisplay` including the Phoenix menu state, camera state and clipping state. The state can be saved to a file and loaded later.
-* [**`URLOptionsManager`**](../../packages/phoenix-event-display/src/managers/url-options-manager.ts)  
+- [**`URLOptionsManager`**](../../packages/phoenix-event-display/src/managers/url-options-manager.ts)  
   Manages `EventDisplay` options available through the URL like loading an event through the URL (`file` & `type`) or hiding overlay widgets (`hideWidgets`).
 
 ## Event data loaders

--- a/guides/developers/event_data_format.md
+++ b/guides/developers/event_data_format.md
@@ -1,9 +1,8 @@
 # Event Data Format
 
-Phoenix internally makes use of a JSON format to represent event data. The JSON format is designed to be human-readable, but still compact. 
+Phoenix internally makes use of a JSON format to represent event data. The JSON format is designed to be human-readable, but still compact.
 
 There is a [event_file_checker.py](https://github.com/HSF/phoenix-helpers/blob/main/checkers/event_file_checker.py) validation script provided in the [phoenix-helpers](https://github.com/HSF/phoenix-helpers) repository.
-
 
 ### Event data
 
@@ -22,7 +21,7 @@ The format is the following.
 }
 ```
 
-`EVENT_KEY` is an identifier for each event (it could be a number, or a descriptive string e.g. 'HWW example'), and the format of each `event_object` would be as follows: 
+`EVENT_KEY` is an identifier for each event (it could be a number, or a descriptive string e.g. 'HWW example'), and the format of each `event_object` would be as follows:
 
 ```js
 {
@@ -41,36 +40,34 @@ The format is the following.
 
 Where:
 
-* `event number` and `run number` are hopefully obvious,
-* `OBJECT_TYPE` is one of the supported types that will be mentioned [below](#supported-object-types),
-* `COLLECTION_NAME` is an arbitrary name used to label this particular collection (you can have as many collections of each `OBJECT_TYPE` as you like).
-* `...` can be any other optional key/value pairs. Phoenix understands by default the following keys which will be used in the event Metadata panel, valuse being free strings :
-  * `ls` will be printed for `LS` entry
-  * `lumiblock` will be printed for `LumiBlock` entry
-  * `time` : will be printed for `Data recorded` entry
-  
+- `event number` and `run number` are hopefully obvious,
+- `OBJECT_TYPE` is one of the supported types that will be mentioned [below](#supported-object-types),
+- `COLLECTION_NAME` is an arbitrary name used to label this particular collection (you can have as many collections of each `OBJECT_TYPE` as you like).
+- `...` can be any other optional key/value pairs. Phoenix understands by default the following keys which will be used in the event Metadata panel, valuse being free strings :
+  - `ls` will be printed for `LS` entry
+  - `lumiblock` will be printed for `LumiBlock` entry
+  - `time` : will be printed for `Data recorded` entry
 
 You can find various examples in the [files folder](../../docs/assets/files):
 
-* [atlas.json](../../docs/assets/files/event_data/ATLAS_calibration.json) is an ATLAS Calibration file containing a single event.
-* [LHCbEventData.json](../../docs/assets/files/lhcb/LHCbEventData.json) is a large file containing LHCb simulated events.
-
+- [atlas.json](../../docs/assets/files/event_data/ATLAS_calibration.json) is an ATLAS Calibration file containing a single event.
+- [LHCbEventData.json](../../docs/assets/files/lhcb/LHCbEventData.json) is a large file containing LHCb simulated events.
 
 #### Supported object types
 
 Currently Phoenix supports the following physics objects:
 
-* Tracks - the trajectory of a charged particle (usually in a magnetic field)
-* Jets - cones of activity within the detector
-* Hits - individual measurements, which can either be points, lines, or boxes
-* CaloClusters - cluters of deposits in a calorimeter
-* [Planar]CaloCells - deposits of energy in a calorimeter (planar and cylindrical are supported).
-* Vertices - optionally linked to tracks
-* MissingEnergy
-* Compound objects which link 'Tracks' and 'Clusters' :
-  * Muons 
-  * Photons
-  * Electrons
+- Tracks - the trajectory of a charged particle (usually in a magnetic field)
+- Jets - cones of activity within the detector
+- Hits - individual measurements, which can either be points, lines, or boxes
+- CaloClusters - cluters of deposits in a calorimeter
+- [Planar]CaloCells - deposits of energy in a calorimeter (planar and cylindrical are supported).
+- Vertices - optionally linked to tracks
+- MissingEnergy
+- Compound objects which link 'Tracks' and 'Clusters' :
+  - Muons
+  - Photons
+  - Electrons
 
 (other shapes may be supported in the future)
 
@@ -78,63 +75,77 @@ What follows in the detailed format of each object type. Any extra entry is cons
 In all the descriptions, `opt` means that the attribute described is optional.
 
 #### 'Tracks'
+
 Tracks is a list of Track objects with the following attrbutes :
-* `pos` - list of positions along the track, each  given as a triplet [x, y, z]
-* `color` (opt) - Hexadecimal string representing the color to draw the track.
-* `dparams` (opt) - parameters of the tracks. 5 floats matching d0, z0, phi, theta, qOverP
-* `d0`, `z0`, `phi`, `eta`, `qOverP`  (opt) - parameters of the tracks, taking precedence over `dparams`
+
+- `pos` - list of positions along the track, each given as a triplet [x, y, z]
+- `color` (opt) - Hexadecimal string representing the color to draw the track.
+- `dparams` (opt) - parameters of the tracks. 5 floats matching d0, z0, phi, theta, qOverP
+- `d0`, `z0`, `phi`, `eta`, `qOverP` (opt) - parameters of the tracks, taking precedence over `dparams`
 
 #### 'Jets'
+
 Jets are a list of Jet objects with the following attributes :
-* `eta` - eta direction
-* `phi`- phi direction
-* `theta` (opt) - if not given, eta is used to calculate theta
-* `energy`, `et` (opt) - energy of the Jets, used to set its length
-* `coneR` (opt) - the radius of the jet cone. If not given, radius is 10% of the length
-* `color` (opt) - Hexadecimal string representing the color to draw the jet.
+
+- `eta` - eta direction
+- `phi`- phi direction
+- `theta` (opt) - if not given, eta is used to calculate theta
+- `energy`, `et` (opt) - energy of the Jets, used to set its length
+- `coneR` (opt) - the radius of the jet cone. If not given, radius is 10% of the length
+- `color` (opt) - Hexadecimal string representing the color to draw the jet.
 
 #### 'Hits'
+
 Hits can be defined in 2 ways. Either as an array of positions or as an array of Hit objects.
 
 In case aray of positions is used, Hits have format [ [x,y,z], [x,y,z], [x,y,z], ... ] i.e. an array of 3-dim arrays containing Cartesian coordinate.
 These will be rendered as points.
 
 In case of array of Hit objects, format is [ hit, hit, hit ] where the hit object has the following attributes :
-* `type` (opt) - type of Hit. One of `Point`, `Line` or `Box`. Defaults to Point
-* `pos` - an array of number describing the hit
-  * for `Point` type, it should have 3 coordinates : [x, y, z]
-  * for `Line` type, it should have 6 coordinates : [x0, y0, z0, x1, y1, z1]
-  * for `Box` type, it should have 6 coordinates : [x, y, z, length in x, width in y, height in z]
-* `color` (opt) - Hexadecimal string representing the color to draw the hit.
-Note that all hit objects in a given Hits collection have to be of the same type.
+
+- `type` (opt) - type of Hit. One of `Point`, `Line` or `Box`. Defaults to Point
+- `pos` - an array of number describing the hit
+  - for `Point` type, it should have 3 coordinates : [x, y, z]
+  - for `Line` type, it should have 6 coordinates : [x0, y0, z0, x1, y1, z1]
+  - for `Box` type, it should have 6 coordinates : [x, y, z, length in x, width in y, height in z]
+- `color` (opt) - Hexadecimal string representing the color to draw the hit.
+  Note that all hit objects in a given Hits collection have to be of the same type.
 
 #### 'CaloClusters' and 'CaloCells'
+
 We are talking here of cylindrical calorimeters, the deposits will be displayed as boxes with fixed square base and length matching the energy. The orientation of the boxes is radial.
 'CaloClusters' and 'CaloCells' are lists of CaloCluster and CaloCell objects respectively. These have the same set of attributes :
-* `energy` - energy of the cluster or deposit, converted to length of the displayed box
-* `phi` - phi direction
-* `eta` - eta direction
-  
+
+- `energy` - energy of the cluster or deposit, converted to length of the displayed box
+- `phi` - phi direction
+- `eta` - eta direction
+
 #### 'PlanarCaloCells'
+
 We are talking here of planar calorimeters, the deposits will be displayed as boxes with square base of cellSize and length matching the energy.
 These boxes will be positions on a given plane (the plane pf the calorimeter) at the specified coordinates in this plane.
 
 PlanarCaloCells is an object with the following attributes :
-* `plane` - the Calorimeter plane, defined as 4 numbers, giving a direction (normal to the plane) and a distance to the origin : [dx, dy, dz, length]
-* `cells` - a list of Cell objects with the following attributes:
-  * `cellSize` - size of the Calorimeter cell which fired
-  * `energy` - energy of the deposit, converted to length of the displayed box
-  * `pos` - position of the cell within the calo plane given as a pair [x, y]
-  * `color` (opt) - Hexadecimal string representing the color to draw the cell.
+
+- `plane` - the Calorimeter plane, defined as 4 numbers, giving a direction (normal to the plane) and a distance to the origin : [dx, dy, dz, length]
+- `cells` - a list of Cell objects with the following attributes:
+  - `cellSize` - size of the Calorimeter cell which fired
+  - `energy` - energy of the deposit, converted to length of the displayed box
+  - `pos` - position of the cell within the calo plane given as a pair [x, y]
+  - `color` (opt) - Hexadecimal string representing the color to draw the cell.
 
 #### 'Vertices
+
 'Vertices are a list of Vertex objects with the following attributes :
-* `color` (opt) - Hexadecimal string representing the color to draw the vertex.
-* one of the 2 following sets of attributes 
-  * `x`, `y`, `z` : describing the position of the vertex
-  * `pos` : array of 3 numbers (x, y, z) describing the position of the vertex
+
+- `color` (opt) - Hexadecimal string representing the color to draw the vertex.
+- one of the 2 following sets of attributes
+  - `x`, `y`, `z` : describing the position of the vertex
+  - `pos` : array of 3 numbers (x, y, z) describing the position of the vertex
 
 #### MissingEnergy
+
 This is a list of objects, displayed as dashed lines starting from 0 and staying in the plane z=0. Each object has the following attributes :
-* `etx`, `ety` : describing the direction of the line
-* `color` (opt) - Hexadecimal string representing the color to draw the line.
+
+- `etx`, `ety` : describing the direction of the line
+- `color` (opt) - Hexadecimal string representing the color to draw the line.

--- a/guides/developers/geometry-tips.md
+++ b/guides/developers/geometry-tips.md
@@ -2,22 +2,23 @@
 
 This guide is intended to provide some tips on creating an experimental geometry for use within Phoenix.
 
-At the time of writing, the threejs recommended geometry format is gltf (GL Transmission Format) or glb (the binary version of gltf). See this [threejs documentation](https://threejs.org/docs/#manual/en/introduction/Loading-3D-models) for details. 
+At the time of writing, the threejs recommended geometry format is gltf (GL Transmission Format) or glb (the binary version of gltf). See this [threejs documentation](https://threejs.org/docs/#manual/en/introduction/Loading-3D-models) for details.
 
 One big advantage of gltf/glb is Phoenix can use the embedded GLTF scenes to populate the geometry menu. So rather than having a lot of separate files for the different parts of an experiment, and then adding them individually to the top level scene and UI one-by-one e.g.:
+
 ```typescript
-    this.eventDisplay.loadGLTFGeometry(
-      'assets/geometry/barrel.gltf',
-      'Barrel',
-      'Inner Detector',
-      1000
-    );
-    this.eventDisplay.loadGLTFGeometry(
-      'assets/geometry/end-cap.gltf',
-      'Endcap',
-      'Inner Detector',
-      1000
-    );
+this.eventDisplay.loadGLTFGeometry(
+  'assets/geometry/barrel.gltf',
+  'Barrel',
+  'Inner Detector',
+  1000,
+);
+this.eventDisplay.loadGLTFGeometry(
+  'assets/geometry/end-cap.gltf',
+  'Endcap',
+  'Inner Detector',
+  1000,
+);
 ```
 
 you can instead load _one_ file, and Phoenix will loop over the internal structure and create the appropriate geometry UI entries. See the LHCB interactive example for how this works in practice (specifically, [lhcb.component.ts](lhcb.component.ts) is where the geometry is loaded).
@@ -25,12 +26,15 @@ you can instead load _one_ file, and Phoenix will loop over the internal structu
 It is also discussed [here](https://github.com/HSF/phoenix/blob/main/guides/users.md#phoenix-menu-definition-in-gltf).
 
 # Creating gltf/glb content
+
 ## Blender
+
 [Blender](https://www.blender.org) is an incredibly powerful _free_ tool to create 3D content. It also has an comprehensive set of importers and exporters (including an gltf exporter, obviously) meaning you can load content from almost any format and save it as compressed glb. It also understands scenes (see the Blender [documentation](https://docs.blender.org/manual/en/latest/scene_layout/scene/introduction.html) for more), so you can load many different geometry files, put them in their own scenes and export, and then Phoenix will fill the geometry UI menu for you as described above.
 
-* **N.B.** When exporting content from Blender it is very important that you remember to [Apply](https://docs.blender.org/manual/en/latest/scene_layout/object/editing/apply.html) all transformations - otherwise you can be in the situation that your geometry looks perfect inside Blender, but is the wrong size/rotation when viewed in Phoenix.
+- **N.B.** When exporting content from Blender it is very important that you remember to [Apply](https://docs.blender.org/manual/en/latest/scene_layout/object/editing/apply.html) all transformations - otherwise you can be in the situation that your geometry looks perfect inside Blender, but is the wrong size/rotation when viewed in Phoenix.
 
 ## From ROOT or GDML
+
 Read [this guide](convert-gdml-to-gltf.md) for how to convert from gdml or ROOT to gltf.
 
 ## Converting gltf to glb
@@ -38,6 +42,7 @@ Read [this guide](convert-gdml-to-gltf.md) for how to convert from gdml or ROOT 
 Converting a gltf to glb, especially compressed glb, can lead to huge reductions in size (see [#530](https://github.com/HSF/phoenix/pull/530) for an example).
 
 The recommended way to do this is with the [gltf-pipeline](https://github.com/CesiumGS/gltf-pipeline) command line tool e.g.:
+
 ```
 gltf-pipeline -i LHCb.gltf -o LHCb.glb -d
 ```

--- a/guides/developers/set-up-phoenix.md
+++ b/guides/developers/set-up-phoenix.md
@@ -1,19 +1,19 @@
 # Set up Phoenix for an experiment
 
-* [Introduction](#introduction)
-* [Setting up an Angular app](#setting-up-an-angular-app)
-  * [Create the Angular app](#create-the-angular-app)
-  * [Set up `phoenix-ui-components`](#set-up-phoenix-ui-components)
-    * [Import `PhoenixUIModule`](#import-phoenixuimodule)
-    * [Import required styles](#import-required-styles)
-    * [Set up assets](#set-up-assets)
-* [Setting up the event display](#setting-up-the-event-display)
-  * [Create an experiment component](#create-an-experiment-component)
-  * [Set up the route](#set-up-the-route)
-* [Resolving problems](#resolving-problems)
-  * [Angular version](#angular-version) 
-  * [npm error gyp ERR](#npm-error-gyp-ERR)
-  * [ng build errors](#ng-build-errors)
+- [Introduction](#introduction)
+- [Setting up an Angular app](#setting-up-an-angular-app)
+  - [Create the Angular app](#create-the-angular-app)
+  - [Set up `phoenix-ui-components`](#set-up-phoenix-ui-components)
+    - [Import `PhoenixUIModule`](#import-phoenixuimodule)
+    - [Import required styles](#import-required-styles)
+    - [Set up assets](#set-up-assets)
+- [Setting up the event display](#setting-up-the-event-display)
+  - [Create an experiment component](#create-an-experiment-component)
+  - [Set up the route](#set-up-the-route)
+- [Resolving problems](#resolving-problems)
+  - [Angular version](#angular-version)
+  - [npm error gyp ERR](#npm-error-gyp-ERR)
+  - [ng build errors](#ng-build-errors)
 
 ## Introduction
 
@@ -55,7 +55,6 @@ Now that you have an app set up. Install the `phoenix-ui-components` package to 
 npm install phoenix-ui-components
 ```
 
-
 #### Import required styles
 
 Add the the Bootstrap stylesheet to the `src/index.html` file of your app.
@@ -64,12 +63,14 @@ Add the the Bootstrap stylesheet to the `src/index.html` file of your app.
 <head>
   ...
 
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+  <link
+    rel="stylesheet"
+    href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+  />
 </head>
 ```
 
 #### Add Phoenix Theming
-
 
 Go to the `src/styles.scss` file of your app and import the global Phoenix styles.
 
@@ -108,7 +109,10 @@ Now, open the `main-display.component.html` file and use the Phoenix UI componen
 <app-nav></app-nav>
 <!-- UI menu at the bottom -->
 <app-ui-menu></app-ui-menu>
-<app-experiment-info experiment="atlas" experimentTagline="ATLAS Experiment at CERN"></app-experiment-info>
+<app-experiment-info
+  experiment="atlas"
+  experimentTagline="ATLAS Experiment at CERN"
+></app-experiment-info>
 <!-- Phoenix menu at the top right -->
 <app-phoenix-menu [rootNode]="phoenixMenuRoot"></app-phoenix-menu>
 <div id="eventDisplay"></div>
@@ -117,43 +121,52 @@ Now, open the `main-display.component.html` file and use the Phoenix UI componen
 The `[rootNode]="phoenixMenuRoot"` specified here for the Phoenix menu will be a defined in `main-display.component.ts`.
 
 One can easily customize the app-ui-menu. There are 2 main ways :
-  - just adding buttons at the end of it by inserting the corresponding components with the `app-ui-menu` declaration :
-  ```html
-  <app-ui-menu>
-    <app-cycle-events [interval]="5000"></app-cycle-events>
-  </app-ui-menu>
-  ```
-  will add a button to cycle through events every 5s at the end of the menu bar
-  - redefine the manu bar completely using `app-ui-menu-wrapper` instead of `app-ui-menu` :
-  ```html
-  <app-ui-menu-wrapper>
-    <app-event-selector></app-event-selector>
-    <app-cycle-events [interval]="5000"></app-cycle-events>
-  </app-ui-menu-wrapper>
-  ```
-  This defines a very restricted menu with only the event selector and the event cycling button
+
+- just adding buttons at the end of it by inserting the corresponding components with the `app-ui-menu` declaration :
+
+```html
+<app-ui-menu>
+  <app-cycle-events [interval]="5000"></app-cycle-events>
+</app-ui-menu>
+```
+
+will add a button to cycle through events every 5s at the end of the menu bar
+
+- redefine the manu bar completely using `app-ui-menu-wrapper` instead of `app-ui-menu` :
+
+```html
+<app-ui-menu-wrapper>
+  <app-event-selector></app-event-selector>
+  <app-cycle-events [interval]="5000"></app-cycle-events>
+</app-ui-menu-wrapper>
+```
+
+This defines a very restricted menu with only the event selector and the event cycling button
 
 Finally, open the `main-display.component.ts` file and initialize the Phoenix event display using the intermediate Angular `EventDisplayService`.
 
 ```ts
 import { Component, OnInit } from '@angular/core';
-import {EventDisplayService, PhoenixUIModule} from 'phoenix-ui-components';
-import { Configuration, PhoenixLoader, PresetView, ClippingSetting, PhoenixMenuNode } from 'phoenix-event-display';
+import { EventDisplayService, PhoenixUIModule } from 'phoenix-ui-components';
+import {
+  Configuration,
+  PhoenixLoader,
+  PresetView,
+  ClippingSetting,
+  PhoenixMenuNode,
+} from 'phoenix-event-display';
 
 @Component({
   selector: 'app-main-display',
-  imports: [
-    PhoenixUIModule
-  ],
+  imports: [PhoenixUIModule],
   templateUrl: './main-display.component.html',
-  styleUrl: './main-display.component.scss'
+  styleUrl: './main-display.component.scss',
 })
 export class MainDisplayComponent implements OnInit {
-
   /** The root Phoenix menu node. */
-  phoenixMenuRoot = new PhoenixMenuNode("Phoenix Menu");
+  phoenixMenuRoot = new PhoenixMenuNode('Phoenix Menu');
 
-  constructor(private eventDisplay: EventDisplayService) { }
+  constructor(private eventDisplay: EventDisplayService) {}
 
   ngOnInit() {
     // Create the event display configuration
@@ -164,18 +177,26 @@ export class MainDisplayComponent implements OnInit {
         new PresetView('Left View', [0, 0, -12000], [0, 0, 0], 'left-cube'),
         new PresetView('Center View', [-500, 12000, 0], [0, 0, 0], 'top-cube'),
         // more fancy view, looking at point 0,0,5000 and with some clipping
-        new PresetView('Right View', [0, 0, 12000], [0, 0, 5000], 'right-cube', ClippingSetting.On, 90, 90)
+        new PresetView(
+          'Right View',
+          [0, 0, 12000],
+          [0, 0, 5000],
+          'right-cube',
+          ClippingSetting.On,
+          90,
+          90,
+        ),
       ],
       // default view with x, y, z of the camera and then x, y, z of the point it looks at
-      defaultView: [4000, 0, 4000, 0, 0 ,0],
+      defaultView: [4000, 0, 4000, 0, 0, 0],
       phoenixMenuRoot: this.phoenixMenuRoot,
       // Event data to load by default
       defaultEventFile: {
         // (Assuming the file exists in the `src/assets` directory of the app)
         eventFile: 'assets/jive_xml_event_data.xml',
-        eventType: 'jivexml'
+        eventType: 'jivexml',
       },
-    }
+    };
 
     // Initialize the event display
     this.eventDisplay.init(configuration);
@@ -186,8 +207,8 @@ export class MainDisplayComponent implements OnInit {
 }
 ```
 
-(!) It is assumed that you use your data and detector geometry instead of links provided in 
-`eventFile` and `loadGLTFGeometry` above. For testing purposes, you may take geometry and events at: 
+(!) It is assumed that you use your data and detector geometry instead of links provided in
+`eventFile` and `loadGLTFGeometry` above. For testing purposes, you may take geometry and events at:
 
 - [geometry examples](https://github.com/HSF/phoenix/tree/main/packages/phoenix-ng/projects/phoenix-app/src/assets/geometry)
 - [event examples](https://github.com/HSF/phoenix/tree/main/packages/phoenix-ng/projects/phoenix-app/src/assets/files)
@@ -207,17 +228,14 @@ Now, navigate to `src/app/app.routes.ts` and add the routing for the experiment 
 
 ```ts
 import { Routes } from '@angular/router';
-import {MainDisplayComponent} from "./main-display/main-display.component";
+import { MainDisplayComponent } from './main-display/main-display.component';
 
-export const routes: Routes = [
-  { path: '', component: MainDisplayComponent }
-];
+export const routes: Routes = [{ path: '', component: MainDisplayComponent }];
 ```
 
 This will serve the experiment component through the base URL `/` of the server.
 
 Finally, you can start the app with `npm start` and navigate to `http://localhost:4200` where you will see the experiment component in action.
-
 
 ## Resolving problems
 
@@ -226,22 +244,21 @@ Finally, you can start the app with `npm start` and navigate to `http://localhos
 Phoenix event display may delay the updates of the Angular framework. Your
 application should have the same version of Angular as `phoenix-ui-components` package
 
-You may check "dependencies" section of 
+You may check "dependencies" section of
 [phoenix-ui-components package.json here](https://github.com/HSF/phoenix/blob/main/packages/phoenix-ng/package.json)
-then copy the correct version to your package.json and run `npm install`. 
-
+then copy the correct version to your package.json and run `npm install`.
 
 ### npm error gyp ERR
 
-What is happening? 
+What is happening?
 One of the javascript dependencies may try to build some C++ code on your machine.
 For this it uses node-gyp, which in turn, uses your machine compiler and installed
-libraries. This may cause some errors. 
+libraries. This may cause some errors.
 
-1. On Windows, you may experience `npm error gyp ERR` 
+1. On Windows, you may experience `npm error gyp ERR`
    while trying to run ` npm install phoenix-ui-components`. In general, you need
-   to install and make available modern python version and MS C++ redistributable.   
-   The later might be installed standalone or as a bundle of VS Community edition. 
+   to install and make available modern python version and MS C++ redistributable.  
+   The later might be installed standalone or as a bundle of VS Community edition.
    [More in this SO answer](https://stackoverflow.com/questions/57879150/how-can-i-solve-error-gypgyp-errerr-find-vsfind-vs-msvs-version-not-set-from)
 
 2. On linux machines you may need libgl and gcc building tools to be installed. E.g. on ubuntu:
@@ -251,9 +268,9 @@ libraries. This may cause some errors.
 
 ### ng build errors
 
-The provided setup should work while one runs `ng serve` or its alias `npm start`. 
-There is another common command `ng build` or `npm run build` same as `npm run watch`. 
+The provided setup should work while one runs `ng serve` or its alias `npm start`.
+There is another common command `ng build` or `npm run build` same as `npm run watch`.
 The later commands my not run falling with multiple errors around `require("...")`.
-One of the options of fixing it is using custom webpack builder configuration in 
+One of the options of fixing it is using custom webpack builder configuration in
 angular.json file. You may look [here as an example](https://github.com/eic/firebird/blob/main/firebird-ng/angular.json)
 and adjust it for your project

--- a/guides/developers/test-setup.md
+++ b/guides/developers/test-setup.md
@@ -1,14 +1,14 @@
 # Test Setup in Phoenix
 
-* [Introduction](#introduction)
-* [Unit Tests in Phoenix](#unit-tests-in-phoenix)
-  * [Unit Test Syntax in Jest Example](#unit-test-syntax-in-jest-example)
-  * [Jest Configuration](#jest-configuration)
-* [E2E Tests in Phoenix](#e2e-tests-in-phoenix)
-  * [E2E Test Syntax in Cypress Example](#e2e-test-syntax-in-cypress-example)
-  * [Cypress Configuration](#cypress-configuration)
-* [Running tests locally](#running-the-tests-locally)
-* [Fixing problems](#fixing-problems)
+- [Introduction](#introduction)
+- [Unit Tests in Phoenix](#unit-tests-in-phoenix)
+  - [Unit Test Syntax in Jest Example](#unit-test-syntax-in-jest-example)
+  - [Jest Configuration](#jest-configuration)
+- [E2E Tests in Phoenix](#e2e-tests-in-phoenix)
+  - [E2E Test Syntax in Cypress Example](#e2e-test-syntax-in-cypress-example)
+  - [Cypress Configuration](#cypress-configuration)
+- [Running tests locally](#running-the-tests-locally)
+- [Fixing problems](#fixing-problems)
 
 ## Introduction
 
@@ -21,14 +21,14 @@ While writing unit tests, we make sure to follow these practices:
 1. We focus on testing the functionality of the underlying code and not on the code coverage. We believe code coverage is achieved as a by-product of writing good tests. Unit tests are not written to reach a certain code coverage percentage, they are written to test the behavior of a unit (class, function, etc). If we test the behaviors properly, we will automatically have high code coverage.
 2. We try not to duplicate implementation logic in the tests as errors may repeat if our tests mirror the implementation logic.
 3. We try to keep the tests as simple as possible and you can find them ending with the extension `.test.ts`. We try to avoid using complex logic in the tests as it may be difficult to debug and maintain.
-4. We try to keep the tests as readable as possible. We use the `it('<should work as expected>', () => {})` syntax to write the description of a test and make sure that it is clear enough as to what is being tested. Inside the test cases, you can use either the [AAA (Arrange, Act, Assert)](https://automationpanda.com/2020/07/07/arrange-act-assert-a-pattern-for-writing-good-tests/) or [GWT (Given, When, Then)](https://martinfowler.com/bliki/GivenWhenThen.html) pattern to clearly define the phases of your test case. We should test "what" the function does instead of "how" it does it.  
+4. We try to keep the tests as readable as possible. We use the `it('<should work as expected>', () => {})` syntax to write the description of a test and make sure that it is clear enough as to what is being tested. Inside the test cases, you can use either the [AAA (Arrange, Act, Assert)](https://automationpanda.com/2020/07/07/arrange-act-assert-a-pattern-for-writing-good-tests/) or [GWT (Given, When, Then)](https://martinfowler.com/bliki/GivenWhenThen.html) pattern to clearly define the phases of your test case. We should test "what" the function does instead of "how" it does it.
 5. We have to make sure that the tests are deterministic and not flaky. Flaky tests are tests that fail intermittently and are difficult to debug, i.e., the tests we write should always present the same behavior. For this, each test case has to be isolated and independent of the other test cases.
-6. Since Phoenix uses `WebGLRenderer` extensively, we make sure to mock it whenever we are using it inside our tests. This is because [WebGLRenderer](https://threejs.org/docs/#api/en/renderers/WebGLRenderer) is not supported by [jsdom](https://jestjs.io/docs/configuration#testenvironment-string) due to non-availability of `WebGLContext` in Node.js and the browserless nature of `jsdom` and hence, we mock it using our custom helper [`webgl-mock.ts`](https://github.com/HSF/phoenix/blob/main/packages/phoenix-event-display/src/tests/helpers/webgl-mock.ts). 
-7. The code we are supposed to test should not be mocked. We should mock the code that is not supposed to be tested. For example, if we are testing the `EventDisplay` class, we should not mock the `EventDisplay` class, but we should mock the `WebGLRenderer` class as it is not supposed to be tested in this case. 
+6. Since Phoenix uses `WebGLRenderer` extensively, we make sure to mock it whenever we are using it inside our tests. This is because [WebGLRenderer](https://threejs.org/docs/#api/en/renderers/WebGLRenderer) is not supported by [jsdom](https://jestjs.io/docs/configuration#testenvironment-string) due to non-availability of `WebGLContext` in Node.js and the browserless nature of `jsdom` and hence, we mock it using our custom helper [`webgl-mock.ts`](https://github.com/HSF/phoenix/blob/main/packages/phoenix-event-display/src/tests/helpers/webgl-mock.ts).
+7. The code we are supposed to test should not be mocked. We should mock the code that is not supposed to be tested. For example, if we are testing the `EventDisplay` class, we should not mock the `EventDisplay` class, but we should mock the `WebGLRenderer` class as it is not supposed to be tested in this case.
 8. `Constants` are not tested separately. Testing the code that uses those constants should be sufficient. `Types` are not tested as they don't contain any logic that has to be tested.
 9. We should avoid having assertions that have nothing to do with the test case and the code to be tested. Proper usage of assertions is important to make sure that the test case is testing just the right thing. For example, if we are testing a function that returns a [Group](https://threejs.org/docs/#api/en/objects/Group), we can check if the correct objects exist inside it. And then we can check if the objects are instances of the correct class and have the correct properties, etc.
 10. `toBeTruthy` and `toBe(true)` are not the same. `toBeTruthy` checks if the value is truthy, i.e., it checks if the value is not `null`, `undefined`, `0`, `false`, `NaN`, or an empty string. `toBe(true)` checks if the value is exactly `true` as it calls `Object.is` to compare values. Make sure to do the [Setup and Teardown](https://jestjs.io/docs/setup-teardown) of the test cases properly. For example, if we are testing a function that adds an object to a list, we should make sure to remove the object from the list after the test case is executed. This is because the test cases are executed in parallel and if we don't remove the object from the list, it may affect the other test cases.
-11. To debug when the tests fail, just check the console for the `expected` and `actual` values as Jest provides rich context. If the values are not what you expect, you can use the `console.log` statements to debug the code as well. 
+11. To debug when the tests fail, just check the console for the `expected` and `actual` values as Jest provides rich context. If the values are not what you expect, you can use the `console.log` statements to debug the code as well.
 
 ### Unit Test Syntax in Jest Example
 
@@ -42,14 +42,16 @@ describe('ClassName', () => {
 ```
 
 Some simple examples of unit tests written in TypeScript using Jest:
+
 - [info-logger.test.ts](https://github.com/HSF/phoenix/blob/main/packages/phoenix-event-display/src/tests/helpers/info-logger.test.ts)
 - [file-explorer.component.test.ts](https://github.com/HSF/phoenix/blob/main/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/file-explorer/file-explorer.component.test.ts)
 
 ### Jest Configuration
 
-The configuration file for Jest inside `phoenix-event-display` is [jest.conf.js](https://github.com/HSF/phoenix/blob/main/packages/phoenix-event-display/configs/jest.conf.js) and the configuration file for Jest inside `phoenix-ng` is [jest.conf.js](https://github.com/HSF/phoenix/blob/main/packages/phoenix-ng/jest.config.js). Both require slightly different configurations so we decided not to merge them. 
+The configuration file for Jest inside `phoenix-event-display` is [jest.conf.js](https://github.com/HSF/phoenix/blob/main/packages/phoenix-event-display/configs/jest.conf.js) and the configuration file for Jest inside `phoenix-ng` is [jest.conf.js](https://github.com/HSF/phoenix/blob/main/packages/phoenix-ng/jest.config.js). Both require slightly different configurations so we decided not to merge them.
 
 To learn more about Jest and related documentation, we recommend you check out the following links:
+
 - [Jest Docs](https://jestjs.io/docs/getting-started)
 - [Jest API](https://jestjs.io/docs/api)
 
@@ -57,11 +59,11 @@ To learn more about Jest and related documentation, we recommend you check out t
 
 While writing end-to-end tests, we make sure to follow these practices:
 
-1. We utilized visual (screenshot) testing a lot in each experiment with a minimum of 1 screenshot covering each experiment except in the case of `CMSComponent` where we have multiple screenshots to test the different user-specific scenarios. 
+1. We utilized visual (screenshot) testing a lot in each experiment with a minimum of 1 screenshot covering each experiment except in the case of `CMSComponent` where we have multiple screenshots to test the different user-specific scenarios.
 2. We make sure that we are taking screenshots only if something changes on the event display as it is rendered on a canvas and we can't really assert anything otherwise. We can also check if the expected elements exist (not all but only 2-3 elements) in the DOM.
 3. We avoid using common classes like `.btn-primary` to access an element as it may change in the future if someone introduces a new button and the test will immediately break. We should either find a more suitable selector that will not change or add `data-testid` attribute to elements so that they can be queried in tests individually.
 4. Most of the tests inside the `CMSComponent` are written while thinking about the most common workflows that a user will go through while browsing the Phoenix app.
-5. We make sure to run and debug the e2e tests locally in the browser provided by Cypress (via `cy.open`) as it helps us to know the reason of failure in a better way. 
+5. We make sure to run and debug the e2e tests locally in the browser provided by Cypress (via `cy.open`) as it helps us to know the reason of failure in a better way.
 6. Both in the case of unit tests and the e2e tests, we avoid using timeouts as much as possible. We use `cy.wait` only when we are sure that the element will be rendered in the DOM after a certain time.
 
 ### End-to-End Test Syntax in Cypress Example
@@ -79,43 +81,55 @@ describe('CMSComponent', () => {
 
 The configuration file for e2e tests is [cypress.config.ts](https://github.com/HSF/phoenix/blob/main/packages/phoenix-ng/cypress.config.ts). More examples of e2e tests can be found inside the [phoenix-app/cypress](https://github.com/HSF/phoenix/tree/main/packages/phoenix-ng/projects/phoenix-app/cypress) folder and we recommend you to check out the [official Cypress documentation](https://docs.cypress.io/guides/overview/why-cypress) as it is quite fantastic and more than enough to get started with Cypress.
 
-
 # Running the tests locally
 
 Ideally you test locally before pushing a PR. You can do this with e.g:
+
 ```
 yarn test:ci
 ```
+
 (please note you will need to have `jest` installed locally for this to work)
 
 # Fixing problems
+
 If you see issues, either in the CI or from your local tests (see above), then follow these tips to help solve the problems.
 
 ## Failures in documentation coverage
+
 We currently fail the CI if the documentation coverage drops below 100%. If this happens, the easiest way to find the undocumentation code is to run `compodoc` locally, _without_ the coverage requirement. i.e. do:
+
 ```
 cd packages/phoenix-event-display
 yarn compodoc -p configs/compodoc.conf.json
 ```
+
 Now you can look in `documentation` and see which code is not fully documented.
 Once you have fixed it, you can check the CI would succeed with:
+
 ```
 # From the root directory
 yarn docs:coverage
 ```
 
-## Failures in linting 
+## Failures in linting
 
 If you see errors like:
+
 ```
 10:43  error  Insert `,`  prettier/prettier
 ```
+
 Then firstly, you should be able to spot them locally by running:
+
 ```sh
 yarn lint
 ```
+
 and you can automatically fix them with:
+
 ```sh
 yarn lint:fix
 ```
+
 (obviously you will then need to commit and push the fixes).

--- a/guides/developers/using-jsroot.md
+++ b/guides/developers/using-jsroot.md
@@ -23,14 +23,14 @@ const eventDisplay = new EventDisplay({});
 // To load `.json.gz` geometry
 eventDisplay.loadRootJSONGeometry(
   'https://root.cern/js/files/geom/cms.json.gz',
-  'CMS Detector'
+  'CMS Detector',
 );
 
 // To load `.root` geometry
 eventDisplay.loadRootGeometry(
   'https://root.cern/js/files/geom/atlas2.root',
   'atlas', // Object name
-  'ATLAS Detector'
+  'ATLAS Detector',
 );
 ```
 
@@ -45,7 +45,7 @@ const eventDisplay = new EventDisplay({});
 
 // Create the JSRootEventLoader and specify URL of the .root event data file
 const jsrootEventLoader = new JSRootEventLoader(
-  'https://root.cern/js/files/geom/tracks_hits.root'
+  'https://root.cern/js/files/geom/tracks_hits.root',
 );
 
 // Get the event data in Phoenix format by specifying an array of objects (e.g "tracks;1", "hits;1") in the .root file

--- a/guides/release.md
+++ b/guides/release.md
@@ -9,7 +9,7 @@ There are two ways to make a release.
 
 ## Automated release using GitHub Actions
 
-***CURRENTLY NOT WORKING***
+**_CURRENTLY NOT WORKING_**
 
 1. Go to the "Actions" tab of the Phoenix repository.
 2. Navigate to the `phoenix-release` workflow.

--- a/guides/users.md
+++ b/guides/users.md
@@ -1,21 +1,21 @@
 # User manual
 
-* [Getting started](#getting-started)
-  * [The demo grid](#the-demo-grid)
-  * [The Phoenix standard UI](#the-phoenix-standard-ui)
-  * [The Phoenix menu](#the-phoenix-menu)
-  * [The Phoenix iconbar](#the-phoenix-iconbar)
-    * [Collections info panel](#collections-info-panel)
-  * [Keyboard controls](#keyboard-controls)
-  * [AR/VR mode](#arvr-mode)
-  * [Event display state](#event-display-state)
-  * [Labels](#labels)
-  * [URL options](#url-options)
-* [Using Phoenix with your own data](#using-phoenix-with-your-own-data)
-  * [Event data](#event-data)
-    * [Format](#format)
-    * [Supported object types](#supported-object-types)
-  * [Geometry](#geometry)
+- [Getting started](#getting-started)
+  - [The demo grid](#the-demo-grid)
+  - [The Phoenix standard UI](#the-phoenix-standard-ui)
+  - [The Phoenix menu](#the-phoenix-menu)
+  - [The Phoenix iconbar](#the-phoenix-iconbar)
+    - [Collections info panel](#collections-info-panel)
+  - [Keyboard controls](#keyboard-controls)
+  - [AR/VR mode](#arvr-mode)
+  - [Event display state](#event-display-state)
+  - [Labels](#labels)
+  - [URL options](#url-options)
+- [Using Phoenix with your own data](#using-phoenix-with-your-own-data)
+  - [Event data](#event-data)
+    - [Format](#format)
+    - [Supported object types](#supported-object-types)
+  - [Geometry](#geometry)
 
 ## Getting started
 
@@ -23,18 +23,18 @@
 
 When you first open the Phoenix [demo](https://hepsoftwarefoundation.org/phoenix) (see the developer [instructions](../guides/developers.md) for how to check it out and run locally) you will see a grid of Phoenix demos:
 
-  * **Playground** : a blank canvas where you can load 3D objects, move them around and generally experiment with Phoenix
-  * **Geometry display** : a simple demo of generating geometry procedurally/programmatically with Phoenix
-  * **ATLAS** : the ATLAS experiment demo. Here you can load `Phoenix JSON` or `JiveXML` event data files, and visualise physics objects such as Jets, Tracks, Calo cells etc within the ATLAS geometry.
-  * **LHCb** : the LHCb experiment demo shows a detailed view of the LHCb geometry, as well as tracks passing through it.
-  * **CMS** : the CMS experiment demo. Here you select from various event data files, and visualise physics objects such as Jets, Tracks, Calo cells etc within the CMS geometry. One special feature of the CMS demo is the visualisation of Muon Chambers.
-  * **TrackML** : this shows the imaginary detector created for the TrackML [challenges](https://www.kaggle.com/c/trackml-particle-identification).
-  
+- **Playground** : a blank canvas where you can load 3D objects, move them around and generally experiment with Phoenix
+- **Geometry display** : a simple demo of generating geometry procedurally/programmatically with Phoenix
+- **ATLAS** : the ATLAS experiment demo. Here you can load `Phoenix JSON` or `JiveXML` event data files, and visualise physics objects such as Jets, Tracks, Calo cells etc within the ATLAS geometry.
+- **LHCb** : the LHCb experiment demo shows a detailed view of the LHCb geometry, as well as tracks passing through it.
+- **CMS** : the CMS experiment demo. Here you select from various event data files, and visualise physics objects such as Jets, Tracks, Calo cells etc within the CMS geometry. One special feature of the CMS demo is the visualisation of Muon Chambers.
+- **TrackML** : this shows the imaginary detector created for the TrackML [challenges](https://www.kaggle.com/c/trackml-particle-identification).
+
 ### The Phoenix standard UI
 
 Since Phoenix is configurable, it is not guaranteed that all demos/implementations will look the same, but a typical Phoenix view is shown below:
 
-![Main view of Phoenix](images/phoenix-main-view.png "Main View of Phoenix")
+![Main view of Phoenix](images/phoenix-main-view.png 'Main View of Phoenix')
 
 In the centre, you see the 3D view of the experiment and event data.
 
@@ -52,62 +52,62 @@ In general the Phoenix menu is used to determine what geometry and event data is
 
 All items in the Phoenix menu have the same basic layout:
 
-![Phoenix menu item](images/phoenix-menu-item.png "Phoenix menu item")
+![Phoenix menu item](images/phoenix-menu-item.png 'Phoenix menu item')
 
 From left-to-right:
 
-  * A slider, which determines if the item (or the sub-items beneath it) is visible
-  * The name of the item
-  * A gear icon, to open the options for this item
-  * And an arrow to open/collapse sub items.
+- A slider, which determines if the item (or the sub-items beneath it) is visible
+- The name of the item
+- A gear icon, to open the options for this item
+- And an arrow to open/collapse sub items.
 
 As an example of options, here is an expanded geometry view:
 
-![Phoenix geometry menu item](images/phoenix-menu-geometry.png "Phoenix geometry menu item")
+![Phoenix geometry menu item](images/phoenix-menu-geometry.png 'Phoenix geometry menu item')
 
 you can see that we can change the opacity and colour of the geometry item.
 
 Another example of options: here is an expanded event data view, showing how you can apply cuts to track collections:
 
-![Phoenix event menu item](images/phoenix-menu-item-event-options.png "Phoenix event menu item")
+![Phoenix event menu item](images/phoenix-menu-item-event-options.png 'Phoenix event menu item')
 
 Another important point: clicking on the gear icon at the very top allows you to save/load the menu configuration.
 
-![Phoenix menu options](images/phoenix-menu-main-options.png "Main options of the Phoenix menu")
+![Phoenix menu options](images/phoenix-menu-main-options.png 'Main options of the Phoenix menu')
 
 ### The Phoenix iconbar
 
 At the bottom of the main view you have the Phoenix iconbar (which can be shown/hidden by clicking on the arrow on top):
 
-![Phoenix iconbar](images/phoenix-icon-bar.png "Phoenix icon bar")
+![Phoenix iconbar](images/phoenix-icon-bar.png 'Phoenix icon bar')
 
 From left to right, you can access the following functions:
 
-   * **Zoom** : the plus/minus icons allow you to zoom in and out, respectively
-   * **View options and Tools** : clicking on this will allow you to access some preset views, and to view/hide the axes
-   * **Auto rotate** : clicking on this will set the camera orbiting the origin
-   * **Dark/light theme** : switches between dark and light themes
-   * **Geometry clipping** : allows you to 'slice' away parts of the geometry in order to view the event data/geometry inside
-   * **Orthographic/perspective view** : allows you to switch between different view modes
-   * **Overlay** : enables/disables the view overlay (a separate overlaid view of the detector)
-   * **Object selection** : once enabled, a new window will pop up which will display information about selected objects
-   * **Info panel** : shows a window displaying relevant information from Phoenix (for example, about events opened)
-   * **Collision animation** : starts a simple animation, simulating a collision and subsequent event data appearing
-   * **Preset animations** : shows a list of preset animations that can be triggered by clicking on the preset
-   * **Collection information** : displays a panel showing textual information about the event data collections (see below)
-   * **Performance mode** : clicking on this will turn on performance mode which makes Phoenix faster but decreases quality
-   * **VR mode** : will make Phoenix enter Virtual Reality (VR) mode
-   * **AR mode** : will make Phoenix enter Augmented Reality (AR) mode
-   * **Screenshot mode** : will enter screenshot mode by hiding all overlays
-   * **Import/export** : allows you to load new event data, or detector geometry (depending on configuration)
-   * **Create shareable link** : opens a dialog for creating a shareable link/URL to the experiment
-   * **Browse events** : [optional] if setup on the server, you can browse a specified directory for example events. 
+- **Zoom** : the plus/minus icons allow you to zoom in and out, respectively
+- **View options and Tools** : clicking on this will allow you to access some preset views, and to view/hide the axes
+- **Auto rotate** : clicking on this will set the camera orbiting the origin
+- **Dark/light theme** : switches between dark and light themes
+- **Geometry clipping** : allows you to 'slice' away parts of the geometry in order to view the event data/geometry inside
+- **Orthographic/perspective view** : allows you to switch between different view modes
+- **Overlay** : enables/disables the view overlay (a separate overlaid view of the detector)
+- **Object selection** : once enabled, a new window will pop up which will display information about selected objects
+- **Info panel** : shows a window displaying relevant information from Phoenix (for example, about events opened)
+- **Collision animation** : starts a simple animation, simulating a collision and subsequent event data appearing
+- **Preset animations** : shows a list of preset animations that can be triggered by clicking on the preset
+- **Collection information** : displays a panel showing textual information about the event data collections (see below)
+- **Performance mode** : clicking on this will turn on performance mode which makes Phoenix faster but decreases quality
+- **VR mode** : will make Phoenix enter Virtual Reality (VR) mode
+- **AR mode** : will make Phoenix enter Augmented Reality (AR) mode
+- **Screenshot mode** : will enter screenshot mode by hiding all overlays
+- **Import/export** : allows you to load new event data, or detector geometry (depending on configuration)
+- **Create shareable link** : opens a dialog for creating a shareable link/URL to the experiment
+- **Browse events** : [optional] if setup on the server, you can browse a specified directory for example events.
 
 The AR and VR mode will only be available if your device (or headset) supports AR or VR.
 
 #### Collections info panel
 
-![Phoenix collections info](images/phoenix-collections-info-pane.png "Phoenix collections info")
+![Phoenix collections info](images/phoenix-collections-info-pane.png 'Phoenix collections info')
 
 This displays some more details about the various collections. And under the **Selection** column are two icons, which allow you to either zoom the camera to the object, or to select (and highlight) it.
 
@@ -115,12 +115,12 @@ This displays some more details about the various collections. And under the **S
 
 Phoenix support various keyboard controls:
 
-   * **Shift-T** : change theme
-   * **Shift-Number** : switch to that numbered preset view
-   * **Shift-R** : rotate view
-   * **+/-** : zoom
-   * **Shift-C** : enable clipping
-   * **Shift-V** : switch between orthographic and perspective
+- **Shift-T** : change theme
+- **Shift-Number** : switch to that numbered preset view
+- **Shift-R** : rotate view
+- **+/-** : zoom
+- **Shift-C** : enable clipping
+- **Shift-V** : switch between orthographic and perspective
 
 ### AR/VR mode
 
@@ -128,9 +128,9 @@ Phoenix relies on the WebXR functionality of [three.js](https://threejs.org), so
 
 **VR:** Currently the VR has been tested on the following devices:
 
-   * Android smartphones
-   * Oculus Quest (make sure you use the Oculus browser - Firefox reality is currently unusably slow)
-   * Oculus Rift S (as of writing, the best option seems to be to use google Chrome canary i.e. beta)
+- Android smartphones
+- Oculus Quest (make sure you use the Oculus browser - Firefox reality is currently unusably slow)
+- Oculus Rift S (as of writing, the best option seems to be to use google Chrome canary i.e. beta)
 
 **AR:** On Android you will need the latest version of Chrome. On iOS, you will need to use the [WebXR Viewer from Mozilla](https://apps.apple.com/us/app/webxr-viewer/id1295998056) to make AR work.\
 Make sure your device supports AR and is listed here: <https://developers.google.com/ar/devices>
@@ -143,13 +143,13 @@ Phoenix keeps track of the event display state which can be saved as a JSON file
 
 The state includes:
 
-   * Phoenix menu configuration
-   * Geometry clipping
-   * Camera position
+- Phoenix menu configuration
+- Geometry clipping
+- Camera position
 
 The "Save state" and "Load state" buttons are in the options of top level Phoenix menu node.
 
-![Event display state](images/phoenix-event-display-state.png "Event display state")
+![Event display state](images/phoenix-event-display-state.png 'Event display state')
 
 ### Labels
 
@@ -157,7 +157,7 @@ Labels can be added to individual physics objects from the collections info pane
 
 You can also save the added labels in a JSON file from the options of "Labels" Phoenix menu node and load them later.
 
-![Phoenix labels](images/phoenix-labels.png "Phoenix labels")
+![Phoenix labels](images/phoenix-labels.png 'Phoenix labels')
 
 ### URL options
 
@@ -169,10 +169,10 @@ http://localhost:4200/#/atlas?<option_1>=<option_1_value>&<option_2>=<option_2_v
 
 Available options are:
 
-   * **file** : path or URL to the event data file you want to load (requires `type` option)
-   * **type** : type of the event data file (for example, `jivexml` or `json`)
-   * **config** : path or URL to the config or state file (this is the JSON file you get when you save state from the Phoenix menu)
-   * **hideWidgets** : hide all overlay widgets including Phoenix menu and iconbar
+- **file** : path or URL to the event data file you want to load (requires `type` option)
+- **type** : type of the event data file (for example, `jivexml` or `json`)
+- **config** : path or URL to the config or state file (this is the JSON file you get when you save state from the Phoenix menu)
+- **hideWidgets** : hide all overlay widgets including Phoenix menu and iconbar
 
 For example, event from a JSON event data file served through `/assets/event_data/data.json` can be loaded through the following URL:
 
@@ -185,68 +185,82 @@ http://localhost:4200/#/atlas?file=assets/event_data/data.json&type=json
 For details on the Phoenix event data format, please see [Phoenix Event Data Format](developers/event_data_format.md)
 
 #### 'Jets'
+
 Jets are a list of Jet objects with the following attributes :
-* `eta` - eta direction
-* `phi`- phi direction
-* `theta` (opt) - if not given, eta is used to calculate theta
-* `energy`, `et` (opt) - energy of the Jets, used to set its length
-* `coneR` (opt) - the radius of the jet cone. If not given, radius is 10% of the length
-* `color` (opt) - Hexadecimal string representing the color to draw the jet.
-* `origin_X`, `origin_Y`, `origin_Z` (opt) - Origin of the jet
+
+- `eta` - eta direction
+- `phi`- phi direction
+- `theta` (opt) - if not given, eta is used to calculate theta
+- `energy`, `et` (opt) - energy of the Jets, used to set its length
+- `coneR` (opt) - the radius of the jet cone. If not given, radius is 10% of the length
+- `color` (opt) - Hexadecimal string representing the color to draw the jet.
+- `origin_X`, `origin_Y`, `origin_Z` (opt) - Origin of the jet
 
 #### 'Hits'
+
 Hits can be defined in 2 ways. Either as an array of positions or as an array of Hit objects.
 
 In case aray of positions is used, Hits have format [ [x,y,z], [x,y,z], [x,y,z], ... ] i.e. an array of 3-dim arrays containing Cartesian coordinate.
 These will be rendered as points.
 
 In case of array of Hit objects, format is [ hit, hit, hit ] where the hit object has the following attributes :
-* `type` (opt) - type of Hit. One of `Point`, `Line` or `Box`. Defaults to Point
-* `pos` - an array of number describing the hit
-  * for `Point` type, it should have 3 coordinates : [x, y, z]
-  * for `Line` type, it should have 6 coordinates : [x0, y0, z0, x1, y1, z1]
-  * for `Box` type, it should have 6 coordinates : [x, y, z, length in x, width in y, height in z]
-* `color` (opt) - Hexadecimal string representing the color to draw the hit.
-Note that all hit objects in a given Hits collection have to be of the same type.
+
+- `type` (opt) - type of Hit. One of `Point`, `Line` or `Box`. Defaults to Point
+- `pos` - an array of number describing the hit
+  - for `Point` type, it should have 3 coordinates : [x, y, z]
+  - for `Line` type, it should have 6 coordinates : [x0, y0, z0, x1, y1, z1]
+  - for `Box` type, it should have 6 coordinates : [x, y, z, length in x, width in y, height in z]
+- `color` (opt) - Hexadecimal string representing the color to draw the hit.
+  Note that all hit objects in a given Hits collection have to be of the same type.
 
 #### 'CaloClusters' and 'CaloCells'
+
 We are talking here of cylindrical calorimeters, the deposits will be displayed as boxes with fixed square base and length matching the energy. The orientation of the boxes is radial.
 'CaloClusters' and 'CaloCells' are lists of CaloCluster and CaloCell objects respectively. These have the same set of attributes :
-* `energy` - energy of the cluster or deposit, converted to length of the displayed box
-* `phi` - phi direction
-* `eta` - eta direction
-  
+
+- `energy` - energy of the cluster or deposit, converted to length of the displayed box
+- `phi` - phi direction
+- `eta` - eta direction
+
 #### 'PlanarCaloCells'
+
 We are talking here of planar calorimeters, the deposits will be displayed as boxes with square base of cellSize and length matching the energy.
 These boxes will be positions on a given plane (the plane pf the calorimeter) at the specified coordinates in this plane.
 
 PlanarCaloCells is an object with the following attributes :
-* `plane` - the Calorimeter plane, defined as 4 numbers, giving a direction (normal to the plane) and a distance to the origin : [dx, dy, dz, length]
-* `cells` - a list of Cell objects with the following attributes:
-  * `cellSize` - size of the Calorimeter cell which fired
-  * `energy` - energy of the deposit, converted to length of the displayed box
-  * `pos` - position of the cell within the calo plane given as a pair [x, y]
-  * `color` (opt) - Hexadecimal string representing the color to draw the cell.
+
+- `plane` - the Calorimeter plane, defined as 4 numbers, giving a direction (normal to the plane) and a distance to the origin : [dx, dy, dz, length]
+- `cells` - a list of Cell objects with the following attributes:
+  - `cellSize` - size of the Calorimeter cell which fired
+  - `energy` - energy of the deposit, converted to length of the displayed box
+  - `pos` - position of the cell within the calo plane given as a pair [x, y]
+  - `color` (opt) - Hexadecimal string representing the color to draw the cell.
 
 #### 'IrregularCaloCells'
-Calorimeter cells with arbitrary polyhedron-type geometry. 
+
+Calorimeter cells with arbitrary polyhedron-type geometry.
 Each cell is represented by 8 (x,y,z) vertices connected using a convex hull from the [ConvexGeometry](https://threejs.org/docs/#examples/en/geometries/ConvexGeometry) class.
 
 IrregularCaloCells is a list of objects with the following attributes :
-   * `layer` - the Calorimeter layer
-   * `vtx` - a flattened list of 8 vertex coordinates (24 floats)
-   * `color` - an integer list of [R,G,B] values
-   * `opacity` - value from 0 to 1
+
+- `layer` - the Calorimeter layer
+- `vtx` - a flattened list of 8 vertex coordinates (24 floats)
+- `color` - an integer list of [R,G,B] values
+- `opacity` - value from 0 to 1
 
 #### 'Vertices
+
 'Vertices are a list of Vertex objects with the following attributes :
-* `x`, `y`, `z` : describing the position of the vertex
-* `color` (opt) - Hexadecimal string representing the color to draw the vertex.
+
+- `x`, `y`, `z` : describing the position of the vertex
+- `color` (opt) - Hexadecimal string representing the color to draw the vertex.
 
 #### MissingEnergy
+
 This is a list of objects, displayed as dashed lines starting from 0 and staying in the plane z=0. Each object has the following attributes :
-* `etx`, `ety` : describing the direction of the line
-* `color` (opt) - Hexadecimal string representing the color to draw the line.
+
+- `etx`, `ety` : describing the direction of the line
+- `color` (opt) - Hexadecimal string representing the color to draw the line.
 
 ### Geometry Data
 
@@ -261,5 +275,6 @@ Phoenix currently supports loading `.obj`, `.gltf`, `.root`, `.json.gz` and `.js
 GLTF files can have several scenes. Phoenix will display all of them at once, but it will create one menu item per scene so that they can be made visible/invisible independently. The menu item will simply use the name of the scene. If this name contains one or more ' > ' sequence(s) this will be interpreted as the separator between different levels of the menu. Hence scene 'A > B > C' will have name C and be located in submenu B of menu entry A
 
 GLTF scenes can also have extra data attached to them, in a dictionnary called `extras` attached to the scene object. 2 entries of that dictionnary will be interpreted by phoenix :
-* if a`visible` entry exists with boolean value, phoenix will interpret is as the initial visibility of that scene. By default scenes are visible
-* if an `opacity` entry exist with floating point value within [0, 1], phoenix will interpret is as the opacity of that scene. By default opacity is 1
+
+- if a`visible` entry exists with boolean value, phoenix will interpret is as the initial visibility of that scene. By default scenes are visible
+- if an `opacity` entry exist with floating point value within [0, 1], phoenix will interpret is as the opacity of that scene. By default opacity is 1

--- a/packages/phoenix-ng/ANGULAR_20_UPGRADE.md
+++ b/packages/phoenix-ng/ANGULAR_20_UPGRADE.md
@@ -3,9 +3,11 @@
 This branch restarts the Angular 20 upgrade from a clean `main` base.
 
 Initial state:
+
 - No functional changes yet
 - This PR is opened to track progress and discussion
 
 Next steps:
+
 - Incremental Angular 20 upgrade
 - Fix CI issues as they arise

--- a/packages/phoenix-ng/ANGULAR_20_UPGRADE.md
+++ b/packages/phoenix-ng/ANGULAR_20_UPGRADE.md
@@ -1,0 +1,11 @@
+# Angular 20 Upgrade (Clean Restart)
+
+This branch restarts the Angular 20 upgrade from a clean `main` base.
+
+Initial state:
+- No functional changes yet
+- This PR is opened to track progress and discussion
+
+Next steps:
+- Incremental Angular 20 upgrade
+- Fix CI issues as they arise


### PR DESCRIPTION
This PR restarts the Angular 20 upgrade from a clean `main` base, replacing #729.

This initial commit only adds a small tracking document to establish a clean starting point.
Further Angular 20 upgrade changes will be added incrementally in small commits.
