### PR TITLE
fix: use InstancedMesh for CaloCells to prevent WebGL crash (#474)

### DIFF
--- a/packages/phoenix-event-display/src/loaders/object-type-registry.ts
+++ b/packages/phoenix-event-display/src/loaders/object-type-registry.ts
@@ -89,7 +89,8 @@ export function getDefaultObjectTypeConfigs(): ObjectTypeConfig[] {
     },
     {
       typeName: 'CaloCells',
-      getObject: PhoenixObjects.getCaloCell,
+      getObject: PhoenixObjects.getCaloCellsInstanced,
+      concatonateObjs: true,
       cuts: [
         new Cut('phi', -pi, pi, 0.01),
         new Cut('eta', -5.0, 5.0, 0.1),
@@ -98,7 +99,7 @@ export function getDefaultObjectTypeConfigs(): ObjectTypeConfig[] {
       scaleConfig: {
         key: 'caloCellsScale',
         label: 'CaloCells Scale',
-        scaleMethod: 'scaleChildObjects',
+        scaleMethod: 'scaleInstancedObjects',
         scaleAxis: 'z',
       },
     },

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -24,6 +24,8 @@ import {
   CanvasTexture,
   ShaderMaterial,
   DoubleSide,
+  InstancedMesh,
+  Matrix4,
 } from 'three';
 import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js';
 import { EVENT_DATA_TYPE_COLORS } from '../../helpers/constants';
@@ -771,6 +773,102 @@ export class PhoenixObjects {
     caloCellParams.uuid = cube.uuid;
 
     return cube;
+  }
+
+  /**
+   * Create all CaloCells as a single InstancedMesh for performance.
+   * Receives the entire collection array and returns one object with
+   * per-instance transforms and colors, reducing 187K draw calls to 1.
+   * @param cellsParams Array of all cell parameters in the collection.
+   * @returns InstancedMesh containing all cells.
+   */
+  public static getCaloCellsInstanced(cellsParams: any[]): Object3D {
+    const defaultRadius = 1700;
+    const defaultZ = 2000;
+    const defaultSide = 30;
+    const defaultLength = 30;
+
+    const count = cellsParams.length;
+    const unitBox = new BoxGeometry(1, 1, 1);
+    const material = new MeshPhongMaterial({
+      color: cellsParams[0]?.color ?? EVENT_DATA_TYPE_COLORS.CaloClusters,
+      transparent: true,
+      opacity: 0.7,
+    });
+
+    const mesh = new InstancedMesh(unitBox, material, count);
+
+    // Reusable temporaries to avoid per-iteration allocation
+    const tempMatrix = new Matrix4();
+    const tempPosition = new Vector3();
+    const tempScale = new Vector3();
+    const tempColor = new Color();
+    const tempObj = new Object3D();
+
+    for (let i = 0; i < count; i++) {
+      const cell = cellsParams[i];
+
+      // Position (reuse existing helper)
+      const position = PhoenixObjects.getCaloPosition(
+        cell,
+        defaultRadius,
+        defaultZ,
+      );
+
+      // Cell dimensions — scale encodes variable width/length
+      const cellWidth = cell.side ?? defaultSide;
+      let cellLength = cell.length ?? defaultLength;
+      if (cellLength < cellWidth) {
+        cellLength = cellWidth;
+      }
+
+      // Orientation via lookAt (same 3-branch logic as getCaloCell)
+      tempObj.position.copy(position);
+      tempObj.rotation.set(0, 0, 0);
+      tempObj.updateMatrix();
+      if (!cell.radius && !cell.z) {
+        tempObj.lookAt(0, 0, 0);
+      } else if (cell.z && !cell.radius) {
+        tempObj.lookAt(position.x, position.y, 0);
+      }
+      if (cell.radius) {
+        tempObj.lookAt(0, 0, position.z);
+      }
+
+      // Compose transform: position + orientation + scale
+      tempScale.set(cellWidth, cellWidth, cellLength);
+      tempMatrix.compose(position, tempObj.quaternion, tempScale);
+      mesh.setMatrixAt(i, tempMatrix);
+
+      // Per-instance color
+      tempColor.set(cell.color ?? EVENT_DATA_TYPE_COLORS.CaloClusters);
+      mesh.setColorAt(i, tempColor);
+
+      // Write back identifiers for filtering and collection lookups
+      cell._instanceId = i;
+      cell.uuid = mesh.uuid;
+    }
+
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) {
+      mesh.instanceColor.needsUpdate = true;
+    }
+
+    // Compute bounding sphere across all instances for correct frustum culling.
+    // Without this, Three.js uses the unit-box bounding sphere and cells
+    // disappear when panning.
+    mesh.computeBoundingSphere();
+
+    mesh.name = 'CaloCell';
+    mesh.userData = {
+      _isInstancedCaloCells: true,
+      _instanceData: cellsParams,
+      _originalMatrices: null, // lazily populated on first filter
+      _scaleValue: 1, // current scale factor (for filter↔scale coordination)
+      _scaleAxis: null as string | null,
+    };
+
+    return mesh;
   }
 
   /**

--- a/packages/phoenix-event-display/src/managers/three-manager/controls-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/controls-manager.ts
@@ -8,6 +8,7 @@ import {
   Group,
   Scene,
   Mesh,
+  InstancedMesh,
   TubeGeometry,
   MathUtils,
 } from 'three';
@@ -704,6 +705,10 @@ export class ControlsManager {
             }
           }
         });
+      } else if (object instanceof InstancedMesh) {
+        // InstancedMesh: compute bounding sphere across all instances
+        object.computeBoundingSphere();
+        objectPosition = object.boundingSphere?.center ?? new Vector3();
       } else if (object.position.equals(origin)) {
         // Get the center of bounding sphere of objects with no position
         objectPosition = object.geometry?.boundingSphere?.center;

--- a/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
@@ -22,6 +22,8 @@ import {
   TubeGeometry,
   MeshToonMaterial,
   Line,
+  InstancedMesh,
+  Matrix4,
   type Object3DEventMap,
 } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
@@ -298,6 +300,15 @@ export class SceneManager {
     const collection = eventData.getObjectByName(collectionName);
     if (collection) {
       for (const child of Object.values(collection.children)) {
+        // InstancedMesh: filter by scaling hidden instances to zero
+        if (
+          child.userData?._isInstancedCaloCells &&
+          child instanceof InstancedMesh
+        ) {
+          this.filterInstancedMesh(child, filters);
+          continue;
+        }
+
         if (child.userData) {
           for (const filter of filters) {
             const value = child.userData[filter.field];
@@ -913,6 +924,143 @@ export class SceneManager {
         }
       }
     });
+  }
+
+  /**
+   * Filter an InstancedMesh by setting hidden instances to zero-scale.
+   * Respects current scale factor so filter and scale don't conflict.
+   * @param mesh The InstancedMesh to filter.
+   * @param filters Cuts used to determine visibility of each instance.
+   */
+  private filterInstancedMesh(mesh: InstancedMesh, filters: Cut[]) {
+    const instanceData: any[] = mesh.userData._instanceData;
+    if (!instanceData) return;
+
+    this.ensureOriginalMatrices(mesh);
+
+    const originalMatrices: Float32Array = mesh.userData._originalMatrices;
+    const scaleValue: number = mesh.userData._scaleValue ?? 1;
+    const scaleAxis: string | null = mesh.userData._scaleAxis ?? null;
+    const zeroMatrix = new Matrix4().makeScale(0, 0, 0);
+    const tempMatrix = new Matrix4();
+    const pos = new Vector3();
+    const quat = new Quaternion();
+    const scl = new Vector3();
+
+    for (let i = 0; i < instanceData.length; i++) {
+      const cell = instanceData[i];
+      let visible = true;
+
+      for (const filter of filters) {
+        const value = cell[filter.field];
+        if (value !== undefined && !filter.cutPassed(value)) {
+          visible = false;
+          break;
+        }
+      }
+
+      if (visible) {
+        tempMatrix.fromArray(originalMatrices, i * 16);
+        // Re-apply current scale factor so filtering doesn't reset scale
+        if (scaleValue !== 1) {
+          tempMatrix.decompose(pos, quat, scl);
+          this.applyAxisScale(scl, scaleValue, scaleAxis);
+          tempMatrix.compose(pos, quat, scl);
+        }
+        mesh.setMatrixAt(i, tempMatrix);
+      } else {
+        mesh.setMatrixAt(i, zeroMatrix);
+      }
+    }
+
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  /**
+   * Scale instances in an InstancedMesh along an axis.
+   * Stores scale state so filtering preserves it. Skips zero-scaled (filtered) instances.
+   * Falls back to scaleChildObjects for non-instanced groups.
+   * @param groupName Name of the group containing the InstancedMesh.
+   * @param value Scale factor (1 = original size).
+   * @param axis Optional axis to scale along ('x', 'y', 'z').
+   */
+  public scaleInstancedObjects(
+    groupName: string,
+    value: number,
+    axis?: string,
+  ) {
+    const object = this.scene.getObjectByName(groupName);
+    if (!object) return;
+
+    let handled = false;
+    object.traverse((child: Object3D) => {
+      if (
+        child.userData?._isInstancedCaloCells &&
+        child instanceof InstancedMesh
+      ) {
+        handled = true;
+        const instanceData: any[] = child.userData._instanceData;
+        if (!instanceData) return;
+
+        this.ensureOriginalMatrices(child);
+
+        // Store scale state for filter coordination
+        child.userData._scaleValue = value;
+        child.userData._scaleAxis = axis ?? null;
+
+        const originalMatrices: Float32Array = child.userData._originalMatrices;
+        const tempMatrix = new Matrix4();
+        const currentMatrix = new Matrix4();
+        const pos = new Vector3();
+        const quat = new Quaternion();
+        const scl = new Vector3();
+
+        for (let i = 0; i < instanceData.length; i++) {
+          // Skip instances that are currently filtered out (zero-scale)
+          child.getMatrixAt(i, currentMatrix);
+          const e = currentMatrix.elements;
+          if (e[0] === 0 && e[5] === 0 && e[10] === 0) continue;
+
+          tempMatrix.fromArray(originalMatrices, i * 16);
+          tempMatrix.decompose(pos, quat, scl);
+          this.applyAxisScale(scl, value, axis);
+          tempMatrix.compose(pos, quat, scl);
+          child.setMatrixAt(i, tempMatrix);
+        }
+
+        child.instanceMatrix.needsUpdate = true;
+      }
+    });
+
+    // Fallback for non-instanced objects in the same group
+    if (!handled) {
+      this.scaleChildObjects(groupName, value, axis);
+    }
+  }
+
+  /** Snapshot the original instance matrices on first use. */
+  private ensureOriginalMatrices(mesh: InstancedMesh) {
+    if (!mesh.userData._originalMatrices) {
+      mesh.userData._originalMatrices =
+        mesh.instanceMatrix.array.slice() as Float32Array;
+    }
+  }
+
+  /** Apply a scale factor to a Vector3 along a specific axis or uniformly. */
+  private applyAxisScale(scl: Vector3, value: number, axis?: string | null) {
+    switch (axis) {
+      case 'x':
+        scl.x *= value;
+        break;
+      case 'y':
+        scl.y *= value;
+        break;
+      case 'z':
+        scl.z *= value;
+        break;
+      default:
+        scl.multiplyScalar(value);
+    }
   }
 
   /**

--- a/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/selection-manager.ts
@@ -9,6 +9,8 @@ import {
   AmbientLight,
   AxesHelper,
   Mesh,
+  InstancedMesh,
+  Color,
 } from 'three';
 import { Easing, Group as TweenGroup, Tween } from '@tweenjs/tween.js';
 import { InfoLogger } from '../../helpers/info-logger';
@@ -65,6 +67,16 @@ export class SelectionManager {
   private selectedObjects: Set<Mesh> = new Set();
   /** Currently hovered object (for outline preview) */
   private hoveredObject: Mesh | null = null;
+
+  // InstancedMesh per-cell hover highlight (CaloCells)
+  /** The InstancedMesh currently being hovered */
+  private hoveredInstanceMesh: InstancedMesh | null = null;
+  /** The instanceId of the currently highlighted cell */
+  private hoveredInstanceId: number | null = null;
+  /** Original color of the highlighted cell (to restore on un-hover) */
+  private hoveredInstanceOriginalColor: Color | null = null;
+  /** Highlight color for hovered instanced cells */
+  private static readonly INSTANCE_HIGHLIGHT_COLOR = new Color(0xffffff);
 
   // Drag detection to prevent accidental selection during orbit controls
   /** Mouse down position for drag detection (selection system) */
@@ -555,11 +567,33 @@ export class SelectionManager {
       }
     }
 
-    // Only update hover outline if the target object has changed
-    if (targetObject !== this.hoveredObject) {
+    // For InstancedMesh, compare instanceId too (different cells = same object)
+    const isInstanced = targetObject?.userData?._isInstancedCaloCells;
+    const instanceId: number | null = isInstanced
+      ? (targetObject!.userData._lastHitInstanceId ?? null)
+      : null;
+
+    const hoverChanged = isInstanced
+      ? targetObject !== this.hoveredObject ||
+        instanceId !== this.hoveredInstanceId
+      : targetObject !== this.hoveredObject;
+
+    if (hoverChanged) {
+      // Restore any previous instanced cell highlight before switching
+      this.clearInstanceHighlight();
+
       this.hoveredObject = targetObject;
 
-      // Set hover outline (this is separate from sticky selections)
+      if (isInstanced && instanceId !== null) {
+        // Highlight the hovered cell via color change
+        this.setInstanceHighlight(targetObject as InstancedMesh, instanceId);
+        this.effectsManager.setHoverOutline(null);
+        this.updateInfoPanelForHover(targetObject);
+        this.currentlyOutlinedObject = null;
+        return;
+      }
+
+      // Non-instanced: normal outline
       this.effectsManager.setHoverOutline(targetObject);
 
       // Update info panel for hovered object (immediate feedback)
@@ -568,6 +602,45 @@ export class SelectionManager {
       // Also update the currently outlined object for backwards compatibility
       this.currentlyOutlinedObject = targetObject;
     }
+  }
+
+  /**
+   * Highlight an individual instance in an InstancedMesh by changing its color.
+   * Saves the original color so it can be restored on un-hover.
+   */
+  private setInstanceHighlight(mesh: InstancedMesh, instanceId: number) {
+    if (!mesh.instanceColor) return;
+
+    const origColor = new Color();
+    mesh.getColorAt(instanceId, origColor);
+
+    this.hoveredInstanceMesh = mesh;
+    this.hoveredInstanceId = instanceId;
+    this.hoveredInstanceOriginalColor = origColor;
+
+    mesh.setColorAt(instanceId, SelectionManager.INSTANCE_HIGHLIGHT_COLOR);
+    mesh.instanceColor.needsUpdate = true;
+  }
+
+  /**
+   * Restore the original color of a previously highlighted instanced cell.
+   */
+  private clearInstanceHighlight() {
+    if (
+      this.hoveredInstanceMesh &&
+      this.hoveredInstanceId !== null &&
+      this.hoveredInstanceOriginalColor &&
+      this.hoveredInstanceMesh.instanceColor
+    ) {
+      this.hoveredInstanceMesh.setColorAt(
+        this.hoveredInstanceId,
+        this.hoveredInstanceOriginalColor,
+      );
+      this.hoveredInstanceMesh.instanceColor.needsUpdate = true;
+    }
+    this.hoveredInstanceMesh = null;
+    this.hoveredInstanceId = null;
+    this.hoveredInstanceOriginalColor = null;
   }
 
   /**
@@ -651,6 +724,16 @@ export class SelectionManager {
    */
   private updateInfoPanelForHover(object: Mesh | null) {
     if (object) {
+      // InstancedMesh CaloCells: read per-instance data
+      let userData = object.userData;
+      if (
+        userData?._isInstancedCaloCells &&
+        userData._instanceData &&
+        userData._lastHitInstanceId !== undefined
+      ) {
+        userData = userData._instanceData[userData._lastHitInstanceId] ?? {};
+      }
+
       // Object is being hovered - update info panel
       this.selectedObject.name = object.name;
       this.selectedObject.attributes.splice(
@@ -659,7 +742,7 @@ export class SelectionManager {
       );
       this.activeObject.update(object.uuid);
 
-      const prettyParams = PrettySymbols.getPrettyParams(object.userData);
+      const prettyParams = PrettySymbols.getPrettyParams(userData);
 
       for (const key of Object.keys(prettyParams)) {
         this.selectedObject.attributes.push({
@@ -815,7 +898,19 @@ export class SelectionManager {
     // Perform intersection test
     const intersects = raycaster.intersectObjects(intersectableObjects, false);
 
-    return intersects.length > 0 ? intersects[0].object : null;
+    if (intersects.length === 0) return null;
+
+    const hit = intersects[0];
+    // For InstancedMesh CaloCells, store the hit instanceId for downstream use
+    if (
+      hit.object.userData?._isInstancedCaloCells &&
+      hit.object instanceof InstancedMesh &&
+      hit.instanceId !== undefined
+    ) {
+      hit.object.userData._lastHitInstanceId = hit.instanceId;
+    }
+
+    return hit.object;
   }
 
   /**
@@ -924,6 +1019,9 @@ export class SelectionManager {
   public highlightObject(uuid: string, objectsGroup: Object3D) {
     const object = objectsGroup.getObjectByProperty('uuid', uuid);
     if (object && object instanceof Mesh) {
+      // Skip OutlinePass for instanced CaloCells (can't outline individual instances)
+      if (object.userData?._isInstancedCaloCells) return;
+
       // Use the modern selection system instead of legacy outline
       this.effectsManager.selectObject(object);
       this.selectedObjects.add(object);
@@ -938,6 +1036,7 @@ export class SelectionManager {
    */
   public disableHighlighting() {
     // Clear all selections instead of just the legacy outline
+    this.clearInstanceHighlight();
     this.effectsManager.clearAllSelections();
     this.selectedObjects.clear();
     this.currentlyOutlinedObject = null;
@@ -1088,6 +1187,7 @@ export class SelectionManager {
     const hadSelections = this.selectedObjects.size > 0;
 
     // Clear all selected outlines from the effects manager (if initialized)
+    this.clearInstanceHighlight();
     if (this.effectsManager) {
       this.effectsManager.clearAllSelections();
     }
@@ -1183,6 +1283,7 @@ export class SelectionManager {
       this.effectsManager.setHoverOutline(null);
     }
     this.selectedObjects.clear();
+    this.clearInstanceHighlight();
     this.hoveredObject = null;
     this.currentlyOutlinedObject = null;
 

--- a/packages/phoenix-event-display/src/tests/loaders/objects/phoenix-objects.test.ts
+++ b/packages/phoenix-event-display/src/tests/loaders/objects/phoenix-objects.test.ts
@@ -1,4 +1,11 @@
-import { Line, LineSegments, Mesh, Object3D, Points } from 'three';
+import {
+  Line,
+  LineSegments,
+  Mesh,
+  Object3D,
+  Points,
+  InstancedMesh,
+} from 'three';
 import { PhoenixObjects } from '../../../loaders/objects/phoenix-objects';
 
 describe('PhoenixObjects', () => {
@@ -248,6 +255,33 @@ describe('PhoenixObjects', () => {
     expect(obj).toBeInstanceOf(Object3D);
     expect(obj.name).toBe('PlanarCaloCell');
     expect(obj.type).toBe('Mesh');
+  });
+
+  it('should create an InstancedMesh from CaloCells parameters', () => {
+    const cellsParams: any[] = [
+      { energy: 100, phi: 0.5, eta: 1.0, theta: 0.8 },
+      { energy: 200, phi: -0.3, eta: -1.5, theta: 2.1 },
+      { energy: 50, phi: 1.2, eta: 0.0, theta: 1.57 },
+    ];
+
+    const result = PhoenixObjects.getCaloCellsInstanced(cellsParams);
+
+    expect(result).toBeInstanceOf(InstancedMesh);
+    expect(result.name).toBe('CaloCell');
+
+    const mesh = result as InstancedMesh;
+    expect(mesh.count).toBe(3);
+    expect(mesh.userData._isInstancedCaloCells).toBe(true);
+    expect(mesh.userData._instanceData).toBe(cellsParams);
+    expect(mesh.userData._originalMatrices).toBeNull();
+
+    // Each cell should have been assigned an _instanceId and shared uuid
+    expect(cellsParams[0]._instanceId).toBe(0);
+    expect(cellsParams[1]._instanceId).toBe(1);
+    expect(cellsParams[2]._instanceId).toBe(2);
+    expect(cellsParams[0].uuid).toBe(mesh.uuid);
+    expect(cellsParams[1].uuid).toBe(mesh.uuid);
+    expect(cellsParams[2].uuid).toBe(mesh.uuid);
   });
 
   it('should create a Vertex from the given parameters and get it as a MET object', () => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -21,7 +21,14 @@ import { EventDisplayService } from '../../../../services/event-display.service'
 export class CollectionsInfoOverlayComponent implements OnInit, OnDestroy {
   @Input() showObjectsInfo: boolean;
   /** Columns to exclude from the collection info table. */
-  @Input() excludedColumns: string[] = ['uuid', 'hits', 'isCut', 'labelText'];
+  @Input() excludedColumns: string[] = [
+    'uuid',
+    'hits',
+    'isCut',
+    'labelText',
+    '_instanceId',
+    '_position',
+  ];
   hideInvisible: boolean;
   collections: { type: string; collections: string[] }[];
   selectedCollection: string;
@@ -72,13 +79,40 @@ export class CollectionsInfoOverlayComponent implements OnInit, OnDestroy {
       .getCollection(selectedCollection)
       .map((object: any) => ({
         ...object,
-        isCut: !eventDataGroup.getObjectByProperty('uuid', object.uuid)
-          ?.visible,
+        isCut: this.isObjectCut(object, eventDataGroup),
       }));
 
     this.collectionColumns = Object.keys(this.showingCollection[0]).filter(
       (column) => !this.excludedColumns.includes(column),
     );
+  }
+
+  /**
+   * Check whether an object is hidden by filtering.
+   * For InstancedMesh CaloCells, checks the instance matrix for zero-scale.
+   */
+  private isObjectCut(object: any, eventDataGroup: any): boolean {
+    const sceneObject = eventDataGroup?.getObjectByProperty(
+      'uuid',
+      object.uuid,
+    );
+    if (!sceneObject) return false;
+
+    // InstancedMesh: check if instance matrix is zero-scale
+    if (
+      sceneObject.userData?._isInstancedCaloCells &&
+      object._instanceId !== undefined
+    ) {
+      if (!sceneObject.userData._originalMatrices) {
+        return false; // No filtering applied yet — all visible
+      }
+      const arr = sceneObject.instanceMatrix.array;
+      const off = object._instanceId * 16;
+      // Zero-scale matrix has diagonal elements [0],[5],[10] = 0
+      return arr[off] === 0 && arr[off + 5] === 0 && arr[off + 10] === 0;
+    }
+
+    return !sceneObject.visible;
   }
 
   sort(column: string, order: string) {


### PR DESCRIPTION
## Title
fix: use InstancedMesh for CaloCells to prevent WebGL crash (#474)

## Body

### Summary

This fixes the long-standing CaloCells performance issue (#474) where loading ATLAS events with calorimeter data (187,650 cells) would crash the browser. FPS dropped to ~1.8 and WebGL context was lost entirely, making the page unrecoverable.

I spent a good amount of time digging into this one. The root cause was straightforward but the fix touched a lot of surfaces. Phoenix was creating a separate THREE.Mesh (each with its own BoxGeometry + MeshPhongMaterial) for every single cell. That's 187K individual draw calls per frame. No GPU can handle that.

The fix replaces all of that with a single THREE.InstancedMesh (one geometry, one material, one draw call). Per-instance transforms and colors are stored in typed arrays. On my test machine (laptop), loading the same atlas.json that used to crash now runs at a stable 30 FPS with zero impact from CaloCells being enabled.

### What changed

- phoenix-objects.ts - New getCaloCellsInstanced() method that takes the entire cell array and builds one InstancedMesh with per-instance position, orientation, scale, and color
- object-type-registry.ts - CaloCells config now uses concatonateObjs: true so the full array is passed at once instead of per-cell
- scene-manager.ts - Filter and scale logic adapted for InstancedMesh. Filtering uses a scale-to-zero approach (hidden instances get a zero-scale matrix). Scale and filter coordinate through stored state so they don't overwrite each other
- selection-manager.ts - Raycaster now preserves instanceId for InstancedMesh hits, hover shows per-cell physics data in the info panel. OutlinePass selection is skipped since you can't outline individual instances
- controls-manager.ts - getObjectPosition() handles InstancedMesh via computeBoundingSphere()
- collections-info-overlay.component.ts - Visibility check reads the instance matrix instead of object.visible, internal fields (_instanceId, _position) excluded from the table
- phoenix-objects.test.ts - Test covering InstancedMesh creation, instance count, instanceId assignment, and shared uuid

### Issues I ran into along the way

- Frustum culling - Without calling computeBoundingSphere() after setting all instance matrices, Three.js uses the unit-box bounding sphere (radius ~0.87 at origin) and culls cells when panning. Took a bit to figure out why cells were disappearing
- Scale and filter conflicting - Both write to the same instance matrix buffer from original snapshots. If you scaled then filtered, the filter would restore un-scaled originals and silently lose the scale. Fixed by storing scale state on userData and re-applying it during filter restores
- UUID sharing - All 187K cells share one InstancedMesh uuid. Collections-info panel needed adaptation to check per-instance matrix state instead of per-object visibility
- lookAt in a batch loop - Can't call mesh.lookAt() per-instance. Used a temp Object3D with reset rotation before each lookAt() to extract quaternions for Matrix4.compose()

### Performance

Before: 187,000 draw calls, 187,000 scene graph children, 1.8 FPS (context lost on atlas.json)  
After: 1 draw call, 1 scene graph child, stable 30 FPS on laptop


https://github.com/user-attachments/assets/2751e6e5-3420-4e70-9833-d5b734089115

