### PR TITLE
fix: upgrade tween.js to v25 with explicit group management

### DIFF
--- a/packages/phoenix-event-display/package.json
+++ b/packages/phoenix-event-display/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.28.5",
-    "@tweenjs/tween.js": "^23.1.3",
+    "@tweenjs/tween.js": "^25.0.0",
     "dat.gui": "^0.7.9",
     "html2canvas": "^1.4.1",
     "jsroot": "^7.9.1",

--- a/packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts
@@ -1,4 +1,4 @@
-import { Easing, Tween } from '@tweenjs/tween.js';
+import { Easing, Group as TweenGroup, Tween } from '@tweenjs/tween.js';
 import {
   TubeGeometry,
   BufferGeometry,
@@ -45,6 +45,7 @@ export class AnimationsManager {
     private scene: Scene,
     private activeCamera: Camera,
     private rendererManager: RendererManager,
+    private tweenGroup: TweenGroup,
   ) {
     this.animateEvent = this.animateEvent.bind(this);
     this.animateEventWithClipping = this.animateEventWithClipping.bind(this);
@@ -62,7 +63,7 @@ export class AnimationsManager {
     duration: number = 1000,
     easing?: typeof Easing.Linear.None,
   ) {
-    const tween = new Tween(this.activeCamera.position).to(
+    const tween = new Tween(this.activeCamera.position, this.tweenGroup).to(
       { x: pos[0], y: pos[1], z: pos[2] },
       duration,
     );
@@ -187,10 +188,10 @@ export class AnimationsManager {
 
             if (eventObject.geometry instanceof TracksMesh) {
               eventObject.material.progress = 0;
-              const eventObjectTween = new Tween(eventObject.material).to(
-                { progress: 1 },
-                tweenDuration,
-              );
+              const eventObjectTween = new Tween(
+                eventObject.material,
+                this.tweenGroup,
+              ).to({ progress: 1 }, tweenDuration);
               eventObjectTween.onComplete(() => {
                 eventObject.material.progress = 1;
               });
@@ -201,6 +202,7 @@ export class AnimationsManager {
 
               const eventObjectTween = new Tween(
                 eventObject.geometry.drawRange,
+                this.tweenGroup,
               ).to({ count: geometryPosCount }, tweenDuration);
               eventObjectTween.onComplete(() => {
                 eventObject.geometry.drawRange.count = oldDrawRangeCount;
@@ -211,11 +213,14 @@ export class AnimationsManager {
         }
         // Animation for Jets
         else if (eventObject.name === 'Jet') {
-          const scaleTween = new Tween({
-            x: 0.01,
-            y: 0.01,
-            z: 0.01,
-          }).to(
+          const scaleTween = new Tween(
+            {
+              x: 0.01,
+              y: 0.01,
+              z: 0.01,
+            },
+            this.tweenGroup,
+          ).to(
             {
               x: eventObject.scale.x,
               y: eventObject.scale.y,
@@ -264,7 +269,7 @@ export class AnimationsManager {
     });
 
     // Tween for animation sphere
-    const animationSphereTween = new Tween(animationSphere).to(
+    const animationSphereTween = new Tween(animationSphere, this.tweenGroup).to(
       { radius: 3000 },
       tweenDuration,
     );
@@ -296,10 +301,10 @@ export class AnimationsManager {
 
     animationSphereTween.onUpdate(onAnimationSphereUpdate);
 
-    const animationSphereTweenClone = new Tween(animationSphere).to(
-      { radius: 10000 },
-      extraAnimationSphereDuration,
-    );
+    const animationSphereTweenClone = new Tween(
+      animationSphere,
+      this.tweenGroup,
+    ).to({ radius: 10000 }, extraAnimationSphereDuration);
     animationSphereTweenClone.onUpdate(onAnimationSphereUpdate);
 
     animationSphereTween.chain(animationSphereTweenClone);
@@ -379,7 +384,7 @@ export class AnimationsManager {
     // Create tweens for the animation clipping planes
     for (const animationClipPlane of animationClipPlanes) {
       animationClipPlane.constant = 0;
-      const tween = new Tween(animationClipPlane).to(
+      const tween = new Tween(animationClipPlane, this.tweenGroup).to(
         { constant: clippingConstant },
         tweenDuration,
       );
@@ -446,7 +451,7 @@ export class AnimationsManager {
     const particleTweens = [];
 
     for (const particle of particles) {
-      new Tween(particle.material)
+      new Tween(particle.material, this.tweenGroup)
         .to(
           {
             opacity: 1,
@@ -455,7 +460,7 @@ export class AnimationsManager {
         )
         .start();
 
-      const particleToOrigin = new Tween(particle.position)
+      const particleToOrigin = new Tween(particle.position, this.tweenGroup)
         .to(
           {
             z: 0,

--- a/packages/phoenix-event-display/src/managers/three-manager/controls-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/controls-manager.ts
@@ -1,4 +1,4 @@
-import { Tween } from '@tweenjs/tween.js';
+import { Group as TweenGroup, Tween } from '@tweenjs/tween.js';
 import {
   Camera,
   PerspectiveCamera,
@@ -35,15 +35,20 @@ export class ControlsManager {
   private controlsChangeHandler: ((event: any) => void) | null = null;
   /** Track state for hideTubeTracksOnZoom. */
   private tracksHidden: boolean = false;
+  /** Shared tween.js group for animations. */
+  private tweenGroup: TweenGroup;
   /**
    * Constructor for setting up all the controls.
    * @param rendererManager The renderer manager to get the main renderer.
    * @param defaultView The default camera position as [x, y, z] coordinates.
+   * @param tweenGroup Shared tween.js group for animations.
    */
   constructor(
     rendererManager: RendererManager,
     defaultView: number[] = [0, 0, 200],
+    tweenGroup: TweenGroup = new TweenGroup(),
   ) {
+    this.tweenGroup = tweenGroup;
     this.renderr = rendererManager;
 
     const rendererElement = rendererManager.getMainRenderer()?.domElement;
@@ -650,7 +655,7 @@ export class ControlsManager {
     const objectPosition = this.getObjectPosition(uuid, objectsGroup);
     if (objectPosition) {
       // Moving the camera to the object's position and then zooming out
-      new Tween(this.getMainCamera().position)
+      new Tween(this.getMainCamera().position, this.tweenGroup)
         .to(
           {
             x: objectPosition.x * 1.1 + offset,

--- a/packages/phoenix-event-display/src/managers/three-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/index.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from '@angular/core';
-import { Tween, update as tweenUpdate } from '@tweenjs/tween.js';
+import { Group as TweenGroup, Tween } from '@tweenjs/tween.js';
 import type { Object3DEventMap, Intersection } from 'three';
 import {
   Group,
@@ -77,6 +77,8 @@ export class ThreeManager {
   private arManager: ARManager;
   /** Coloring manager for three.js functions related to coloring of objects. */
   private colorManager: ColorManager;
+  /** Shared tween.js group for all animation tweens. */
+  private tweenGroup = new TweenGroup();
   /** Loading manager for loadable resources. */
   private loadingManager: LoadingManager;
   /** State manager for managing the scene's state. */
@@ -169,6 +171,7 @@ export class ThreeManager {
     this.controlsManager = new ControlsManager(
       this.rendererManager,
       configuration.defaultView,
+      this.tweenGroup,
     );
     this.controlsManager.hideTubeTracksOnZoom(
       this.sceneManager.getScene(),
@@ -185,6 +188,7 @@ export class ThreeManager {
       this.sceneManager.getScene(),
       this.controlsManager.getMainCamera(),
       this.rendererManager,
+      this.tweenGroup,
     );
     // VR manager
     this.vrManager = new VRManager();
@@ -209,6 +213,7 @@ export class ThreeManager {
       this.sceneManager.getScene(),
       this.effectsManager,
       this.infoLogger,
+      this.tweenGroup,
     );
     // Set camera of the event display state
     new StateManager().setCamera(this.controlsManager.getMainCamera());
@@ -230,7 +235,6 @@ export class ThreeManager {
     this.controlsManager.getMainControls().update();
     this.controlsManager.getOverlayControls()?.update();
     // this.controlsManager.updateSync();
-    tweenUpdate();
   }
 
   /**
@@ -266,7 +270,7 @@ export class ThreeManager {
     const now = performance.now();
 
     // Update TWEEN animations
-    tweenUpdate(now);
+    this.tweenGroup.update(now);
 
     if (this.controlsManager.isOverlayLinked())
       this.controlsManager.syncOverlayFromMain();
@@ -1200,6 +1204,7 @@ export class ThreeManager {
   private animateCameraPosition(cameraPosition: number[], duration: number) {
     const posAnimation = new Tween(
       this.controlsManager.getMainCamera().position,
+      this.tweenGroup,
     );
     posAnimation.to(
       {
@@ -1220,6 +1225,7 @@ export class ThreeManager {
   private animateCameraTarget(cameraTarget: number[], duration: number) {
     const rotAnimation = new Tween(
       this.controlsManager.getMainControls().target,
+      this.tweenGroup,
     );
     rotAnimation.to(
       {

--- a/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
@@ -10,7 +10,7 @@ import {
   AxesHelper,
   Mesh,
 } from 'three';
-import * as TWEEN from '@tweenjs/tween.js';
+import { Easing, Group as TweenGroup, Tween } from '@tweenjs/tween.js';
 import { InfoLogger } from '../../helpers/info-logger';
 import { EffectsManager } from './effects-manager';
 import { PrettySymbols } from '../../helpers/pretty-symbols';
@@ -92,6 +92,8 @@ export class SelectionManager {
   private smoothedFPS = 60;
   /** FPS smoothing factor */
   private readonly FPS_SMOOTHING = 0.1;
+  /** Shared tween.js group for animations. */
+  private tweenGroup: TweenGroup;
 
   // Hysteresis thresholds to prevent oscillation
   /** Performance thresholds for dynamic frame skipping to maintain stable FPS. */
@@ -140,6 +142,7 @@ export class SelectionManager {
     scene: Scene,
     effectsManager: EffectsManager,
     infoLogger: InfoLogger,
+    tweenGroup: TweenGroup = new TweenGroup(),
   ) {
     this.getControls = getControls;
     this.getOverlayControls = getOverlayControls;
@@ -148,6 +151,7 @@ export class SelectionManager {
     this.isInit = true;
     this.infoLogger = infoLogger;
     this.effectsManager = effectsManager;
+    this.tweenGroup = tweenGroup;
     // Custom outline system is now used instead of OutlinePass
 
     // Always enable passive double-click detection for both canvases
@@ -402,7 +406,7 @@ export class SelectionManager {
         };
 
         // Create tween for smooth transition
-        const targetTween = new TWEEN.Tween(currentTarget)
+        const targetTween = new Tween(currentTarget, this.tweenGroup)
           .to(
             {
               x: point.x,
@@ -411,7 +415,7 @@ export class SelectionManager {
             },
             1000,
           ) // 1 second duration
-          .easing(TWEEN.Easing.Cubic.Out) // Smooth easing
+          .easing(Easing.Cubic.Out) // Smooth easing
           .onUpdate(() => {
             // Update controls target during animation
             controls.target.set(

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/animations-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/animations-manager.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { Easing } from '@tweenjs/tween.js';
+import { Easing, Group as TweenGroup } from '@tweenjs/tween.js';
 import { Camera, Object3D, PerspectiveCamera, Scene, Vector3 } from 'three';
 import {
   AnimationsManager,
@@ -19,7 +19,12 @@ describe('AnimationsManager', () => {
   beforeEach(() => {
     scene = new Scene();
     camera = new PerspectiveCamera();
-    animationsManager = new AnimationsManager(scene, camera, rendererManager);
+    animationsManager = new AnimationsManager(
+      scene,
+      camera,
+      rendererManager,
+      new TweenGroup(),
+    );
   });
 
   afterEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6268,7 +6268,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tweenjs/tween.js@npm:^23.1.3, @tweenjs/tween.js@npm:~23.1.3":
+"@tweenjs/tween.js@npm:^25.0.0":
+  version: 25.0.0
+  resolution: "@tweenjs/tween.js@npm:25.0.0"
+  checksum: 457052e70954dd6f40aa722d3770007c0e000edc10d0ca3d33626848e92adb08b666eb3d6b731eeb4238c1652e704500ed0b0b511f4a5a0a36da9f26cce3f6db
+  languageName: node
+  linkType: hard
+
+"@tweenjs/tween.js@npm:~23.1.3":
   version: 23.1.3
   resolution: "@tweenjs/tween.js@npm:23.1.3"
   checksum: 2f8a908b275bb6729bde4b863c277bf7411d2e0302ceb0455369479077b89eaf8380cd9206b91ff574416418a95c6f06db4e1ddea732a286d0db0ba8e7c093d3
@@ -16537,7 +16544,7 @@ __metadata:
     "@babel/helper-string-parser": ^7.27.1
     "@babel/plugin-transform-runtime": ^7.28.5
     "@compodoc/compodoc": ^1.1.32
-    "@tweenjs/tween.js": ^23.1.3
+    "@tweenjs/tween.js": ^25.0.0
     "@types/dat.gui": ^0.7.13
     "@types/three": ~0.178.1
     dat.gui: ^0.7.9


### PR DESCRIPTION




## Summary

In this PR, I upgraded `@tweenjs/tween.js` from v23 to v25, which fixes #680.

In v25, tween.js removed implicit global group registration. That means tweens are no longer automatically tracked — they must be explicitly added to a `Group` and updated using `group.update()`. Without this change, all tween-based animations silently fail.

To address this:

* I created a shared `TweenGroup` instance inside `ThreeManager`
* Passed this shared group to `AnimationsManager`, `ControlsManager`, and `SelectionManager`
* Updated all `new Tween(obj)` calls to explicitly pass the group:

  ```js
  new Tween(obj, tweenGroup)
  ```
* Replaced the global `tweenUpdate()` call with `tweenGroup.update(now)` inside the render loop
* Fixed a pre-existing bug where `tweenUpdate()` was being called twice per frame

---

## What Was Broken (Before This Fix)

All tween-based animations were silently failing, including:

* “Look at Object” camera animation
* Event collision / propagation animation
* Double-click orbit target smooth transition
* Camera fly-through presets

The +/- zoom buttons were unaffected because they directly manipulate the camera and don’t use tweens.

---

## Test Plan

* Load an event at `http://localhost:4200/atlas`
* Click an object → use “Look at Object” → camera smoothly animates
* Click animate event → collision / propagation animation plays
* Double-click a surface → orbit target transitions smoothly
* Verify +/- zoom buttons still work as expected

---

This upgrade restores all tween-driven animations and aligns the project with the new tween.js v25 architecture.

https://github.com/user-attachments/assets/b6368d2f-05e9-4a10-b0f2-fa865c00d2d5

