### PR TITLE
feat: add command palette for quick access to actions and collections

### DIFF
--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -12,6 +12,7 @@ import { StateManager } from '../../managers/state-manager';
 import { loadFile, saveFile } from '../../helpers/file';
 import { DatGUIMenuUI } from './dat-gui-ui';
 import { PhoenixMenuUI } from './phoenix-menu/phoenix-menu-ui';
+import { PhoenixMenuNode } from './phoenix-menu/phoenix-menu-node';
 import {
   getFromLocalStorage,
   setToLocalStorage,
@@ -478,6 +479,14 @@ export class UIManager {
    */
   public shiftCartesianGridByPointer() {
     this.three.shiftCartesianGrid();
+  }
+
+  /**
+   * Get the root node of the Phoenix menu tree.
+   * @returns The root PhoenixMenuNode, or undefined if not configured.
+   */
+  public getPhoenixMenuRoot(): PhoenixMenuNode | undefined {
+    return this.configuration?.phoenixMenuRoot;
   }
 
   /**

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.html
@@ -22,6 +22,7 @@
     [eventDataImportOptions]="eventDataImportOptions"
   ></app-io-options>
   <app-share-link></app-share-link>
+  <app-command-palette></app-command-palette>
   <app-vp-toggle></app-vp-toggle>
 </app-ui-menu-wrapper>
 <app-embed-menu></app-embed-menu>

--- a/packages/phoenix-ng/projects/phoenix-app/src/assets/icons/command.svg
+++ b/packages/phoenix-ng/projects/phoenix-app/src/assets/icons/command.svg
@@ -1,0 +1,8 @@
+<svg width="0" height="0" class="hidden">
+	<symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="command">
+		<g fill="none" stroke="var(--phoenix-options-icon-path, #fff)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+			<polyline points="4 17 10 11 4 5"></polyline>
+			<line x1="12" y1="19" x2="20" y2="19"></line>
+		</g>
+	</symbol>
+</svg>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-ui.module.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-ui.module.ts
@@ -65,6 +65,7 @@ import {
   EventDataExplorerComponent,
   EventDataExplorerDialogComponent,
   CycleEventsComponent,
+  CommandPaletteComponent,
 } from './ui-menu';
 
 import { AttributePipe } from '../services/extras/attribute.pipe';
@@ -127,6 +128,7 @@ const PHOENIX_COMPONENTS: Type<any>[] = [
   FileExplorerComponent,
   RingLoaderComponent,
   CycleEventsComponent,
+  CommandPaletteComponent,
 ];
 
 @NgModule({

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/command-palette/command-palette.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/command-palette/command-palette.component.html
@@ -1,0 +1,61 @@
+<button
+  class="menu-toggle"
+  matTooltip="Command palette ( / )"
+  matTooltipPosition="above"
+  matTooltipTouchGestures="off"
+  (click)="toggle()"
+>
+  <svg class="menu-toggle-icon" [ngClass]="{ 'active-icon': isOpen }">
+    <use href="assets/icons/command.svg#command"></use>
+  </svg>
+</button>
+
+<div class="command-backdrop" *ngIf="isOpen" (click)="close()"></div>
+<div class="command-palette" *ngIf="isOpen" (click)="$event.stopPropagation()">
+  <div class="command-header">
+    <svg class="command-search-icon">
+      <use href="assets/icons/help.svg#help"></use>
+    </svg>
+    <input
+      #searchInput
+      type="text"
+      class="command-input"
+      placeholder="Search collections, actions, shortcuts..."
+      [(ngModel)]="query"
+      (input)="onSearch()"
+      (keydown)="onKeyDown($event)"
+      autocomplete="off"
+      spellcheck="false"
+    />
+    <span class="command-hint">esc</span>
+  </div>
+  <div class="command-results" *ngIf="results.length > 0">
+    <div
+      *ngFor="let cmd of results; let i = index"
+      class="command-result"
+      [class.active]="i === activeIndex"
+      (mouseenter)="setActive(i)"
+      (click)="execute(cmd)"
+    >
+      <span class="command-category" [attr.data-category]="cmd.category">
+        {{ cmd.category }}
+      </span>
+      <span class="command-label">{{ cmd.label }}</span>
+      <span class="command-shortcut" *ngIf="cmd.shortcut">
+        {{ cmd.shortcut }}
+      </span>
+    </div>
+  </div>
+  <div class="command-empty" *ngIf="results.length === 0 && query">
+    No results for "<strong>{{ query }}</strong
+    >"
+  </div>
+  <div class="command-footer">
+    <span><kbd>↑↓</kbd> navigate</span>
+    <span><kbd>↵</kbd> select</span>
+    <span><kbd>esc</kbd> close</span>
+    <span class="command-footer-right"
+      ><kbd>/</kbd> or <kbd>Ctrl K</kbd> to open</span
+    >
+  </div>
+</div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/command-palette/command-palette.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/command-palette/command-palette.component.scss
@@ -1,0 +1,232 @@
+:host {
+  display: flex;
+  margin: 0 0.6rem;
+}
+
+.menu-toggle {
+  display: flex;
+  background: unset;
+  border: none;
+  height: 2.5rem;
+  width: 2.5rem;
+  min-height: 2.5rem;
+  min-width: 2.5rem;
+  padding: 0.65rem;
+  cursor: pointer;
+  align-self: center;
+  transition: all 0.4s;
+
+  &-icon {
+    width: 100%;
+    height: 100%;
+
+    &.active-icon {
+      --phoenix-options-icon-path: #00bcd4;
+    }
+  }
+
+  &:hover {
+    background-color: var(--phoenix-options-icon-bg);
+    border-radius: 40%;
+    transition: all 0.4s;
+  }
+}
+
+.command-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 9998;
+  backdrop-filter: blur(2px);
+}
+
+.command-palette {
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(560px, 90vw);
+  background: var(--phoenix-background-color-secondary);
+  border: 1px solid var(--phoenix-border);
+  border-radius: 12px;
+  box-shadow:
+    0 16px 48px rgba(0, 0, 0, 0.25),
+    0 0 0 1px var(--phoenix-background-color-tertiary);
+  z-index: 9999;
+  overflow: hidden;
+  animation: paletteIn 0.15s ease-out;
+}
+
+@keyframes paletteIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) scale(0.96) translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) scale(1) translateY(0);
+  }
+}
+
+.command-header {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--phoenix-border);
+  gap: 0.6rem;
+}
+
+.command-search-icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  opacity: 0.5;
+
+  path,
+  use {
+    fill: var(--phoenix-text-color-secondary);
+  }
+}
+
+.command-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--phoenix-text-color);
+  font-size: 0.95rem;
+  font-family: inherit;
+
+  &::placeholder {
+    color: var(--phoenix-text-color-secondary);
+    opacity: 0.6;
+  }
+}
+
+.command-hint {
+  font-size: 0.65rem;
+  color: var(--phoenix-text-color-secondary);
+  background: var(--phoenix-background-color-tertiary);
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.command-results {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 0.35rem 0;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--phoenix-scroll-color);
+    border-radius: 4px;
+  }
+}
+
+.command-result {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  gap: 0.6rem;
+  transition: background 0.1s;
+
+  &:hover,
+  &.active {
+    background: var(--phoenix-background-color-tertiary);
+  }
+
+  &.active {
+    .command-label {
+      color: var(--phoenix-accent);
+    }
+  }
+}
+
+.command-category {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 4.5rem;
+  text-align: center;
+
+  &[data-category='Action'] {
+    background: rgba(0, 188, 212, 0.15);
+    color: var(--phoenix-accent);
+  }
+
+  &[data-category='View'] {
+    background: rgba(17, 138, 178, 0.15);
+    color: var(--phoenix-primary);
+  }
+
+  &[data-category='Collection'] {
+    background: rgba(241, 232, 51, 0.15);
+    color: #c4b800;
+  }
+
+  &[data-category='Geometry'] {
+    background: rgba(156, 39, 176, 0.12);
+    color: #b060c0;
+  }
+}
+
+.command-label {
+  flex: 1;
+  font-size: 0.85rem;
+  color: var(--phoenix-text-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-shortcut {
+  font-size: 0.7rem;
+  color: var(--phoenix-text-color-secondary);
+  background: var(--phoenix-background-color-tertiary);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--phoenix-border);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.command-empty {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: var(--phoenix-text-color-secondary);
+  font-size: 0.85rem;
+}
+
+.command-footer {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--phoenix-border);
+  gap: 1rem;
+  font-size: 0.65rem;
+  color: var(--phoenix-text-color-secondary);
+
+  kbd {
+    background: var(--phoenix-background-color-tertiary);
+    border: 1px solid var(--phoenix-border);
+    border-radius: 3px;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.6rem;
+    font-family: inherit;
+  }
+}
+
+.command-footer-right {
+  margin-left: auto;
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/command-palette/command-palette.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/command-palette/command-palette.component.ts
@@ -1,0 +1,286 @@
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
+import { EventDisplayService } from '../../../services/event-display.service';
+import type { PhoenixMenuNode } from 'phoenix-event-display';
+
+export interface PaletteCommand {
+  label: string;
+  category: string;
+  shortcut?: string;
+  execute: () => void;
+}
+
+@Component({
+  standalone: false,
+  selector: 'app-command-palette',
+  templateUrl: './command-palette.component.html',
+  styleUrls: ['./command-palette.component.scss'],
+})
+export class CommandPaletteComponent implements OnInit, OnDestroy {
+  isOpen = false;
+  query = '';
+  results: PaletteCommand[] = [];
+  activeIndex = 0;
+
+  private commands: PaletteCommand[] = [];
+  private refreshTimer: any;
+  private darkTheme = false;
+  private clippingOn = false;
+  private rotating = false;
+
+  @ViewChild('searchInput') searchInput: ElementRef<HTMLInputElement>;
+
+  constructor(private eventDisplay: EventDisplayService) {}
+
+  ngOnInit() {
+    this.darkTheme = this.eventDisplay.getUIManager().getDarkTheme();
+    this.registerBuiltInCommands();
+    // Rebuild menu commands periodically until event data is loaded
+    this.refreshTimer = setInterval(() => this.rebuildMenuCommands(), 2000);
+  }
+
+  ngOnDestroy() {
+    clearInterval(this.refreshTimer);
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  onGlobalKeyDown(e: KeyboardEvent) {
+    const tag = (e.target as HTMLElement)?.tagName?.toLowerCase();
+    if (tag === 'input' || tag === 'textarea') return;
+
+    if ((e.ctrlKey || e.metaKey) && e.code === 'KeyK') {
+      e.preventDefault();
+      this.toggle();
+    } else if (e.code === 'Slash' && !e.shiftKey && !e.ctrlKey) {
+      e.preventDefault();
+      this.toggle();
+    }
+  }
+
+  toggle() {
+    this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.query = '';
+      this.activeIndex = 0;
+      this.rebuildMenuCommands();
+      this.results = this.getDefaultResults();
+      setTimeout(() => this.searchInput?.nativeElement?.focus(), 50);
+    }
+  }
+
+  close() {
+    this.isOpen = false;
+  }
+
+  onSearch() {
+    this.activeIndex = 0;
+    if (!this.query.trim()) {
+      this.results = this.getDefaultResults();
+      return;
+    }
+    const q = this.query.toLowerCase();
+    const scored = this.commands
+      .map((cmd) => ({
+        cmd,
+        score: this.matchScore(cmd, q),
+      }))
+      .filter((s) => s.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 20);
+    this.results = scored.map((s) => s.cmd);
+  }
+
+  onKeyDown(e: KeyboardEvent) {
+    switch (e.code) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this.activeIndex = Math.min(
+          this.activeIndex + 1,
+          this.results.length - 1,
+        );
+        this.scrollActiveIntoView();
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        this.activeIndex = Math.max(this.activeIndex - 1, 0);
+        this.scrollActiveIntoView();
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (this.results[this.activeIndex]) {
+          this.execute(this.results[this.activeIndex]);
+        }
+        break;
+      case 'Escape':
+        this.close();
+        break;
+    }
+  }
+
+  execute(cmd: PaletteCommand) {
+    cmd.execute();
+    this.close();
+  }
+
+  setActive(index: number) {
+    this.activeIndex = index;
+  }
+
+  private matchScore(cmd: PaletteCommand, query: string): number {
+    const label = cmd.label.toLowerCase();
+    const cat = cmd.category.toLowerCase();
+    if (label === query) return 100;
+    if (label.startsWith(query)) return 80;
+    if (label.includes(query)) return 60;
+    if (cat.includes(query)) return 30;
+    // Fuzzy: check if all query chars appear in order
+    let qi = 0;
+    for (let i = 0; i < label.length && qi < query.length; i++) {
+      if (label[i] === query[qi]) qi++;
+    }
+    return qi === query.length ? 20 : 0;
+  }
+
+  private scrollActiveIntoView() {
+    setTimeout(() => {
+      const el = document.querySelector('.command-result.active');
+      el?.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  private getDefaultResults(): PaletteCommand[] {
+    return this.commands.slice(0, 20);
+  }
+
+  private registerBuiltInCommands() {
+    this.commands = [
+      {
+        label: 'Toggle Dark Theme',
+        category: 'Action',
+        shortcut: '⇧ T',
+        execute: () => {
+          this.darkTheme = !this.darkTheme;
+          this.eventDisplay.getUIManager().setDarkTheme(this.darkTheme);
+        },
+      },
+      {
+        label: 'Toggle Auto Rotate',
+        category: 'Action',
+        shortcut: '⇧ R',
+        execute: () => {
+          this.rotating = !this.rotating;
+          this.eventDisplay.getThreeManager().autoRotate(this.rotating);
+        },
+      },
+      {
+        label: 'Zoom In',
+        category: 'Action',
+        shortcut: '⇧ +',
+        execute: () => this.eventDisplay.getThreeManager().zoomTo(1 / 1.2, 100),
+      },
+      {
+        label: 'Zoom Out',
+        category: 'Action',
+        shortcut: '⇧ -',
+        execute: () => this.eventDisplay.getThreeManager().zoomTo(1.2, 100),
+      },
+      {
+        label: 'Toggle Clipping',
+        category: 'Action',
+        shortcut: '⇧ C',
+        execute: () => {
+          this.clippingOn = !this.clippingOn;
+          const tm = this.eventDisplay.getThreeManager();
+          tm.setClipping(this.clippingOn);
+          if (this.clippingOn) tm.setClippingAngle(0, 180);
+        },
+      },
+      {
+        label: 'Reset Camera',
+        category: 'Action',
+        shortcut: '⇧ V',
+        execute: () => this.eventDisplay.getThreeManager().revertMainCamera(),
+      },
+      {
+        label: 'Toggle Cartesian Grid',
+        category: 'View',
+        execute: () => {
+          const sm = this.eventDisplay.getThreeManager().getSceneManager();
+          const grid = sm.getScene().getObjectByName('CartesianGrid');
+          if (grid) sm.objectVisibility(grid, !grid.visible);
+        },
+      },
+      {
+        label: 'Toggle Axes',
+        category: 'View',
+        execute: () => {
+          const sm = this.eventDisplay.getThreeManager().getSceneManager();
+          const axes = sm.getScene().getObjectByName('Axes');
+          if (axes) sm.objectVisibility(axes, !axes.visible);
+        },
+      },
+    ];
+
+    this.addPresetViews();
+  }
+
+  private addPresetViews() {
+    const ui = this.eventDisplay.getUIManager();
+    const views = ui?.getPresetViews?.();
+    if (views) {
+      views.forEach((view: any, i: number) => {
+        this.commands.push({
+          label: `View: ${view.label}`,
+          category: 'View',
+          shortcut: i < 9 ? `⇧ ${i + 1}` : undefined,
+          execute: () => this.eventDisplay.getUIManager().displayView(view),
+        });
+      });
+    }
+  }
+
+  private rebuildMenuCommands() {
+    // Remove old dynamic commands
+    this.commands = this.commands.filter(
+      (c) => c.category !== 'Collection' && c.category !== 'Geometry',
+    );
+
+    const root = this.eventDisplay.getUIManager()?.getPhoenixMenuRoot?.();
+    if (root && root.children.length > 0) {
+      const prevCount = this.commands.length;
+      this.walkTree(root);
+      // Stop polling once tree is stable
+      if (this.commands.length === prevCount && prevCount > 8) {
+        clearInterval(this.refreshTimer);
+      }
+    }
+  }
+
+  private walkTree(node: PhoenixMenuNode, path: string = '') {
+    for (const child of node.children) {
+      const fullPath = path ? `${path} › ${child.name}` : child.name;
+      const isGeometry = fullPath.startsWith('Detector');
+
+      if (child.onToggle) {
+        this.commands.push({
+          label: fullPath,
+          category: isGeometry ? 'Geometry' : 'Collection',
+          execute: () => {
+            const newState = !child.toggleState;
+            child.toggleSelfAndDescendants(newState);
+          },
+        });
+      }
+
+      if (child.children.length > 0) {
+        this.walkTree(child, fullPath);
+      }
+    }
+  }
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/index.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/index.ts
@@ -37,3 +37,4 @@ export * from './event-data-explorer/event-data-explorer.component';
 export * from './event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component';
 export * from './cycle-events/cycle-events.component';
 export * from './ui-menu-wrapper/ui-menu-wrapper.component';
+export * from './command-palette/command-palette.component';

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.html
@@ -61,6 +61,9 @@
   <!-- Toggle for shareable link constructor modal-->
   <app-share-link></app-share-link>
 
+  <!-- Command palette trigger -->
+  <app-command-palette></app-command-palette>
+
   <!-- Extra options -->
   <ng-content></ng-content>
 </app-ui-menu-wrapper>


### PR DESCRIPTION
### Summary

This adds a command palette to Phoenix so actions and collections can be accessed quickly from a searchable menu.

You can open it with `/`, `Ctrl+K`, or by clicking a `>_` button added to the toolbar.  
The idea is similar to the command palette used in editors like VS Code — instead of navigating menus, you can just search for what you want to do.

The palette walks the existing Phoenix menu tree, so it automatically discovers actions, collections, and geometry controls from the loaded event.

---

### Features

- Fuzzy search across commands
- Keyboard navigation (↑ ↓ Enter Esc)
- Toolbar button (`>_`) so it’s easy to access without shortcuts
- Automatically discovers collections and geometry from the event
- Includes common actions like:
  - dark theme toggle
  - auto rotate
  - clipping
  - zoom
  - reset camera
  - cartesian grid / axes
- Works across the existing experiment views (ATLAS, CMS, LHCb, TrackML, Playground)

---

### Changes

New command palette component:

- `command-palette.component.ts`
- `command-palette.component.html`
- `command-palette.component.scss`

Toolbar integration:

- added `<app-command-palette>` to `ui-menu.component.html`
- added `<app-command-palette>` to `lhcb.component.html`

Other changes:

- new toolbar icon `command.svg` (`>_`)
- export added in `ui-menu/index.ts`
- component registered in `phoenix-ui.module.ts`
- `ui-manager/index.ts` exposes `getPhoenixMenuRoot()` so the palette can read the menu structure

---

### Testing

Things I checked locally:

- `>_` icon appears in the toolbar for ATLAS/CMS and opens the palette
- `/` and `Ctrl+K` both open the palette
- typing filters results
- arrow keys move through results, Enter runs the command
- Esc closes it
- toggling things like dark theme, clipping, rotate works
- collections visibility can be toggled from the palette
- works the same in the LHCb view
- icon doesn't conflict with the existing info icon (`ℹ`)

Everything seems to behave the same as before, just with faster access to actions.







https://github.com/user-attachments/assets/32ccf584-84cf-406b-8755-fec2af8a0d4c



