### PR TITLE
fix: rename RendererManager.removeControls() to removeRenderer() (#809)

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/renderer-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/renderer-manager.ts
@@ -167,9 +167,9 @@ export class RendererManager {
 
   /**
    * Remove a renderer from the available renderers list.
-   * @param renderer Three,js WebGLRenderer to be removed.
+   * @param renderer Three.js WebGLRenderer to be removed.
    */
-  public removeControls(renderer: WebGLRenderer) {
+  public removeRenderer(renderer: WebGLRenderer) {
     const index: number = this.renderers.indexOf(renderer);
     if (index > -1) {
       this.renderers.splice(index, 1);


### PR DESCRIPTION
Fixes #809

**Problem**
In `renderer-manager.ts`, the method `removeControls(renderer)` splices from `this.renderers` it removes a **renderer**, not controls. This is a copy-paste naming error that makes the API confusing and may cause callers to miss the actual renderer removal method.

**Changes**
- Renamed `removeControls()` → `removeRenderer()` in `RendererManager` to accurately reflect what the method does
- Fixed minor JSDoc typo (`Three,js` → `Three.js`)

**Notes**
- The method was not called anywhere in the codebase, so this is a safe rename with no breaking downstream changes
- `ControlsManager` has its own legitimate `removeControls()` method only the misnamed one in `RendererManager` was affected