### PR TITLE
fix(three-manager): clear selections on event switch to prevent memor…

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/index.ts
@@ -1088,8 +1088,23 @@ export class ThreeManager {
 
   /**
    * Clears event data of the scene.
+   * Also clears all selections and hover outlines to prevent stale references
+   * and orphaned outline helpers when event data is disposed.
    */
   public clearEventData() {
+    // Clear all selections before disposing event data to avoid:
+    // 1. Memory leak from orphaned outline helpers remaining in the scene
+    // 2. Visual artifacts from old selection outlines persisting
+    // 3. Stale references to disposed mesh objects in selectedOutlines Map
+    if (this.selectionManager) {
+      this.selectionManager.clearAllSelections();
+    }
+
+    // Clear hover outline separately as it's not included in clearAllSelections
+    if (this.effectsManager) {
+      this.effectsManager.setHoverOutline(null);
+    }
+
     this.sceneManager.clearEventData();
   }
 

--- a/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
@@ -1066,14 +1066,23 @@ export class SelectionManager {
   }
 
   /**
-   * Programmatically clear all selections.
+   * Programmatically clear all selections and reset internal state.
+   * This method is called when event data is cleared to prevent stale references.
    */
   public clearAllSelections(): void {
-    if (this.selectedObjects.size > 0) {
-      this.effectsManager.clearAllSelections();
-      this.selectedObjects.clear();
+    const hadSelections = this.selectedObjects.size > 0;
 
-      // Note: No info panel clearing - info panel is now hover-controlled
+    // Clear all selected outlines from the effects manager (if initialized)
+    if (this.effectsManager) {
+      this.effectsManager.clearAllSelections();
+    }
+    this.selectedObjects.clear();
+
+    // Reset internal tracking to prevent stale references to disposed meshes
+    this.hoveredObject = null;
+    this.currentlyOutlinedObject = null;
+
+    if (hadSelections && this.infoLogger) {
       this.infoLogger.add('All selections cleared', 'Selection');
     }
   }


### PR DESCRIPTION
### Description
This PR fixes a critical bug where selection outlines (the rainbow highlights on tracks) would "stick" to the screen even after switching to a new event.

Previously, when you loaded a new event, the app did a good job of clearing the main event data, but it forgot to clean up the outline helpers because they sit in the scene root, not inside the event group. This resulted in "ghost" outlines piling up in the scene, overlapping with new data, and causing a progressive memory leak that could eventually crash the browser tab.

---

### Changes
* **Updated `ThreeManager.clearEventData`**
  I added a step to explicitly call `selectionManager.clearAllSelections()` **before** we dispose of the event data. This ensures we wipe the slate clean while the references are still valid.

* **Hardened `SelectionManager.clearAllSelections`**
  I improved the cleanup logic to make sure we strictly reset internal pointers (like `hoveredObject` and `currentlyOutlinedObject`) to `null`. This stops the app from holding onto references of "dead" meshes that have already been removed.

---

### Impact
* **No more visual ghosts:** Old outlines disappear instantly when you switch events, so you don't get confused by data from the previous event overlapping the new one.
* **Better Performance:** We stop accumulating orphaned `LineSegments` in the background, which prevents the GPU memory from bloating and crashing the context during long sessions.
* **Cleaner Code:** Fixes a lifecycle mismatch between how we handle the scene and how we handle selections.

---

### How to Verify
1.  **Load up Phoenix** with an event (like ATLAS JiveXML).
2.  **Select some tracks:** Click on 3–5 tracks so they get that rainbow outline.
3.  **Switch events:** Load a different event using the selector.
    * *Before this fix:* The old rainbow outlines would stay frozen on screen.
    * *After this fix:* The outlines vanish immediately, and the new event loads on a clean canvas.
4.  **(Optional) Stress Test:** Switch back and forth 10+ times. The memory usage should stay flat, and you shouldn't see any weird artifacts.

