### PR TITLE
Fix GPU memory leak by disposing intermediate geometries after GLTF merge

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/import-manager.ts
@@ -442,6 +442,11 @@ export class ImportManager {
               );
               mesh.renderOrder = (val as any).renderOrder;
               scene.add(mesh);
+
+              // Dispose intermediate geometries to free GPU memory
+              for (const geom of (val as any).geoms) {
+                geom.dispose();
+              }
             }
 
             this.processGeometry(


### PR DESCRIPTION
### Summary

This PR fixes a GPU memory leak in the GLTF loading path where intermediate geometries created during BufferGeometryUtils.mergeGeometries() were not being disposed after the merged mesh was created.

In loadGLTFGeometryInternal, individual mesh geometries are cloned and transformed before being merged into a single geometry per material. While the merged geometry is used for rendering, the intermediate cloned geometries remained allocated in GPU memory and were never released.

Since Three.js requires explicit disposal of GPU-backed resources, repeated geometry loads (or reloads) in long-running sessions could lead to steadily increasing GPU memory usage and eventually WebGL context loss or browser crashes.

---

### Fix

After creating and adding the merged mesh to the scene, this change explicitly disposes all intermediate geometries used in the merge step. This follows the same disposal pattern already used in phoenix-objects.ts, keeping behavior consistent across geometry loading paths.

---

### Impact
	•	Prevents GPU memory buildup during repeated GLTF geometry loads
	•	Improves stability for long-running event display sessions
	•	No change to rendering output or application behavior, only resource cleanup

---

### Testing
	•	Manually tested by loading and reloading GLTF detector geometries multiple times in the event display
	•	Observed stable GPU memory usage compared to continuous growth before the fix
	•	No visual or functional regressions observed in geometry rendering

---

### Scope
	•	Small, localized change in import-manager.ts
	•	No API or functional behavior changes