### PR TITLE
fix: replace deprecated substr() with substring() in URLOptionsManager

### DIFF
--- a/packages/phoenix-event-display/src/managers/url-options-manager.ts
+++ b/packages/phoenix-event-display/src/managers/url-options-manager.ts
@@ -32,8 +32,9 @@ export class URLOptionsManager {
     private eventDisplay: EventDisplay,
     private configuration: Configuration,
   ) {
+    const queryIndex = window.location.href.indexOf('?');
     this.urlOptions = new URLSearchParams(
-      window.location.href.substr(window.location.href.lastIndexOf('?')),
+      queryIndex !== -1 ? window.location.href.substring(queryIndex) : '',
     );
   }
 


### PR DESCRIPTION
hello @EdwardMoyse 
What
Replaced the deprecated String.prototype.substr() call in [url-options-manager.ts](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [String.prototype.substring()](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), along with a guard for URLs that don't contain a query string.

Why
substr() is deprecated in ECMAScript and behaves incorrectly when the URL has no ? character — lastIndexOf('?') returns -1, and substr(-1) extracts just the last character of the URL instead of returning an empty string. This leads to unexpected [URLSearchParams](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) being parsed.

How
Used [indexOf('?')](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to find the query string position
Added a guard: if no ? is found, pass an empty string to [URLSearchParams](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Used [substring()](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) instead of substr() when the ? is present

Fixes #807