### PR TITLE
Fix GPU memory leak when loading Box-type hits

### DIFF
--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -487,6 +487,10 @@ export class PhoenixObjects {
       geometries.push(boxGeometry);
     }
     const geometry = mergeGeometries(geometries);
+    // Dispose intermediate geometries to free GPU memory
+    for (const geom of geometries) {
+      geom.dispose();
+    }
     geometry.computeBoundingSphere();
     // material
     const material = new MeshPhongMaterial({
@@ -738,10 +742,13 @@ export class PhoenixObjects {
       color: caloCells[0].color ?? EVENT_DATA_TYPE_COLORS.PlanarCaloCells,
     });
 
-    const outerBox = new Mesh(
-      BufferGeometryUtils.mergeGeometries(geoms),
-      material,
-    );
+    const mergedGeometry = BufferGeometryUtils.mergeGeometries(geoms);
+    // Dispose intermediate geometries to free GPU memory
+    for (const geom of geoms) {
+      geom.dispose();
+    }
+
+    const outerBox = new Mesh(mergedGeometry, material);
 
     outerBox.userData = Object.assign({}, caloCells[0]);
     outerBox.name = 'PlanarCaloCell';


### PR DESCRIPTION
**While looking into event switching, I noticed a GPU memory leak in the loaders that create Box-type hits.**

**What was happening:**

* For each hit, we create a `BoxGeometry`
* These geometries are merged into one using `mergeGeometries()`
* But the original geometries were never disposed
* Since `BoxGeometry` allocates GPU buffers, memory kept growing every time events were loaded

This becomes visible when switching events multiple times — GPU memory keeps increasing and can eventually hurt performance or cause WebGL context loss.

**What I changed:**

* After merging the geometries, I now explicitly dispose the intermediate ones
* Applied the same fix in both:

  * `hitsToBoxes`
  * `getPlanarCaloCells`

This doesn’t change any behavior or visuals — it just cleans up GPU resources properly.

**Testing:**

* Ran the full test suite locally (all tests passing)
* Manually switched between multiple events and confirmed GPU memory stays stable
* Added a screenshot of the test run for reference

<img width="1212" height="1069" alt="image" src="https://github.com/user-attachments/assets/766dfd68-b7ba-4243-a22f-a3ee52405e66" />
