### PR TITLE
feat: add default outline to jets for better overlap visibility

### DIFF
--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -22,6 +22,7 @@ import {
   LineSegments,
   LineDashedMaterial,
   CanvasTexture,
+  EdgesGeometry,
 } from 'three';
 import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js';
 import { EVENT_DATA_TYPE_COLORS } from '../../helpers/constants';
@@ -254,6 +255,22 @@ export class PhoenixObjects {
     mesh.name = 'Jet';
     // Setting uuid for selection from collections info
     jetParams.uuid = mesh.uuid;
+
+    // Add wireframe cage outline so overlapping jets are distinguishable.
+    // Use a low-poly cylinder (12 segments) for clean polygonal edges
+    // over the smooth filled cone (50 segments).
+    const outlineGeo = new CylinderGeometry(width, 10, length, 12, 1, false);
+    const edges = new EdgesGeometry(outlineGeo, 1);
+    outlineGeo.dispose();
+    const jetColor = new Color(jetParams.color ?? EVENT_DATA_TYPE_COLORS.Jets);
+    const outlineColor = jetColor.clone().offsetHSL(0, 0, 0.35);
+    const outlineMaterial = new LineBasicMaterial({
+      color: outlineColor,
+      depthTest: true,
+    });
+    const outline = new LineSegments(edges, outlineMaterial);
+    outline.name = 'JetOutline';
+    mesh.add(outline);
 
     return mesh;
   }

--- a/packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts
@@ -290,6 +290,9 @@ export class EffectsManager {
       return; // Already selected
     }
 
+    // Hide default jet outline while selection outline is active
+    this.setDefaultOutlineVisibility(object, false);
+
     // Create outline helper for this object
     const outlineHelper = this.createOutlineHelper(object);
     this.selectedOutlines.set(object, outlineHelper);
@@ -309,6 +312,9 @@ export class EffectsManager {
       outlineHelper.geometry.dispose();
       (outlineHelper.material as ShaderMaterial).dispose();
       this.selectedOutlines.delete(object);
+
+      // Restore default jet outline
+      this.setDefaultOutlineVisibility(object, true);
     }
   }
 
@@ -336,6 +342,8 @@ export class EffectsManager {
       outlineHelper.removeFromParent();
       outlineHelper.geometry.dispose();
       (outlineHelper.material as ShaderMaterial).dispose();
+      // Restore default jet outline
+      this.setDefaultOutlineVisibility(object, true);
     }
     this.selectedOutlines.clear();
   }
@@ -356,16 +364,33 @@ export class EffectsManager {
       this.hoverOutline.removeFromParent();
       this.hoverOutline.geometry.dispose();
       (this.hoverOutline.material as ShaderMaterial).dispose();
+      // Restore default outline on previous hover target (unless it's selected)
+      if (this.hoverTarget && !this.selectedOutlines.has(this.hoverTarget)) {
+        this.setDefaultOutlineVisibility(this.hoverTarget, true);
+      }
       this.hoverOutline = null;
       this.hoverTarget = null;
     }
 
     // Create new hover outline if object provided and not already selected
     if (object && !this.selectedOutlines.has(object)) {
+      // Hide default outline while hover outline is active
+      this.setDefaultOutlineVisibility(object, false);
       this.hoverOutline = this.createOutlineHelper(object, true); // Different style for hover
       this.hoverTarget = object;
       // Add as child of the object so outline inherits all transformations
       object.add(this.hoverOutline);
+    }
+  }
+
+  /**
+   * Show or hide the default outline (e.g. JetOutline) on an object.
+   * Used to avoid visual conflict between default and selection/hover outlines.
+   */
+  private setDefaultOutlineVisibility(object: Mesh, visible: boolean) {
+    const defaultOutline = object.getObjectByName('JetOutline');
+    if (defaultOutline) {
+      defaultOutline.visible = visible;
     }
   }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/share-link/share-link-dialog/share-link-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/share-link/share-link-dialog/share-link-dialog.component.ts
@@ -85,7 +85,7 @@ export class ShareLinkDialogComponent implements AfterViewInit, OnDestroy {
     if (include) {
       const stateManager = this.eventDisplay.getStateManager();
       if (stateManager) {
-        const state = stateManager.getStateAsJSON();
+        const state = stateManager.saveStateAsJSON();
         const jsonStr = JSON.stringify(state);
         // Compress using built-in deflate to keep URL manageable
         const stream = new Blob([jsonStr])


### PR DESCRIPTION
#### Related issues

Fixes #571

#### Description

Adds a default outline to jet cones to make overlapping jets easier to distinguish.

Each jet now gets a wireframe outline mesh when created. The outline is generated from a low-poly cylinder geometry and rendered using `EdgesGeometry`, producing a clean cage (top rim, bottom rim, and vertical edges). The outline color is the jet’s own color slightly brightened to keep it visible against the semi-transparent fill.

The outline mesh is named `JetOutline` so it can be managed by the selection system. When hover or selection outlines are active, `EffectsManager` temporarily hides the default outline to avoid visual conflicts and restores it when the object is no longer highlighted.

Also fixes a small API rename in the share-link dialog (`getStateAsJSON` → `saveStateAsJSON`).

#### Test plan

- Load an ATLAS event and confirm jet outlines are visible and overlapping jets are easier to distinguish
- Hover/select jets and verify selection outlines behave correctly
- Open the share-link dialog and confirm there are no compile errors
<img width="2557" height="1425" alt="Screenshot 2026-03-10 002422" src="https://github.com/user-attachments/assets/b10c675b-998c-4259-b089-78635481fe28" />


