### PR TITLE
fix: deduplicate three.js instance bundled by jsroot

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/phoenix-ng/projects/*"
   ],
   "scripts": {
-    "postinstall": "yarn workspace phoenix-event-display prepare && husky",
+    "postinstall": "node scripts/patch-jsroot-three.js && yarn workspace phoenix-event-display prepare && husky",
     "start": "lerna run start",
     "start:ssl": "yarn workspace phoenix-ng start:ssl",
     "test:ci": "lerna run test:ci",
@@ -43,6 +43,9 @@
     "ts-jest-mock-import-meta": "^1.2.1",
     "ts-node": "^10.9.2",
     "typescript": "~5.5.4"
+  },
+  "resolutions": {
+    "three": "~0.178.0"
   },
   "packageManager": "yarn@3.3.1",
   "peerDependencies": {

--- a/scripts/patch-jsroot-three.js
+++ b/scripts/patch-jsroot-three.js
@@ -1,0 +1,21 @@
+/**
+ * Patch jsroot's inlined three.js to re-export from the project's single three.js instance.
+ * This prevents the "Multiple instances of Three.js being imported" warning.
+ * See: https://github.com/HSF/phoenix/issues/655
+ */
+const fs = require('fs');
+const path = require('path');
+
+const jsrootThree = path.resolve(
+  __dirname,
+  '../node_modules/jsroot/modules/three.mjs',
+);
+
+if (fs.existsSync(jsrootThree)) {
+  fs.writeFileSync(jsrootThree, "export * from 'three';\n");
+  console.log(
+    'Patched jsroot/modules/three.mjs to re-export from project three.js',
+  );
+} else {
+  console.log('jsroot/modules/three.mjs not found, skipping patch');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19384,13 +19384,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three@npm:0.162.0":
-  version: 0.162.0
-  resolution: "three@npm:0.162.0"
-  checksum: f3ba4d518f7cb209b6e4f8818177c1230014fc1b3dcd66ab113a9babf8e2b522645a1eb144dfc0900bf194e8890bc5d04f358dd4a7f06ee8aa44db56224f88fc
-  languageName: node
-  linkType: hard
-
 "three@npm:~0.178.0":
   version: 0.178.0
   resolution: "three@npm:0.178.0"


### PR DESCRIPTION

## Summary

Fixes #655

JSROOT bundles its own copy of three.js (v174) directly inside  
`jsroot/modules/three.mjs` (~59K lines). This results in a second
three.js instance being loaded at runtime alongside Phoenix's
three.js (v178), triggering the warning:

```

WARNING: Multiple instances of Three.js being imported.

````

Having multiple instances of three.js can lead to issues such as:
- memory leaks
- `instanceof` check failures across module boundaries
- other undefined behavior at runtime

---

## Fix

- Added a **Yarn resolution** in the root `package.json` to enforce a
  single `three@~0.178.0` version across dependencies.

- Added a **postinstall patch script**  
  `scripts/patch-jsroot-three.js` that replaces JSROOT's inlined
  three.js implementation with a simple re-export:

```js
export * from 'three'
````

The patch runs automatically during `yarn install`, ensuring the
fix is applied transparently without requiring any manual steps.

---

## Verification

* Confirmed that only **one REVISION (178)** exists in the bundled
  `vendor.js`. The duplicate version (**174**) is no longer present.

* The console warning no longer appears when running Phoenix on
  my localhost. I have attached a video below showing a comparison
  between the official Phoenix demo website and my local
  environment after applying the fix.


https://github.com/user-attachments/assets/a0e19116-ac70-453d-91eb-678d5c8d400c

