### PR TITLE
fix: re-apply collection cuts after event switch (#863)

### DIFF
--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -609,6 +609,7 @@ export class UIManager {
       (uiMenu) => uiMenu instanceof PhoenixMenuUI,
     ) as PhoenixMenuUI;
     phoenixMenuUI?.loadEventFolderState();
+    phoenixMenuUI?.reapplyCollectionCuts();
   }
 
   /**

--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts
@@ -31,6 +31,9 @@ export class PhoenixMenuUI implements PhoenixUI<PhoenixMenuNode> {
     [key: string]: { enabled: boolean; radius: number };
   } = {};
 
+  /** Registry of active cuts per collection name for re-application on event switch. */
+  private collectionCuts: { [collectionName: string]: Cut[] } = {};
+
   /**
    * Create Phoenix menu UI with different controls related to detector geometry and event data.
    * @param phoenixMenuRoot Root node of the Phoenix menu.
@@ -183,6 +186,8 @@ export class PhoenixMenuUI implements PhoenixUI<PhoenixMenuNode> {
       this.eventFolderState = this.eventFolder.getNodeState();
       this.eventFolder.remove();
     }
+    this.collectionCuts = {};
+
     this.eventFolder = this.phoenixMenuRoot.addChild(
       'Event Data',
       (value: boolean) => {
@@ -250,6 +255,7 @@ export class PhoenixMenuUI implements PhoenixUI<PhoenixMenuNode> {
     this.addDrawOptions(collectionNode, collectionName);
 
     if (cuts && cuts.length > 0) {
+      this.collectionCuts[collectionName] = cuts;
       this.addCutOptions(collectionNode, collectionName, cuts);
     }
 
@@ -524,6 +530,15 @@ export class PhoenixMenuUI implements PhoenixUI<PhoenixMenuNode> {
   public loadEventFolderState() {
     if (this.eventFolderState) {
       this.eventFolder.loadStateFromJSON(this.eventFolderState);
+    }
+  }
+  /**
+   * Re-applies all active cuts to their collections after an event switch.
+   * Called by UIManager after buildEventData() completes.
+   */
+  public reapplyCollectionCuts(): void {
+    for (const [collectionName, cuts] of Object.entries(this.collectionCuts)) {
+      this.sceneManager.collectionFilter(collectionName, cuts);
     }
   }
 }

--- a/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-ui.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-ui.test.ts
@@ -6,6 +6,7 @@ import { InfoLogger } from '../../../../helpers/info-logger';
 import { ThreeManager } from '../../../../managers/three-manager';
 import { PhoenixMenuNode } from '../../../../managers/ui-manager/phoenix-menu/phoenix-menu-node';
 import { PhoenixMenuUI } from '../../../../managers/ui-manager/phoenix-menu/phoenix-menu-ui';
+import { Cut } from '../../../../lib/models/cut.model';
 
 jest.mock('../../../../managers/three-manager');
 
@@ -103,6 +104,51 @@ describe('PhoenixMenuUI', () => {
     const eventDataFolder = phoenixMenuUI.getEventDataTypeFolder('test');
 
     expect(eventDataFolder.name).toBe('test');
+  });
+
+  it('should re-apply cuts to registered collections on event switch', () => {
+    const cuts = [new Cut('eta', -4, 4, 0.1)];
+    cuts[0].maxValue = 0.5;
+
+    const mockCollectionFilter = jest.fn();
+    phoenixMenuUIPrivate.sceneManager = {
+      collectionFilter: mockCollectionFilter,
+      getObjectByName: jest
+        .fn()
+        .mockReturnValue({ getObjectByName: jest.fn() }),
+      objectVisibility: jest.fn(),
+      groupVisibility: jest.fn(),
+    };
+
+    phoenixMenuUI.addEventDataFolder();
+    phoenixMenuUI.addEventDataTypeFolder('test');
+    phoenixMenuUI.addCollection('test', 'Tracks_', cuts);
+    phoenixMenuUI.reapplyCollectionCuts();
+
+    expect(mockCollectionFilter).toHaveBeenCalledWith('Tracks_', cuts);
+  });
+
+  it('should clear cut registry when event data folder is rebuilt', () => {
+    const cuts = [new Cut('eta', -4, 4, 0.1)];
+
+    phoenixMenuUIPrivate.sceneManager = {
+      collectionFilter: jest.fn(),
+      getObjectByName: jest
+        .fn()
+        .mockReturnValue({ getObjectByName: jest.fn() }),
+      objectVisibility: jest.fn(),
+      groupVisibility: jest.fn(),
+    };
+
+    phoenixMenuUI.addEventDataFolder();
+    phoenixMenuUI.addEventDataTypeFolder('test');
+    phoenixMenuUI.addCollection('test', 'Tracks_', cuts);
+
+    expect(Object.keys(phoenixMenuUIPrivate.collectionCuts).length).toBe(1);
+
+    phoenixMenuUI.addEventDataFolder();
+
+    expect(Object.keys(phoenixMenuUIPrivate.collectionCuts).length).toBe(0);
   });
 
   describe('PhoenixMenuNode', () => {


### PR DESCRIPTION
Fixes #863

## Problem
Applied cuts (e.g. η < 0.5 on Tracks) were silently lost on every event 
switch. `buildEventDataFromJSON()` destroys and recreates all 3D objects, 
resetting `visible = true` on every object. No code path re-applied active 
cuts after the rebuild.

## Solution
Added a cut registry to `PhoenixMenuUI` that stores active cuts per 
collection name. After `buildEventData()` completes, `reapplyCollectionCuts()` 
is called automatically via `loadEventFolderPhoenixMenuState()`, re-applying 
all stored cuts to the newly built event objects.

**Files changed:**
- `phoenix-menu-ui.ts` — added `collectionCuts` registry, populate on 
  `addCollection()`, clear on `addEventDataFolder()`, expose 
  `reapplyCollectionCuts()` 
- `ui-manager/index.ts` — call `reapplyCollectionCuts()` after 
  `loadEventFolderState()`
- `phoenix-menu-ui.test.ts` — 2 new tests covering re-application and 
  registry clearing

## Verification

**BEFORE fix** — η < 0.5 applied, then event switched: all tracks reappear, 
cut lost:
<img width="1913" height="913" alt="Screenshot 2026-04-03 164754" src="https://github.com/user-attachments/assets/a3ef3c0d-4883-4094-994e-1494b12fd62c" />


**AFTER fix** — η < 0.5 applied, event switched to different event 
(note changed Run/Event number): tracks stay filtered, cut persists:

<img width="1919" height="906" alt="Screenshot 2026-04-03 164832" src="https://github.com/user-attachments/assets/ded707fa-b459-4c74-809d-3d904dd3919b" />


## Tests
- `should re-apply cuts to registered collections on event switch` ✓
- `should clear cut registry when event data folder is rebuilt` ✓
- All 16 existing `PhoenixMenuUI` tests continue to pass ✓

Updated verification (clean 3-file branch):

**AFTER fix** — different event loaded, η = 0.5 cut persists, 
tracks remain filtered in central region:
<img width="1903" height="1008" alt="Screenshot 2026-04-08 230809" src="https://github.com/user-attachments/assets/39dc28a7-d7ab-4f30-b0e5-029dd4f96f68" />


**Cut panel after event switch** — slider still shows 0.5, 
cut was automatically re-applied:
<img width="1906" height="889" alt="Screenshot 2026-04-08 230854" src="https://github.com/user-attachments/assets/5bec15aa-b2f7-48b5-bc4d-a8a6b1db7437" />