### PR TITLE
fix(io-options-dialog): surface JSON parse errors to user via info logger (#842)

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -110,19 +110,41 @@ export class IOOptionsDialogComponent implements OnInit {
 
   handleJSONEventDataInput(files: FileList) {
     const callback = (content: any) => {
-      const json = typeof content === 'string' ? JSON.parse(content) : content;
-      this.eventDisplay.parsePhoenixEvents(json);
+      try {
+        const json =
+          typeof content === 'string' ? JSON.parse(content) : content;
+        this.eventDisplay.parsePhoenixEvents(json);
+      } catch (error) {
+        this.eventDisplay
+          .getInfoLogger()
+          .add(
+            'Could not parse JSON event file. Please ensure it is valid JSON.',
+            'Error',
+          );
+        console.error('Error parsing JSON event file:', error);
+      }
     };
     this.handleFileInput(files[0], 'json', callback);
   }
 
   handleEDM4HEPJSONEventDataInput(files: FileList) {
     const callback = (content: any) => {
-      const json = typeof content === 'string' ? JSON.parse(content) : content;
-      const edm4hepJsonLoader = new Edm4hepJsonLoader();
-      edm4hepJsonLoader.setRawEventData(json);
-      edm4hepJsonLoader.processEventData();
-      this.eventDisplay.parsePhoenixEvents(edm4hepJsonLoader.getEventData());
+      try {
+        const json =
+          typeof content === 'string' ? JSON.parse(content) : content;
+        const edm4hepJsonLoader = new Edm4hepJsonLoader();
+        edm4hepJsonLoader.setRawEventData(json);
+        edm4hepJsonLoader.processEventData();
+        this.eventDisplay.parsePhoenixEvents(edm4hepJsonLoader.getEventData());
+      } catch (error) {
+        this.eventDisplay
+          .getInfoLogger()
+          .add(
+            'Could not parse EDM4HEP JSON file. Please ensure it is valid JSON.',
+            'Error',
+          );
+        console.error('Error parsing EDM4HEP JSON file:', error);
+      }
     };
     this.handleFileInput(files[0], 'edm4hep.json', callback);
   }


### PR DESCRIPTION
## Summary
Fixes #842

When a malformed or invalid JSON event file was loaded, Phoenix 
crashed silently with no user-facing feedback. The error was only 
visible in the browser console.

## Changes
Added try/catch blocks around `JSON.parse()` calls in:
- `handleJSONEventDataInput`
- `handleEDM4HEPJSONEventDataInput`

Errors are now surfaced via the existing `getInfoLogger()` mechanism, 
consistent with how `handleZipEventDataInput` and `handlePHYSLITEInput` 
already handle errors.

## Before vs After

**Before:** UI stays completely silent when malformed JSON is loaded

**After:** User sees clear message in Info Panel:
`"Could not parse JSON event file. Please ensure it is valid JSON."`

## Testing
- Loaded malformed JSON (`{ "broken":`) → error shown in Info Panel 
- Loaded valid JSON → loads correctly with no error 