### PR TITLE
fix: convert makeRequest() to async/await with proper error propagation

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component.ts
@@ -61,9 +61,9 @@ export class EventDataExplorerDialogComponent {
     );
   }
 
-  loadEvent(file: FileEvent) {
+  async loadEvent(file: FileEvent) {
     this.loading = true;
-    this.error = this.fileLoader.loadEvent(
+    this.error = await this.fileLoader.loadEvent(
       file.url,
       this.eventDisplay,
       file.nocache ? { cache: 'no-cache' } : {},
@@ -72,9 +72,9 @@ export class EventDataExplorerDialogComponent {
     if (!this.error) this.onClose();
   }
 
-  loadConfig(file: FileEvent) {
+  async loadConfig(file: FileEvent) {
     this.loading = true;
-    this.error = this.fileLoader.makeRequest(
+    this.error = await this.fileLoader.makeRequest(
       `${this.dialogData.apiURL}?type=config&f=${file.url}`,
       'text',
       (config) => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
@@ -32,29 +32,31 @@ export class FileLoaderService {
   }
 
   // returns whether an error was found
-  makeRequest(
+  async makeRequest(
     urlPath: string,
     responseType: 'json' | 'text' | 'blob',
     onData: (data: any) => void,
     options: any = {},
-  ) {
-    fetch(urlPath, options)
-      .then((res) => res[responseType]())
-      .then((data) => {
-        if (responseType === 'blob') {
-          data
-            .arrayBuffer()
-            .then((buf) => this.unzip(buf))
-            .then((d) => onData(d));
-        } else {
-          onData(data);
-        }
-      })
-      .catch((error) => {
-        console.error(error);
+  ): Promise<boolean> {
+    try {
+      const res = await fetch(urlPath, options);
+      if (!res.ok) {
+        console.error(`Request failed: ${res.status} ${res.statusText}`);
         return true;
-      });
-    return false;
+      }
+      const data = await res[responseType]();
+      if (responseType === 'blob') {
+        const buf = await (data as Blob).arrayBuffer();
+        const unzipped = await this.unzip(buf);
+        onData(unzipped);
+      } else {
+        onData(data);
+      }
+      return false;
+    } catch (error) {
+      console.error(error);
+      return true;
+    }
   }
 
   loadJSONEvent(eventData: string, eventDisplay: EventDisplayService) {
@@ -76,11 +78,11 @@ export class FileLoaderService {
     eventDisplay.buildEventDataFromJSON(processedEventData);
   }
 
-  loadEvent(
+  async loadEvent(
     file: string,
     eventDisplay: EventDisplayService,
     options: any = {},
-  ) {
+  ): Promise<boolean> {
     this.lastEventsURL = file;
     this.lastEventsOptions = options;
     const isZip = file.split('.').pop() === 'zip';

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts
@@ -41,15 +41,17 @@ export class FileLoaderService {
     try {
       const res = await fetch(urlPath, options);
       if (!res.ok) {
-        console.error(`Request failed: ${res.status} ${res.statusText}`);
+        console.error(
+          `Request failed for ${urlPath}: ${res.status} ${res.statusText}`,
+        );
         return true;
       }
-      const data = await res[responseType]();
       if (responseType === 'blob') {
-        const buf = await (data as Blob).arrayBuffer();
+        const buf = await res.arrayBuffer();
         const unzipped = await this.unzip(buf);
         onData(unzipped);
       } else {
+        const data = await res[responseType]();
         onData(data);
       }
       return false;


### PR DESCRIPTION
**Problem**
`FileLoaderService.makeRequest()` had a broken error-reporting pattern:

1. **Always returned `false` synchronously** - the `return false` at the bottom executed before the `fetch()` promise ever resolved or rejected
2. **`.catch()` return value was lost** - `return true` inside `.catch()` resolved the promise chain, but the synchronous `return false` had already executed
3. **Unzip failures were uncaught** - the inner `.then((buf) => this.unzip(buf))` chain for blob responses had no `.catch()`, so a corrupt zip file caused an unhandled promise rejection
4. **No HTTP error checking** -`fetch()` doesn't throw on 404/500 responses, so HTTP errors were silently treated as successes
5. **Loading state was wrong** - `EventDataExplorerDialogComponent` set `this.loading = false` immediately (synchronously), not after the request completed

**Fix**
- Converted `makeRequest()` to `async/await` with a single `try/catch` wrapping the entire flow (fetch → response parsing → blob/unzip → callback)
- Added `res.ok` check to catch HTTP error responses (404, 500, CORS failures)
- Returns `Promise<boolean>` - `true` on error, `false` on success - matching the original documented contract
- Converted `loadEvent()` in `FileLoaderService` to `async` so it propagates the promise
- Converted `loadEvent()` and `loadConfig()` in `EventDataExplorerDialogComponent` to `async` with `await`, so:
  - `this.error` is set **after** the request completes (not before)
  - `this.loading` is set to `false` **after** the request completes
  - Dialog closes only on actual success

**Files changed**
- `packages/phoenix-ng/projects/phoenix-ui-components/lib/services/file-loader.service.ts`
- `packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-data-explorer/event-data-explorer-dialog/event-data-explorer-dialog.component.ts`

**Testing**
- All 29 test suites / 179 tests pass
- The pre-existing `PHYSLITELoader` build error in `io-options-dialog.component.ts` is unrelated to this change (present on `main`)- Convert makeRequest() from fire-and-forget fetch to async/await
- Add HTTP status check (res.ok) for non-throwing fetch failures
- Wrap entire flow including blob/unzip in try/catch
- Return Promise<boolean> so callers can properly await the result
- Convert loadEvent() in FileLoaderService to async
- Convert loadEvent()/loadConfig() in EventDataExplorerDialog to async
- Fix loading state: this.loading now correctly set to false after fetch completes instead of immediately

Resolves #847