### PR TITLE
fix: ignore generated docs in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ const gitignorePath = path.resolve(__dirname, ".gitignore");
 
 export default [
     includeIgnoreFile(gitignorePath),
+    { ignores: ["docs/**"] },
     ...compat.extends(
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",


### PR DESCRIPTION
This fixes the release failure caused by ESLint running on generated Compodoc files in the root `docs/` directory.

During `lerna publish`, the `version` script generates docs and stages them with `git add .`. The pre-commit hook then runs `lint-staged`, which applies `eslint --fix` to staged `*.ts` files. That includes generated Compodoc files under `docs/api-docs/template-playground/`, where `template-playground.component.ts` contains an intentional self-assignment that violates the `no-self-assign` rule.

This change excludes the generated `docs/**` tree from ESLint so release commits do not fail on generated artifacts.

**Change**
- add `docs/**` to the ESLint ignore list

**Testing**
- ran `yarn workspace phoenix-event-display docs`
- staged the generated docs locally
- ran `yarn lint-staged`
- confirmed the previous `no-self-assign` failure no longer occurs