### PR TITLE
Fix callback leaks and stale state during EventDisplay re-initialization

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -120,6 +120,12 @@ export class EventDisplay {
     if (this.ui) {
       this.ui.cleanup();
     }
+    // Clear accumulated callbacks
+    this.onEventsChange = [];
+    this.onDisplayedEventChange = [];
+    // Reset singletons for clean view transition
+    this.loadingManager?.reset();
+    this.stateManager?.resetForViewTransition();
   }
 
   /**

--- a/packages/phoenix-event-display/src/managers/state-manager.ts
+++ b/packages/phoenix-event-display/src/managers/state-manager.ts
@@ -199,4 +199,16 @@ export class StateManager {
   setEventDisplay(eventDisplay: EventDisplay) {
     this.eventDisplay = eventDisplay;
   }
+
+  /**
+   * Reset state manager for view transitions. Clears stale references.
+   */
+  resetForViewTransition() {
+    this.phoenixMenuRoot = undefined;
+    this.activeCamera = undefined;
+    this.clippingEnabled = new ActiveVariable(false);
+    this.startClippingAngle = new ActiveVariable(0);
+    this.openingClippingAngle = new ActiveVariable(0);
+    this.eventMetadata = { runNumber: '000', eventNumber: '000' };
+  }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/cms/cms.component.ts
@@ -1,4 +1,4 @@
-import { Component, type OnInit } from '@angular/core';
+import { Component, type OnInit, type OnDestroy } from '@angular/core';
 import {
   type Configuration,
   PresetView,
@@ -17,7 +17,7 @@ import {
   templateUrl: './cms.component.html',
   styleUrls: ['./cms.component.scss'],
 })
-export class CMSComponent implements OnInit {
+export class CMSComponent implements OnInit, OnDestroy {
   phoenixMenuRoot: PhoenixMenuNode = new PhoenixMenuNode(
     'Phoenix Menu',
     'phoenix-menu',
@@ -29,7 +29,14 @@ export class CMSComponent implements OnInit {
     EventDataFormat.IG,
   ];
 
+  /** Prevents callbacks on destroyed component */
+  private isDestroyed = false;
+
   constructor(private eventDisplay: EventDisplayService) {}
+
+  ngOnDestroy() {
+    this.isDestroyed = true;
+  }
 
   ngOnInit(): void {
     const cmsLoader = new CMSLoader();
@@ -63,12 +70,16 @@ export class CMSComponent implements OnInit {
       },
     );
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addProgressListener((progress) => (this.loadingProgress = progress));
+    this.eventDisplay.getLoadingManager().addProgressListener((progress) => {
+      if (!this.isDestroyed) {
+        this.loadingProgress = progress;
+      }
+    });
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addLoadListenerWithCheck(() => (this.loaded = true));
+    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
+      if (!this.isDestroyed) {
+        this.loaded = true;
+      }
+    });
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/geometry/geometry.component.ts
@@ -1,4 +1,4 @@
-import { Component, type OnInit } from '@angular/core';
+import { Component, type OnInit, type OnDestroy } from '@angular/core';
 import { EventDisplayService } from 'phoenix-ui-components';
 
 @Component({
@@ -7,9 +7,12 @@ import { EventDisplayService } from 'phoenix-ui-components';
   templateUrl: './geometry.component.html',
   styleUrls: ['./geometry.component.scss'],
 })
-export class GeometryComponent implements OnInit {
+export class GeometryComponent implements OnInit, OnDestroy {
   loaded = false;
   loadingProgress = 0;
+
+  /** Prevents callbacks on destroyed component */
+  private isDestroyed = false;
 
   constructor(private eventDisplay: EventDisplayService) {}
 
@@ -32,13 +35,21 @@ export class GeometryComponent implements OnInit {
     };
     this.eventDisplay.buildGeometryFromParameters(parameters);
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addProgressListener((progress) => (this.loadingProgress = progress));
+    this.eventDisplay.getLoadingManager().addProgressListener((progress) => {
+      if (!this.isDestroyed) {
+        this.loadingProgress = progress;
+      }
+    });
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addLoadListenerWithCheck(() => (this.loaded = true));
+    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
+      if (!this.isDestroyed) {
+        this.loaded = true;
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed = true;
   }
 
   copyCode() {

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts
@@ -1,4 +1,4 @@
-import { Component, type OnInit } from '@angular/core';
+import { Component, type OnInit, type OnDestroy } from '@angular/core';
 import {
   EventDataFormat,
   type EventDataImportOption,
@@ -19,7 +19,7 @@ import { Plane, Vector3 } from 'three';
   templateUrl: './lhcb.component.html',
   styleUrls: ['./lhcb.component.scss'],
 })
-export class LHCbComponent implements OnInit {
+export class LHCbComponent implements OnInit, OnDestroy {
   events: any;
   phoenixMenuRoot: PhoenixMenuNode = new PhoenixMenuNode(
     'Phoenix Menu',
@@ -33,7 +33,14 @@ export class LHCbComponent implements OnInit {
     EventDataFormat.ZIP,
   ];
 
+  /** Prevents callbacks on destroyed component */
+  private isDestroyed = false;
+
   constructor(private eventDisplay: EventDisplayService) {}
+
+  ngOnDestroy() {
+    this.isDestroyed = true;
+  }
 
   ngOnInit() {
     const configuration: Configuration = {
@@ -99,12 +106,16 @@ export class LHCbComponent implements OnInit {
       console.log('Error:', e);
     }
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addProgressListener((progress) => (this.loadingProgress = progress));
+    this.eventDisplay.getLoadingManager().addProgressListener((progress) => {
+      if (!this.isDestroyed) {
+        this.loadingProgress = progress;
+      }
+    });
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addLoadListenerWithCheck(() => (this.loaded = true));
+    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
+      if (!this.isDestroyed) {
+        this.loaded = true;
+      }
+    });
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/playground/playground.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/playground/playground.component.ts
@@ -1,4 +1,4 @@
-import { Component, type OnInit } from '@angular/core';
+import { Component, type OnInit, type OnDestroy } from '@angular/core';
 import { EventDisplayService } from 'phoenix-ui-components';
 import { type Configuration, PresetView } from 'phoenix-event-display';
 import { HttpClient } from '@angular/common/http';
@@ -9,9 +9,12 @@ import { HttpClient } from '@angular/common/http';
   templateUrl: './playground.component.html',
   styleUrls: ['./playground.component.scss'],
 })
-export class PlaygroundComponent implements OnInit {
+export class PlaygroundComponent implements OnInit, OnDestroy {
   loaded = false;
   loadingProgress = 0;
+
+  /** Prevents callbacks on destroyed component */
+  private isDestroyed = false;
 
   constructor(
     protected eventDisplay: EventDisplayService,
@@ -28,12 +31,20 @@ export class PlaygroundComponent implements OnInit {
     };
     this.eventDisplay.init(configuration);
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addProgressListener((progress) => (this.loadingProgress = progress));
+    this.eventDisplay.getLoadingManager().addProgressListener((progress) => {
+      if (!this.isDestroyed) {
+        this.loadingProgress = progress;
+      }
+    });
 
-    this.eventDisplay
-      .getLoadingManager()
-      .addLoadListenerWithCheck(() => (this.loaded = true));
+    this.eventDisplay.getLoadingManager().addLoadListenerWithCheck(() => {
+      if (!this.isDestroyed) {
+        this.loaded = true;
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed = true;
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-selector/event-selector.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-selector/event-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, type OnInit } from '@angular/core';
+import { Component, type OnInit, type OnDestroy } from '@angular/core';
 import { EventDisplayService } from '../../../services/event-display.service';
 
 @Component({
@@ -7,16 +7,25 @@ import { EventDisplayService } from '../../../services/event-display.service';
   templateUrl: './event-selector.component.html',
   styleUrls: ['./event-selector.component.scss'],
 })
-export class EventSelectorComponent implements OnInit {
+export class EventSelectorComponent implements OnInit, OnDestroy {
   // Array containing the keys of the multiple loaded events
   events: string[];
+
+  /** Prevents callbacks on destroyed component */
+  private isDestroyed = false;
 
   constructor(private eventDisplay: EventDisplayService) {}
 
   ngOnInit() {
-    this.eventDisplay.listenToLoadedEventsChange(
-      (events) => (this.events = events),
-    );
+    this.eventDisplay.listenToLoadedEventsChange((events) => {
+      if (!this.isDestroyed) {
+        this.events = events;
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.isDestroyed = true;
   }
 
   changeEvent(selected: any) {


### PR DESCRIPTION
## Problem 

During repeated initialization of `EventDisplay`, callbacks registered across multiple subsystems were not being consistently cleaned up. Specifically, callbacks registered by previous view instances remained referenced after `EventDisplay` was torn down, because cleanup paths did not fully clear stored listeners and stateful references.

In addition, `StateManager` continued to hold references to camera and menu objects from the previous initialization cycle, allowing callbacks tied to destroyed Angular components to remain reachable and executable. As a result, callbacks from older instances causing multiple handlers to fire for a single event.

---

## Fix 
This change ensures that all callbacks registered during an `EventDisplay` lifecycle are explicitly cleared during `EventDisplay.cleanup()`. It also resets internal references inside `StateManager` so that each re-initialization starts from a clean state. Guards were added to callback execution paths to prevent handlers from running after their owning components have been destroyed.

---

## Impact

* Prevents callback accumulation across `EventDisplay` re-initializations
* Eliminates stale references retained by `StateManager`
* Ensures callbacks from destroyed components cannot execute
* Restone correct single-callback execution semantics