### PR TITLE
fix(renderer-manager): make swapRenderers() actually swap renderers (#808)

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/renderer-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/renderer-manager.ts
@@ -177,14 +177,33 @@ export class RendererManager {
   }
 
   /**
-   * Swap any two renderers.
+   * Swap any two renderers in the renderers list.
    * @param rendererA Renderer A to be swapped with renderer B.
    * @param rendererB Renderer B to be swapped with renderer A.
    */
   public swapRenderers(rendererA: WebGLRenderer, rendererB: WebGLRenderer) {
-    const temp: WebGLRenderer = rendererA;
-    rendererA = rendererB;
-    rendererB = temp;
+    const indexA = this.renderers.indexOf(rendererA);
+    const indexB = this.renderers.indexOf(rendererB);
+
+    if (indexA === -1 || indexB === -1) {
+      return;
+    }
+
+    this.renderers[indexA] = rendererB;
+    this.renderers[indexB] = rendererA;
+
+    // Update mainRenderer and overlayRenderer references if involved in the swap
+    if (this.mainRenderer === rendererA) {
+      this.mainRenderer = rendererB;
+    } else if (this.mainRenderer === rendererB) {
+      this.mainRenderer = rendererA;
+    }
+
+    if (this.overlayRenderer === rendererA) {
+      this.overlayRenderer = rendererB;
+    } else if (this.overlayRenderer === rendererB) {
+      this.overlayRenderer = rendererA;
+    }
   }
 
   /**

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/renderer-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/renderer-manager.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+import { RendererManager } from '../../../managers/three-manager/renderer-manager';
+import { WebGLRenderer } from 'three';
+
+// Mock WebGLRenderer since jsdom doesn't support WebGL
+jest.mock('three', () => {
+  const actualThree = jest.requireActual('three');
+  return {
+    ...actualThree,
+    WebGLRenderer: jest.fn().mockImplementation(() => ({
+      setSize: jest.fn(),
+      setPixelRatio: jest.fn(),
+      setAnimationLoop: jest.fn(),
+      render: jest.fn(),
+      domElement: document.createElement('canvas'),
+      localClippingEnabled: false,
+    })),
+  };
+});
+
+describe('RendererManager', () => {
+  let rendererManager: RendererManager;
+
+  beforeEach(() => {
+    rendererManager = new RendererManager();
+  });
+
+  describe('swapRenderers', () => {
+    it('should swap two renderers in the renderers list', () => {
+      const rendererA = new WebGLRenderer();
+      const rendererB = new WebGLRenderer();
+
+      rendererManager.addRenderer(rendererA);
+      rendererManager.addRenderer(rendererB);
+
+      const renderers = rendererManager.getRenderers();
+      const indexA = renderers.indexOf(rendererA);
+      const indexB = renderers.indexOf(rendererB);
+
+      rendererManager.swapRenderers(rendererA, rendererB);
+
+      expect(renderers[indexA]).toBe(rendererB);
+      expect(renderers[indexB]).toBe(rendererA);
+    });
+
+    it('should not modify the list if a renderer is not found', () => {
+      const rendererA = new WebGLRenderer();
+      const rendererB = new WebGLRenderer();
+
+      rendererManager.addRenderer(rendererA);
+      // rendererB is NOT added to the list
+
+      const renderersBefore = [...rendererManager.getRenderers()];
+
+      rendererManager.swapRenderers(rendererA, rendererB);
+
+      expect(rendererManager.getRenderers()).toEqual(renderersBefore);
+    });
+
+    it('should update mainRenderer reference when swapping involves mainRenderer', () => {
+      const mainRenderer = rendererManager.getMainRenderer();
+      const otherRenderer = new WebGLRenderer();
+
+      rendererManager.addRenderer(otherRenderer);
+
+      rendererManager.swapRenderers(mainRenderer, otherRenderer);
+
+      expect(rendererManager.getMainRenderer()).toBe(otherRenderer);
+    });
+
+    it('should update overlayRenderer reference when swapping involves overlayRenderer', () => {
+      const overlayCanvas = document.createElement('canvas');
+      rendererManager.setOverlayRenderer(overlayCanvas);
+
+      const overlayRenderer = rendererManager.getOverlayRenderer();
+      const otherRenderer = new WebGLRenderer();
+      rendererManager.addRenderer(otherRenderer);
+
+      rendererManager.swapRenderers(overlayRenderer, otherRenderer);
+
+      expect(rendererManager.getOverlayRenderer()).toBe(otherRenderer);
+    });
+
+    it('should do nothing when both renderers are the same', () => {
+      const renderer = rendererManager.getMainRenderer();
+      const renderersBefore = [...rendererManager.getRenderers()];
+
+      rendererManager.swapRenderers(renderer, renderer);
+
+      expect(rendererManager.getRenderers()).toEqual(renderersBefore);
+    });
+  });
+});


### PR DESCRIPTION
hello @EdwardMoyse 
The `swapRenderers` method only swapped local parameter references:
```
public swapRenderers(rendererA: WebGLRenderer, rendererB: WebGLRenderer) {
  const temp = rendererA;
  rendererA = rendererB;
  rendererB = temp;
}
```
Since JavaScript passes object references by value, reassigning the parameters inside the function has no effect on the caller or the class's internal state. The method silently did nothing.

**Fix**
Replaced the no-op local swap with logic that:


- Finds both renderers in the internal [this.renderers](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) array by index.
- Swaps their positions in the array.
- Updates [mainRenderer](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [overlayRenderer](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) references if either renderer is involved in the swap.
- Returns early (no-op) if either renderer is not found in the list.

**Tests**
Added [renderer-manager.test.ts](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with 5 test cases covering:
- Swapping two renderers in the list
- No-op when a renderer is not in the list
- Updating [mainRenderer](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) reference when it's part of the swap
- Updating [overlayRenderer](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) reference when it's part of the swap
- Swapping a renderer with itself (identity case)