### PR TITLE
fix(selection-manager): prevent duplicate event listeners on re-init

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
@@ -187,11 +187,21 @@ export class SelectionManager {
   /**
    * Enable passive double-click detection (always active, independent of selection).
    * Sets up event listeners for both main and overlay canvases.
+   * This method can be called multiple times safely due to listener deduplication.
    */
   private enablePassiveDoubleClick() {
     // Main canvas (always available)
     const mainCanvas = document.getElementById('three-canvas');
     if (mainCanvas) {
+      // Remove existing listeners to avoid duplicates on re-initialization
+      mainCanvas.removeEventListener(
+        'mousedown',
+        this.onPassiveMouseDown,
+        true,
+      );
+      mainCanvas.removeEventListener('mouseup', this.onPassiveMouseUp, true);
+
+      // Add listeners
       mainCanvas.addEventListener('mousedown', this.onPassiveMouseDown, true);
       mainCanvas.addEventListener('mouseup', this.onPassiveMouseUp, true);
     }


### PR DESCRIPTION
### Description
I'm submitting this fix to address a memory leak and performance issue I noticed in the `SelectionManager`.

Currently, whenever the application re-initializes (like when a user switches between experiments, e.g., ATLAS to LHCb), the `EventDisplayService` runs the initialization logic again. The problem is that `enablePassiveDoubleClick()` attaches new mouse listeners to the canvas every single time, but it fails to remove the old ones first.

---

### The Issue
The root cause is that `enablePassiveDoubleClick()` just keeps stacking listeners on top of each other.

* **The behaviour:** Every time `init()` is called, two new listeners get added to `#three-canvas`.
* **The result:** If a user switches experiments 10 times, we end up with 20+ active listeners on the same element.
* **Why it matters:** This causes handlers to fire multiple times for a single click and progressively slows down the browser during longer sessions.

---

### The Fix
I updated `enablePassiveDoubleClick` in `selection-manager.ts` to implement a simple "cleanup-before-attach" pattern.

The code now explicitly calls `removeEventListener` for the passive mouse handlers before trying to add them. This ensures that no matter how many times the manager is re-initialized, we only ever have one set of active listeners on the main canvas. This actually just brings the main canvas logic in line with how we were already correctly handling the overlay canvas.

---

### Verification
You can verify this by opening DevTools and looking at the Event Listeners tab for `#three-canvas`:

1.  Check the count of `mousedown` listeners.
2.  Switch between experiments a few times.
3.  **Result:** The listener count should stay stable at 1 (per event type) and not increase with every switch.

---
