### PR TITLE
Replace hardcoded column exclusion list with configurable Input

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -20,6 +20,8 @@ import { EventDisplayService } from '../../../../services/event-display.service'
 })
 export class CollectionsInfoOverlayComponent implements OnInit, OnDestroy {
   @Input() showObjectsInfo: boolean;
+  /** Columns to exclude from the collection info table. */
+  @Input() excludedColumns: string[] = ['uuid', 'hits', 'isCut', 'labelText'];
   hideInvisible: boolean;
   collections: { type: string; collections: string[] }[];
   selectedCollection: string;
@@ -75,7 +77,7 @@ export class CollectionsInfoOverlayComponent implements OnInit, OnDestroy {
       }));
 
     this.collectionColumns = Object.keys(this.showingCollection[0]).filter(
-      (column) => !['uuid', 'hits', 'isCut', 'labelText'].includes(column), // FIXME - this is an ugly hack. But currently hits from tracks make track collections unusable. Better to have exlusion list passed in.
+      (column) => !this.excludedColumns.includes(column),
     );
   }
 


### PR DESCRIPTION
Replace the hardcoded column exclusion array in CollectionsInfoOverlayComponent with a configurable @Input() excludedColumns property. This resolves the FIXME by allowing parent components to customize which columns are hidden in the collections info table, while preserving the existing default behavior.