### PR TITLE
feat: add typed event data pipeline with loader registry

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -12,6 +12,10 @@ import { ThreeManager } from './managers/three-manager/index';
 import { XRSessionType } from './managers/three-manager/xr/xr-manager';
 import { UIManager } from './managers/ui-manager/index';
 import { URLOptionsManager } from './managers/url-options-manager';
+import type {
+  PhoenixEventData,
+  PhoenixEventsData,
+} from './lib/types/event-data';
 
 declare global {
   /**
@@ -30,7 +34,7 @@ export class EventDisplay {
   /** Configuration for preset views and event data loader. */
   public configuration: Configuration;
   /** An object containing event data. */
-  private eventsData: any;
+  private eventsData: PhoenixEventsData;
   /** Array containing callbacks to be called when events change. */
   private onEventsChange: ((events: any) => void)[] = [];
   /** Array containing callbacks to be called when the displayed event changes. */
@@ -151,7 +155,7 @@ export class EventDisplay {
    * @param eventsData Object containing the event data.
    * @returns Array of strings containing the keys of the eventsData object.
    */
-  public parsePhoenixEvents(eventsData: any): string[] {
+  public parsePhoenixEvents(eventsData: PhoenixEventsData): string[] {
     this.eventsData = eventsData;
     if (typeof this.configuration.eventDataLoader === 'undefined') {
       this.configuration.eventDataLoader = new PhoenixLoader();
@@ -169,7 +173,7 @@ export class EventDisplay {
    * of physics objects.
    * @param eventData Object containing the event data.
    */
-  public buildEventDataFromJSON(eventData: any) {
+  public buildEventDataFromJSON(eventData: PhoenixEventData) {
     // Reset labels
     this.resetLabels();
     // Creating UI folder
@@ -196,7 +200,7 @@ export class EventDisplay {
    * the event associated with that key.
    * @param eventKey String that represents the event in the eventsData object.
    */
-  public loadEvent(eventKey: any) {
+  public loadEvent(eventKey: string) {
     const event = this.eventsData[eventKey];
 
     if (event) {

--- a/packages/phoenix-event-display/src/index.ts
+++ b/packages/phoenix-event-display/src/index.ts
@@ -21,6 +21,7 @@ export * from './managers/ui-manager/phoenix-menu/phoenix-menu-node';
 
 // Extras
 export * from './lib/types/configuration';
+export * from './lib/types/event-data';
 export * from './lib/models/cut.model';
 export * from './lib/models/preset-view.model';
 
@@ -34,6 +35,7 @@ export * from './helpers/zip';
 
 // Loaders
 export * from './loaders/event-data-loader';
+export * from './loaders/object-type-registry';
 export * from './loaders/cms-loader';
 export * from './loaders/jivexml-loader';
 export * from './loaders/jsroot-event-loader';

--- a/packages/phoenix-event-display/src/lib/types/event-data.ts
+++ b/packages/phoenix-event-display/src/lib/types/event-data.ts
@@ -1,0 +1,288 @@
+/** Type definitions for Phoenix event data structures. */
+
+/** Track helix params: [d0, z0, phi, theta, qOverP] */
+export type DParams = [number, number, number, number, number];
+
+/** Parameters for a single track. */
+export interface TrackParams {
+  /** Array of [x, y, z] positions defining the track path. */
+  pos?: number[][];
+  /** Helix parameters for Runge-Kutta extrapolation. */
+  dparams?: DParams;
+  /** Azimuthal angle. */
+  phi?: number;
+  /** Pseudorapidity. */
+  eta?: number;
+  /** Transverse impact parameter. */
+  d0?: number;
+  /** Longitudinal impact parameter. */
+  z0?: number;
+  /** Transverse momentum. */
+  pT?: number;
+  /** Chi-squared of the track fit. */
+  chi2?: number;
+  /** Degrees of freedom. */
+  dof?: number;
+  /** Color as hex string. */
+  color?: string;
+  /** Line width for rendering. */
+  linewidth?: number;
+  /** Whether the track was extrapolated. Set internally. */
+  extended?: boolean;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Track ID in merged mesh. Set internally. */
+  tid?: number;
+  /** Material reference. Set internally. */
+  material?: unknown;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Parameters for a single jet. */
+export interface JetParams {
+  /** Pseudorapidity. */
+  eta: number;
+  /** Azimuthal angle. */
+  phi: number;
+  /** Polar angle. Derived from eta if absent. */
+  theta?: number;
+  /** Jet energy. */
+  energy?: number;
+  /** Transverse energy — used if energy is absent. */
+  et?: number;
+  /** Cone radius for visualization width. */
+  coneR?: number;
+  /** Jet origin X displacement. */
+  origin_X?: number;
+  /** Jet origin Y displacement. */
+  origin_Y?: number;
+  /** Jet origin Z displacement. */
+  origin_Z?: number;
+  /** Color for rendering. */
+  color?: string | number;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Can be a simple [x,y,z] array or an object with pos + metadata. */
+export interface HitParams {
+  /** Position coordinates. */
+  pos: number[];
+  /** Drawing type: 'Point', 'CircularPoint', 'Line', or 'Box'. */
+  type?: string;
+  /** Color for rendering. */
+  color?: string | number;
+  /** Additional info attached to the hit. */
+  extraInfo?: Record<string, unknown>;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Parameters for a single calorimeter cluster. */
+export interface CaloClusterParams {
+  /** Cluster energy. */
+  energy: number;
+  /** Azimuthal angle. */
+  phi: number;
+  /** Pseudorapidity. */
+  eta: number;
+  /** Cylindrical radius override. */
+  radius?: number;
+  /** Z position override. */
+  z?: number;
+  /** Side width of the cluster box. */
+  side?: number;
+  /** Length (depth) of the cluster box. */
+  length?: number;
+  /** Color for rendering. */
+  color?: string;
+  /** Polar angle. Derived from eta if absent. */
+  theta?: number;
+  /** Opacity value. */
+  opacity?: number;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Parameters for a single calorimeter cell. */
+export interface CaloCellParams {
+  /** Cell energy. */
+  energy: number;
+  /** Azimuthal angle. */
+  phi: number;
+  /** Pseudorapidity. */
+  eta: number;
+  /** Cylindrical radius override. */
+  radius?: number;
+  /** Z position override. */
+  z?: number;
+  /** Polar angle. Derived from eta if absent. */
+  theta?: number;
+  /** Color for rendering. */
+  color?: string;
+  /** Opacity value. */
+  opacity?: number;
+  /** Side width of the cell box. */
+  side?: number;
+  /** Length (depth) of the cell box. */
+  length?: number;
+  /** UUID assigned after object creation. Set internally. */
+  uuid: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Parameters for a single planar calorimeter cell. */
+export interface PlanarCaloCellParams {
+  /** Cell energy. */
+  energy: number;
+  /** Position [x, y]. */
+  pos?: number[];
+  /** Cell size (width). */
+  cellSize?: number;
+  /** Plane definition [nx, ny, nz, d]. */
+  plane?: number[];
+  /** Color for rendering. */
+  color?: string | number;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Irregular cell defined by 8 arbitrary vertices (24 floats). */
+export interface IrregularCaloCellParams {
+  /** Drawing type identifier. */
+  type?: string;
+  /** Calorimeter layer. */
+  layer: number;
+  /** Flattened list of 8 vertex coordinates (24 floats). */
+  vtx: number[];
+  /** Color as [R, G, B] integer array or string. */
+  color: string | number[];
+  /** Opacity from 0 to 1. */
+  opacity: number;
+  /** Cell energy. */
+  energy?: number;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Parameters for a single vertex. */
+export interface VertexParams {
+  /** Position as [x, y, z]. */
+  pos?: number[];
+  /** X coordinate (alternative to pos). */
+  x?: number;
+  /** Y coordinate (alternative to pos). */
+  y?: number;
+  /** Z coordinate (alternative to pos). */
+  z?: number;
+  /** Sphere size. */
+  size?: number;
+  /** Vertex type for cuts. */
+  vertexType?: number;
+  /** Color for rendering. */
+  color?: string | number;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Parameters for missing transverse energy. */
+export interface MissingEnergyParams {
+  /** X component of missing ET. */
+  etx: number;
+  /** Y component of missing ET. */
+  ety: number;
+  /** Color for rendering. */
+  color?: string | number;
+  /** UUID assigned after object creation. Set internally. */
+  uuid?: string;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Compound objects (Muon, Electron, Photon) link tracks and clusters. */
+export interface CompoundObjectParams {
+  /** Linked track parameters. */
+  LinkedTracks?: TrackParams[];
+  /** Linked cluster parameters. */
+  LinkedClusters?: CaloClusterParams[];
+  /** Azimuthal angle. */
+  phi?: number;
+  /** Pseudorapidity. */
+  eta?: number;
+  /** Energy. */
+  energy?: number;
+  /** Transverse momentum. */
+  pT?: number;
+  /** Extra experiment-specific properties. */
+  [key: string]: unknown;
+}
+
+/** Named collection of physics objects: { collectionName: objectArray }. */
+export type ObjectCollection<T = Record<string, unknown>> = {
+  [collectionName: string]: T[];
+};
+
+/** A single event in Phoenix format. */
+export interface PhoenixEventData {
+  /** Track collections. */
+  Tracks?: ObjectCollection<TrackParams>;
+  /** Jet collections. */
+  Jets?: ObjectCollection<JetParams>;
+  /** Hit collections. */
+  Hits?: ObjectCollection<HitParams | number[]>;
+  /** Calorimeter cluster collections. */
+  CaloClusters?: ObjectCollection<CaloClusterParams>;
+  /** Calorimeter cell collections. */
+  CaloCells?: ObjectCollection<CaloCellParams>;
+  /** Planar calorimeter cell collections. */
+  PlanarCaloCells?: {
+    [collectionName: string]: {
+      /** Plane definition [nx, ny, nz, d]. */
+      plane: number[];
+      /** Array of planar calo cells. */
+      cells: PlanarCaloCellParams[];
+    };
+  };
+  /** Irregular calorimeter cell collections. */
+  IrregularCaloCells?: ObjectCollection<IrregularCaloCellParams>;
+  /** Muon collections. */
+  Muons?: ObjectCollection<CompoundObjectParams>;
+  /** Photon collections. */
+  Photons?: ObjectCollection<CompoundObjectParams>;
+  /** Electron collections. */
+  Electrons?: ObjectCollection<CompoundObjectParams>;
+  /** Vertex collections. */
+  Vertices?: ObjectCollection<VertexParams>;
+  /** Missing energy collections. */
+  MissingEnergy?: ObjectCollection<MissingEnergyParams>;
+  /** Event number. */
+  'event number'?: string | number;
+  /** Event number (alt key). */
+  eventNumber?: string | number;
+  /** Run number. */
+  'run number'?: string | number;
+  /** Run number (alt key). */
+  runNumber?: string | number;
+  /** Experiment-specific object types. */
+  [key: string]: unknown;
+}
+
+/** Multiple events keyed by event name. */
+export interface PhoenixEventsData {
+  /** Individual event data. */
+  [eventKey: string]: PhoenixEventData;
+}

--- a/packages/phoenix-event-display/src/loaders/cms-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/cms-loader.ts
@@ -1,6 +1,7 @@
 import { PhoenixLoader } from './phoenix-loader';
 import { Vector3, QuadraticBezierCurve3 } from 'three';
 import { CMSObjects } from './objects/cms-objects';
+import { ObjectTypeConfig } from './object-type-registry';
 import JSZip from 'jszip';
 
 /**
@@ -20,20 +21,14 @@ export class CMSLoader extends PhoenixLoader {
     this.data = {};
   }
 
-  /**
-   * Loads all the object types and collections of event data.
-   * Overridden from {@link PhoenixLoader}.
-   * @param eventData Event data of a CMS event containing all collections.
-   */
-  protected loadObjectTypes(eventData: any) {
-    super.loadObjectTypes(eventData);
-    if (eventData.MuonChambers) {
-      this.addObjectType(
-        eventData.MuonChambers,
-        CMSObjects.getMuonChamber,
-        'MuonChambers',
-      );
-    }
+  /** Add CMS-specific MuonChambers type to the default configs. */
+  protected getObjectTypeConfigs(): ObjectTypeConfig[] {
+    const configs = super.getObjectTypeConfigs();
+    configs.push({
+      typeName: 'MuonChambers',
+      getObject: CMSObjects.getMuonChamber,
+    });
+    return configs;
   }
 
   /**

--- a/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/edm4hep-json-loader.ts
@@ -67,7 +67,7 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
 
     const eventHeader = event['EventHeader']['collection'];
 
-    if (!('runNumber' in eventHeader)) {
+    if ('runNumber' in eventHeader[0]) {
       return eventHeader[0]['runNumber'];
     }
 
@@ -82,7 +82,7 @@ export class Edm4hepJsonLoader extends PhoenixLoader {
 
     const eventHeader = event['EventHeader']['collection'];
 
-    if (!('eventNumber' in eventHeader)) {
+    if ('eventNumber' in eventHeader[0]) {
       return eventHeader[0]['eventNumber'];
     }
 

--- a/packages/phoenix-event-display/src/loaders/event-data-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/event-data-loader.ts
@@ -1,68 +1,42 @@
 import { InfoLogger } from '../helpers/info-logger';
 import { ThreeManager } from '../managers/three-manager/index';
 import { UIManager } from '../managers/ui-manager/index';
+import type {
+  PhoenixEventData,
+  PhoenixEventsData,
+} from '../lib/types/event-data';
 
 /**
  * Event data loader for implementing different event data loaders.
  */
 export interface EventDataLoader {
-  /**
-   * Takes an object that represents ONE event and takes care of adding
-   * the different objects to the graphic library and the UI controls.
-   * @param eventData Object representing the event.
-   * @param graphicsLibrary Manager containing functionality to draw the 3D objects.
-   * @param ui Manager for showing menus and controls to manipulate the geometries.
-   * @param infoLogger Logger for logging event display data..
-   */
+  /** Load one event into the graphics library and UI. */
   buildEventData(
-    eventData: any,
+    eventData: PhoenixEventData,
     graphicsLibrary: ThreeManager,
     ui: UIManager,
     infoLogger: InfoLogger,
   ): void;
 
-  /**
-   * Takes an object containing multiple events and returns the keys of these events.
-   * @param eventsData Object that contains the different events.
-   * @returns List of keys of the different events.
-   */
-  getEventsList(eventsData: any): string[];
+  /** Get keys of all events in the container. */
+  getEventsList(eventsData: PhoenixEventsData): string[];
 
-  /**
-   * Get the different collections for the current stored event.
-   * @returns List of strings, each representing a collection of the event displayed.
-   */
+  /** Get collection names grouped by object type. */
   getCollections(): { [key: string]: string[] };
 
-  /**
-   * Get all the objects inside a collection.
-   * @param collectionName Key of the collection that will be retrieved.
-   * @returns Object containing all physics objects from the desired collection.
-   */
+  /** Get all objects in a collection by name. */
   getCollection(collectionName: string): any;
 
-  /**
-   * Get metadata associated to the displayed event (experiment info, time, run, event...).
-   * @returns Metadata of the displayed event.
-   */
+  /** Get metadata for the current event. */
   getEventMetadata(): any[];
 
-  /**
-   * Add label of event object to the labels object.
-   * @param label Label to add to the event object.
-   * @param collection Collection the event object is a part of.
-   * @param indexInCollection Event object's index in collection.
-   * @returns A unique label ID string.
-   */
+  /** Add a label to an event object. Returns a unique label ID. */
   addLabelToEventObject(
     label: string,
     collection: string,
     indexInCollection: number,
   ): string;
 
-  /**
-   * Get the object containing labels.
-   * @returns The labels object.
-   */
+  /** Get the labels object. */
   getLabelsObject(): { [key: string]: any };
 }

--- a/packages/phoenix-event-display/src/loaders/object-type-registry.ts
+++ b/packages/phoenix-event-display/src/loaders/object-type-registry.ts
@@ -1,0 +1,212 @@
+import { Object3D, Vector3 } from 'three';
+import { GUI } from 'dat.gui';
+import { Cut } from '../lib/models/cut.model';
+import { PhoenixMenuNode } from '../managers/ui-manager/phoenix-menu/phoenix-menu-node';
+import { PhoenixObjects } from './objects/phoenix-objects';
+
+/** Describes how to load a single physics object type. */
+export interface ObjectTypeConfig {
+  /** Key in eventData (e.g. 'Tracks', 'Jets'). */
+  typeName: string;
+  /** Builds one Three.js object from params. */
+  getObject: (params: any, typeName?: string) => Object3D;
+  /** If true, pass the whole collection at once instead of per-object. */
+  concatonateObjs?: boolean;
+  /** Default cut definitions for this type. */
+  cuts?: Cut[];
+  /** Scale UI config — if set, a scale slider is added. */
+  scaleConfig?: {
+    /** Config key for dat.GUI. */
+    key: string;
+    /** Display label. */
+    label: string;
+    /** Scene manager scale method name. */
+    scaleMethod: string;
+    /** Axis to scale along. */
+    scaleAxis?: string;
+  };
+  /** Completely custom UI extension (used by MissingEnergy). */
+  extendUI?: (
+    typeFolder: GUI,
+    typeFolderPM: PhoenixMenuNode,
+    scaleChildObjects: (typeName: string, value: number) => void,
+  ) => void;
+  /** Custom pre-processing for event data before addObjectType. */
+  preprocessData?: (data: any) => any;
+}
+
+/** Returns default configs for all built-in Phoenix object types. */
+export function getDefaultObjectTypeConfigs(): ObjectTypeConfig[] {
+  const pi = parseFloat(Math.PI.toFixed(2));
+
+  return [
+    {
+      typeName: 'Tracks',
+      getObject: PhoenixObjects.getTrack,
+      cuts: [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -4, 4, 0.1),
+        new Cut('chi2', 0, 100),
+        new Cut('dof', 0, 100),
+        new Cut('pT', 0, 50000, 0.1),
+        new Cut('z0', -30, 30, 0.1),
+        new Cut('d0', -30, 30, 0.1),
+      ],
+    },
+    {
+      typeName: 'Jets',
+      getObject: PhoenixObjects.getJet,
+      cuts: [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -5.0, 5.0, 0.1),
+        new Cut('energy', 0, 600000, 100),
+      ],
+      scaleConfig: {
+        key: 'jetsScale',
+        label: 'Jets Scale',
+        scaleMethod: 'scaleJets',
+      },
+    },
+    {
+      typeName: 'Hits',
+      getObject: PhoenixObjects.getHits,
+      concatonateObjs: true,
+    },
+    {
+      typeName: 'CaloClusters',
+      getObject: (params: any) => PhoenixObjects.getCluster(params),
+      cuts: [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -5.0, 5.0, 0.1),
+        new Cut('energy', 0, 10000),
+      ],
+      scaleConfig: {
+        key: 'caloClustersScale',
+        label: 'CaloClusters Scale',
+        scaleMethod: 'scaleChildObjects',
+        scaleAxis: 'z',
+      },
+    },
+    {
+      typeName: 'CaloCells',
+      getObject: PhoenixObjects.getCaloCell,
+      cuts: [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -5.0, 5.0, 0.1),
+        new Cut('energy', 0, 10000),
+      ],
+      scaleConfig: {
+        key: 'caloCellsScale',
+        label: 'CaloCells Scale',
+        scaleMethod: 'scaleChildObjects',
+        scaleAxis: 'z',
+      },
+    },
+    {
+      typeName: 'PlanarCaloCells',
+      getObject: PhoenixObjects.getPlanarCaloCell,
+      cuts: [new Cut('energy', 0, 10000)],
+      scaleConfig: {
+        key: 'planarCaloCellsScale',
+        label: 'PlanarCaloCells Scale',
+        scaleMethod: 'scaleChildObjects',
+        scaleAxis: 'z',
+      },
+      preprocessData: (data: any) => {
+        // Flatten { collectionName: { plane, cells } } into { collectionName: cells[] }
+        const collections: { [key: string]: any } = {};
+        for (const collectionName in data) {
+          const collection = data[collectionName];
+          const plane = collection['plane'];
+          const unitVector = new Vector3(...plane.slice(0, 3)).normalize();
+          collection['cells'].forEach(
+            (cell: any) =>
+              (cell['plane'] = [...unitVector.toArray(), plane[3]]),
+          );
+          collections[collectionName] = collection['cells'];
+        }
+        return collections;
+      },
+    },
+    {
+      typeName: 'IrregularCaloCells',
+      getObject: PhoenixObjects.getIrregularCaloCell,
+      cuts: [new Cut('layer', 0, 10), new Cut('energy', 0, 10000)],
+      scaleConfig: {
+        key: 'IrregularCaloCellsScale',
+        label: 'IrregularCaloCells Scale',
+        scaleMethod: 'scaleChildObjects',
+        scaleAxis: 'z',
+      },
+    },
+    // Compound types — getObject is set to null here; PhoenixLoader
+    // binds its own getCompoundTrack / getCompoundCluster at runtime
+    {
+      typeName: 'Muons',
+      getObject: null,
+      cuts: [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -4, 4, 0.1),
+        new Cut('energy', 0, 10000),
+        new Cut('pT', 0, 50000),
+      ],
+    },
+    {
+      typeName: 'Photons',
+      getObject: null,
+      cuts: [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -4, 4, 0.1),
+        new Cut('energy', 0, 10000),
+        new Cut('pT', 0, 50000),
+      ],
+    },
+    {
+      typeName: 'Electrons',
+      getObject: null,
+      cuts: [
+        new Cut('phi', -pi, pi, 0.01),
+        new Cut('eta', -4, 4, 0.1),
+        new Cut('energy', 0, 10000),
+        new Cut('pT', 0, 50000),
+      ],
+    },
+    {
+      typeName: 'Vertices',
+      getObject: PhoenixObjects.getVertex,
+      cuts: [new Cut('vertexType', 0, 5)],
+      scaleConfig: {
+        key: 'verticesScale',
+        label: 'Vertices Scale',
+        scaleMethod: 'scaleChildObjects',
+      },
+    },
+    {
+      typeName: 'MissingEnergy',
+      getObject: PhoenixObjects.getMissingEnergy,
+      cuts: [],
+      extendUI: (typeFolder, typeFolderPM, scaleChildObjects) => {
+        const scaleMET = (value: number) => {
+          scaleChildObjects('MissingEnergy', value);
+        };
+        if (typeFolder) {
+          const sizeMenu = typeFolder
+            .add({ jetsScale: 100 }, 'jetsScale', 1, 200)
+            .name('Size (%)');
+          sizeMenu.onChange(scaleMET);
+        }
+        if (typeFolderPM) {
+          typeFolderPM.addConfig({
+            type: 'slider',
+            label: 'Size (%)',
+            value: 100,
+            min: 1,
+            max: 200,
+            allowCustomValue: true,
+            onChange: scaleMET,
+          });
+        }
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
PhoenixLoader.loadObjectTypes() was 290 lines of if/else chains. Adding a new object type meant editing core code, and experiment loaders had to override the entire method just to add one custom type. Replaced it with a declarative registry. Also added proper TypeScript interfaces for event data and fixed a bug in Edm4hepJsonLoader where getRunNumber() and getEventNumber() had inverted logic.

## Changes
- `src/lib/types/event-data.ts` (new) - TypeScript interfaces for TrackParams, JetParams, CaloClusterParams, etc.
- `src/loaders/object-type-registry.ts` (new) - ObjectTypeConfig registry and default configs
- `src/loaders/phoenix-loader.ts` - Replaced 290-line if/else with 60-line registry loop
- `src/loaders/event-data-loader.ts` - Added types to interface methods
- `src/loaders/cms-loader.ts` - Uses getObjectTypeConfigs() override instead of overriding loadObjectTypes()
- `src/loaders/edm4hep-json-loader.ts` - Fixed inverted logic in getRunNumber() / getEventNumber()
- `src/event-display.ts` - Typed eventsData and related methods
- `src/index.ts` - Export new types and registry



## Testing
- `yarn tsc:build --noEmit` passes with zero errors
- All 170 existing tests pass
- Manually loaded Phoenix JSON events - all object types render correctly
- Manually loaded EDM4hep JSON - run/event numbers display correctly now
- Verified CMS .ig file loading still works with MuonChambers via registry extension

## Notes
Skipped decorator-based registration - adds complexity for minimal benefit. The explicit registry is simpler and easier to debug.