### PR TITLE
fix(scene-manager): dispose GPU resources on event switch

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
@@ -458,13 +458,79 @@ export class SceneManager {
 
   /**
    * Clears event data of the scene.
+   * Properly disposes of all GPU resources (geometries, materials, textures)
+   * to prevent memory leaks during event switching.
    */
   public clearEventData() {
     const eventData = this.getEventData();
     if (eventData != null) {
+      this.disposeObject3D(eventData);
       this.scene.remove(eventData);
     }
     this.getEventData();
+  }
+
+  /**
+   * Recursively disposes of all GPU resources in an Object3D hierarchy.
+   * @param object The Object3D to dispose.
+   */
+  private disposeObject3D(object: Object3D) {
+    object.traverse((child: Object3D) => {
+      const mesh = child as Mesh | LineSegments | Line;
+
+      // Dispose geometry
+      if (mesh.geometry) {
+        mesh.geometry.dispose();
+      }
+
+      // Dispose material(s)
+      if (mesh.material) {
+        const materials = Array.isArray(mesh.material)
+          ? mesh.material
+          : [mesh.material];
+
+        for (const material of materials) {
+          // Dispose any textures attached to the material
+          if ((material as any).map) {
+            (material as any).map.dispose();
+          }
+          if ((material as any).alphaMap) {
+            (material as any).alphaMap.dispose();
+          }
+          if ((material as any).aoMap) {
+            (material as any).aoMap.dispose();
+          }
+          if ((material as any).bumpMap) {
+            (material as any).bumpMap.dispose();
+          }
+          if ((material as any).displacementMap) {
+            (material as any).displacementMap.dispose();
+          }
+          if ((material as any).emissiveMap) {
+            (material as any).emissiveMap.dispose();
+          }
+          if ((material as any).envMap) {
+            (material as any).envMap.dispose();
+          }
+          if ((material as any).lightMap) {
+            (material as any).lightMap.dispose();
+          }
+          if ((material as any).metalnessMap) {
+            (material as any).metalnessMap.dispose();
+          }
+          if ((material as any).normalMap) {
+            (material as any).normalMap.dispose();
+          }
+          if ((material as any).roughnessMap) {
+            (material as any).roughnessMap.dispose();
+          }
+          if ((material as any).specularMap) {
+            (material as any).specularMap.dispose();
+          }
+          material.dispose();
+        }
+      }
+    });
   }
 
   /** Returns a mesh representing the passed text. It will use this.textFont. */


### PR DESCRIPTION

### **Description**

This PR addresses a critical memory leak that occurs when switching between events or clearing event data.

While the current implementation of `clearEventData()` successfully removes objects from the Three.js scene graph, it doesn't notify the WebGL renderer that the underlying GPU resources (geometries, materials, and textures) are no longer needed. In Three.js, these resources are not tracked by the JavaScript Garbage Collector and must be disposed of explicitly to free up VRAM.

Without this fix, every event switch causes a linear increase in GPU memory usage. For users browsing through large ATLAS/CMS events or running the display for extended periods, this inevitably leads to a WebGL context loss or a total browser tab crash.

### **Changes**

* **Refactored `clearEventData`**: Now ensures that every object is thoroughly "cleaned" before being detached from the scene.
* **Added `disposeObject3D` helper**:
* Recursively traverses the `Object3D` hierarchy.
* Calls `.dispose()` on all `BufferGeometry` instances.
* Handles `Material` disposal (including support for `Material[]` arrays).
* **Texture Cleanup**: Iterates through all standard material maps (map, alphaMap, normalMap, etc.) to ensure textures are removed from GPU memory.



### **How to verify**

1. Open the Phoenix application and monitor the browser's performance (e.g., Chrome DevTools -> Three dots -> More Tools -> **Performance Monitor**).
2. Watch the **GPU Memory** or **JS Heap** (indirectly affected).
3. Load a large event and switch events 20–30 times.
4. **Before fix**: GPU memory climbs steadily until the tab becomes sluggish or crashes.
5. **After fix**: GPU memory should return to a stable baseline shortly after each `clearEventData()` call.

### **Impact**

* **Stability**: Eliminates "Rats! WebGL hit a snag" errors during long analysis sessions.
* **Performance**: Improves frame rates for users on low-end hardware or integrated GPUs.
* **UX**: Allows physicists to browse hundreds of events in a single session without needing to refresh the page.
