### PR TITLE
fix(phoenix-objects): guard against undefined track.pos

### DIFF
--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -52,7 +52,7 @@ export class PhoenixObjects {
         track.extended = true;
       }
 
-      if (track.pos.length < 2) {
+      if (!track.pos || track.pos.length < 2) {
         console.log('Track too short, and extrapolation failed.');
         continue;
       }
@@ -114,7 +114,7 @@ export class PhoenixObjects {
     const trackObject = new Group();
 
     // Check again, in case there was an issue with the extrapolation.
-    if (positions.length < 2) {
+    if (!positions || positions.length < 2) {
       console.log('Track too short, and extrapolation failed.');
       return trackObject;
     }


### PR DESCRIPTION

### Description

I identified a critical crash in the `PhoenixObjects` loader that occurs when processing malformed or incomplete track data.

When the application loads event data, it validates tracks by checking the number of positions they contain. However, if a track is missing both its explicit position data and the parameters needed to extrapolate those positions, the position array remains undefined.

Currently, the code tries to read the length of this undefined array immediately. This triggers a "Cannot read properties of undefined" error, which causes the entire event display to crash (resulting in a black screen or frozen interface). This issue is particularly common when working with imperfect data sources, such as incomplete JIVEXML files, failed reconstruction exports, or user-uploaded JSON files.

---

### Fix

I updated the track loading logic to be more defensive. I added a check to verify that the position data actually exists before the code attempts to read its length.

If a track is found to be missing necessary data, the loader now gracefully skips that specific track and logs a warning, rather than allowing the error to propagate and crash the browser.

---

### Impact

* **Stability:** Eliminates the application crash when loading partial or malformed event files.
* **Resilience:** Allows the application to continue rendering the rest of the event (jets, hits, valid tracks) even if a few specific tracks are corrupted.
* **User Experience:** Prevents "white screen of death" scenarios for physicists and public users working with custom, experimental, or slightly corrupted data formats.

---

### Test Plan

1.  Create or obtain a JSON event file that contains a track definition missing both position data and extrapolation parameters.
2.  Load this file into the Phoenix display.
3.  **Before Fix:** Observe that the application freezes and throws a TypeError in the console, requiring a page refresh.
4.  **After Fix:** Observe that the application loads the event successfully. The valid parts of the event are displayed, the malformed track is ignored, and a specific warning is logged to the console indicating that extrapolation failed for that track.