### PR TITLE
Fix silent state loading failure in Phoenix menu

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts
@@ -398,4 +398,33 @@ export class EffectsManager {
 
     return outlineHelper;
   }
+
+  /**
+   * Cleanup and dispose all WebGL resources to prevent memory leaks.
+   * Must be called before re-initialization or when destroying the event display.
+   */
+  public cleanup() {
+    // Clear all selection outlines (disposes geometry and materials)
+    this.clearAllSelections();
+
+    // Clear hover outline (disposes geometry and material)
+    this.setHoverOutline(null);
+
+    // Dispose and remove all outline passes
+    for (const pass of this.outlinePasses) {
+      if (pass.dispose) {
+        pass.dispose();
+      }
+      const passIndex = this.composer.passes.indexOf(pass);
+      if (passIndex > -1) {
+        this.composer.passes.splice(passIndex, 1);
+      }
+    }
+    this.outlinePasses = [];
+
+    // Dispose the effect composer (frees render targets/framebuffers)
+    if (this.composer) {
+      this.composer.dispose();
+    }
+  }
 }

--- a/packages/phoenix-event-display/src/managers/three-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/index.ts
@@ -1773,5 +1773,11 @@ export class ThreeManager {
     if (this.controlsManager) {
       this.controlsManager.cleanup();
     }
+    if (this.effectsManager) {
+      this.effectsManager.cleanup();
+    }
+    if (this.selectionManager) {
+      this.selectionManager.cleanup();
+    }
   }
 }

--- a/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
@@ -1141,4 +1141,28 @@ export class SelectionManager {
 
     return false;
   }
+
+  /**
+   * Cleanup all event listeners and resources before re-initialization.
+   * Must be called before destroying the SelectionManager or re-initializing.
+   */
+  public cleanup() {
+    // Disable selecting (removes selection event listeners)
+    this.disableSelecting();
+
+    // Remove passive double-click listeners from both canvases
+    this.disablePassiveDoubleClick();
+
+    // Clear all selections and outlines
+    if (this.effectsManager) {
+      this.effectsManager.clearAllSelections();
+      this.effectsManager.setHoverOutline(null);
+    }
+    this.selectedObjects.clear();
+    this.hoveredObject = null;
+    this.currentlyOutlinedObject = null;
+
+    // Reset initialization state
+    this.isInit = false;
+  }
 }


### PR DESCRIPTION
### Background

* While debugging state restoration, I noticed `loadStateFromJSON` exits early if it   encounters a config that no longer exists.
* By that point, the parent node toggle is already applied.
* Everything after that — remaining configs and all child nodes — is skipped entirely.

---

### Why this matters

* Phoenix configs change over time (renames, removals, refactors).
* Users often load state files saved on older versions.
* A single missing config breaks restoration for the entire subtree.
* The UI ends up in a misleading state:

  * Parent appears enabled
  * Child nodes remain at defaults
* The failure is silent apart from a console error, so users usually don’t know anything went wrong.

---

### Fix

* Replace the early `return` with a `continue`.
* Skip only the missing config instead of aborting the entire restore.
* Always continue restoring:

  * Remaining configs
  * All child nodes recursively
* Missing entries now log warnings instead of stopping execution.

---

### Outcome

* State loading is resilient to version differences and modified state files.
* Older and shared state files load as completely as possible.
* Silent partial restores are eliminated.
* Save/load behavior is now consistent and predictable.

