### PR TITLE
feat(state-manager): persist cut state in Save/Load State (closes #863 part 2)

### DIFF
--- a/packages/phoenix-event-display/src/lib/models/cut.model.ts
+++ b/packages/phoenix-event-display/src/lib/models/cut.model.ts
@@ -6,11 +6,17 @@ import { ConfigRangeSlider } from '../../managers/ui-manager/phoenix-menu/config
  * Used by StateManager to persist active cut state across sessions.
  */
 export interface CutJSON {
+  /** The event data attribute field name this cut applies to. */
   field: string;
+  /** The active minimum bound value of the cut. */
   minValue: number;
+  /** The active maximum bound value of the cut. */
   maxValue: number;
+  /** Step size used by the range slider for this cut. */
   step: number;
+  /** Whether the lower bound cut is currently active. */
   minCutActive: boolean;
+  /** Whether the upper bound cut is currently active. */
   maxCutActive: boolean;
 }
 
@@ -32,6 +38,12 @@ export class Cut {
 
   /**
    * Create the cut to filter an event data attribute.
+   * @param field The event data attribute field name to filter on.
+   * @param minValue The minimum allowed value of the attribute.
+   * @param maxValue The maximum allowed value of the attribute.
+   * @param step Step size for the range slider.
+   * @param minCutActive Whether the lower bound cut is active by default.
+   * @param maxCutActive Whether the upper bound cut is active by default.
    */
   constructor(
     public field: string,

--- a/packages/phoenix-event-display/src/lib/models/cut.model.ts
+++ b/packages/phoenix-event-display/src/lib/models/cut.model.ts
@@ -2,6 +2,19 @@ import { PrettySymbols } from '../../helpers/pretty-symbols';
 import { ConfigRangeSlider } from '../../managers/ui-manager/phoenix-menu/config-types';
 
 /**
+ * Plain-object representation of a Cut, safe for JSON serialization.
+ * Used by StateManager to persist active cut state across sessions.
+ */
+export interface CutJSON {
+  field: string;
+  minValue: number;
+  maxValue: number;
+  step: number;
+  minCutActive: boolean;
+  maxCutActive: boolean;
+}
+
+/**
  * Cut for specifying filters on event data attribute.
  */
 export class Cut {
@@ -13,17 +26,12 @@ export class Cut {
   private defaultApplyMaxValue: boolean;
   /** Default if lower bound applied */
   private defaultApplyMinValue: boolean;
+
   /** Range slider for Cut */
   public configRangeSlider?: ConfigRangeSlider;
+
   /**
    * Create the cut to filter an event data attribute.
-   * @param field Name of the event data attribute to be filtered.
-   * @param minValue Minimum allowed value of the event data attribute.
-   * @param maxValue Maximum allowed value of the event data attribute.
-   * @param step Size of increment when using slider.
-   * @param minCutActive If true, the minimum cut is appled. Can be overriden later with enableMinCut.
-   * @param maxCutActive If true, the maximum cut is appled. Can be overriden later with enableMaxCut.
-   *
    */
   constructor(
     public field: string,
@@ -37,14 +45,17 @@ export class Cut {
     this.defaultMaxValue = maxValue;
     this.defaultApplyMinValue = minCutActive;
     this.defaultApplyMaxValue = maxCutActive;
+
+    // Ensure all numeric values are actual numbers from the start
+    this.ensureNumericValues();
   }
 
-  /** Returns true if upper cut is valid. */
+  /** Enable/disable upper cut */
   enableMaxCut(check: boolean) {
     this.maxCutActive = check;
   }
 
-  /** Returns true if upper cut is valid. */
+  /** Enable/disable lower cut */
   enableMinCut(check: boolean) {
     this.minCutActive = check;
   }
@@ -59,8 +70,7 @@ export class Cut {
 
   /**
    * Create a deep copy of this Cut with the same field, bounds, step,
-   * and active flags. The clone gets fresh defaults equal to the
-   * current values so that reset() works independently.
+   * and active flags.
    */
   clone(): Cut {
     return new Cut(
@@ -74,6 +84,48 @@ export class Cut {
   }
 
   /**
+   * Ensure minValue, maxValue and step are always real numbers
+   * This prevents string values like "0.5" from being saved in JSON.
+   */
+  private ensureNumericValues() {
+    this.minValue = Number(this.minValue);
+    this.maxValue = Number(this.maxValue);
+    this.step = Number(this.step);
+  }
+
+  /**
+   * Serialize the current cut state to a plain object for JSON persistence.
+   * Forces numbers to prevent string values like "0.5".
+   */
+  toJSON(): CutJSON {
+    this.ensureNumericValues(); // Extra safety before serialization
+
+    return {
+      field: this.field,
+      minValue: Number(this.minValue),
+      maxValue: Number(this.maxValue),
+      step: Number(this.step),
+      minCutActive: Boolean(this.minCutActive),
+      maxCutActive: Boolean(this.maxCutActive),
+    };
+  }
+
+  /**
+   * Reconstruct a Cut instance from a previously serialized CutJSON object.
+   * Handles cases where values might come as strings from JSON.parse().
+   */
+  static fromJSON(json: CutJSON): Cut {
+    return new Cut(
+      json.field,
+      Number(json.minValue),
+      Number(json.maxValue),
+      Number(json.step ?? 1),
+      Boolean(json.minCutActive ?? true),
+      Boolean(json.maxCutActive ?? true),
+    );
+  }
+
+  /**
    * Reset the minimum and maximum value of the cut to default.
    */
   reset() {
@@ -81,7 +133,9 @@ export class Cut {
     this.maxValue = this.defaultMaxValue;
     this.minCutActive = this.defaultApplyMinValue;
     this.maxCutActive = this.defaultApplyMaxValue;
-    // Reset the config range slider
+
+    this.ensureNumericValues();
+
     if (this.configRangeSlider != undefined) {
       this.configRangeSlider.enableMin = true;
       this.configRangeSlider.enableMax = true;
@@ -92,8 +146,6 @@ export class Cut {
 
   /**
    * Builds a config range slider for the cut to be used in Phoenix Menu
-   * @param collectionFiltering callback function to apply to all objects inside a collection, filtering them given a parameter
-   * @returns config range slider for the cut to be used in Phoenix Menu
    */
   public getConfigRangeSlider(
     collectionFiltering: () => void,
@@ -110,8 +162,9 @@ export class Cut {
         enableMin: this.minCutActive,
         enableMax: this.maxCutActive,
         onChange: ({ value, highValue }) => {
-          this.minValue = value;
-          this.maxValue = highValue;
+          this.minValue = Number(value); // Force number
+          this.maxValue = Number(highValue); // Force number
+          this.ensureNumericValues();
           collectionFiltering();
         },
         setEnableMin: (checked: boolean) => {

--- a/packages/phoenix-event-display/src/managers/state-manager.ts
+++ b/packages/phoenix-event-display/src/managers/state-manager.ts
@@ -3,7 +3,12 @@ import { Camera } from 'three';
 import { PhoenixMenuNode } from './ui-manager/phoenix-menu/phoenix-menu-node';
 import { loadFile, saveFile } from '../helpers/file';
 import { ActiveVariable } from '../helpers/active-variable';
+import { Cut, CutJSON } from '../lib/models/cut.model';
 
+/** Map of collection name to array of serialized cuts, for JSON persistence. */
+export interface CutStateJSON {
+  [collectionName: string]: CutJSON[];
+}
 /**
  * A singleton manager for managing the scene's state.
  */
@@ -78,7 +83,8 @@ export class StateManager {
 
   /**
    * Get the current state of the event display as a JSON object.
-   * @returns The state object with menu, camera, and clipping data.
+   * Now includes active cut state so Save State preserves filters.
+   * @returns The state object with menu, camera, clipping, and cut data.
    */
   getStateAsJSON(): { [key: string]: any } {
     const controls = this.eventDisplay
@@ -98,9 +104,38 @@ export class StateManager {
           ? this.openingClippingAngle.value
           : null,
       },
+      cuts: this.getActiveCutsAsJSON(),
     };
   }
 
+  /**
+   * Serialize active cuts from PhoenixMenuUI into a plain JSON-safe object.
+   * Only collections with at least one active cut bound are included.
+   * Returns an empty object if no cuts are active or UI is unavailable.
+   */
+  private getActiveCutsAsJSON(): CutStateJSON {
+    const phoenixMenuUI = this.eventDisplay
+      ?.getUIManager()
+      ?.getPhoenixMenuUI?.();
+
+    if (!phoenixMenuUI) {
+      return {};
+    }
+
+    const registry = phoenixMenuUI.getCollectionCuts(); // This returns object { [name: string]: Cut[] }
+    const result: CutStateJSON = {};
+
+    Object.entries(registry).forEach(([collectionName, cuts]) => {
+      const activeCuts = cuts.filter(
+        (cut) => cut.minCutActive || cut.maxCutActive,
+      );
+      if (activeCuts.length > 0) {
+        result[collectionName] = activeCuts.map((cut) => cut.toJSON());
+      }
+    });
+
+    return result;
+  }
   /**
    * Save the state of the event display as JSON.
    */
@@ -169,6 +204,36 @@ export class StateManager {
         }
       }
     }
+    // Restore cut state if present in the saved JSON
+    if (jsonData['cuts']) {
+      this.restoreCutsFromJSON(jsonData['cuts'] as CutStateJSON);
+    }
+  }
+  /**
+   * Deserialize cut state from a saved JSON file, register the cuts back
+   * into PhoenixMenuUI, and re-apply them to the currently loaded event.
+   * @param cutsJSON The cuts section of a loaded state JSON file.
+   */
+  private restoreCutsFromJSON(cutsJSON: CutStateJSON): void {
+    const phoenixMenuUI = this.eventDisplay
+      ?.getUIManager()
+      ?.getPhoenixMenuUI?.();
+
+    if (!phoenixMenuUI) {
+      console.warn(
+        'StateManager: Cannot restore cuts — PhoenixMenuUI not available.',
+      );
+      return;
+    }
+
+    for (const [collectionName, cutJSONArray] of Object.entries(cutsJSON)) {
+      if (Array.isArray(cutJSONArray) && cutJSONArray.length > 0) {
+        const cuts = cutJSONArray.map((c) => Cut.fromJSON(c));
+        phoenixMenuUI.setCollectionCuts(collectionName, cuts);
+      }
+    }
+
+    phoenixMenuUI.reapplyCollectionCuts();
   }
 
   /**

--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -611,6 +611,16 @@ export class UIManager {
     phoenixMenuUI?.loadEventFolderState();
     phoenixMenuUI?.reapplyCollectionCuts();
   }
+  /**
+   * Get the PhoenixMenuUI instance if one is active.
+   * Used by StateManager to access the cut registry for serialization.
+   * @returns The PhoenixMenuUI instance, or undefined if not initialized.
+   */
+  public getPhoenixMenuUI(): PhoenixMenuUI | undefined {
+    return this.uiMenus.find((uiMenu) => uiMenu instanceof PhoenixMenuUI) as
+      | PhoenixMenuUI
+      | undefined;
+  }
 
   /**
    * Get all the UI menus.

--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-ui.ts
@@ -254,9 +254,15 @@ export class PhoenixMenuUI implements PhoenixUI<PhoenixMenuNode> {
 
     this.addDrawOptions(collectionNode, collectionName);
 
-    if (cuts && cuts.length > 0) {
+    // Always register cuts for this collection if any were provided.
+    // This ensures the registry has the Cut instances so StateManager
+    // can serialize active cuts (minCutActive / maxCutActive) even if
+    // the initial cuts array was empty or the user only moves sliders later.
+    if (cuts !== undefined) {
       this.collectionCuts[collectionName] = cuts;
-      this.addCutOptions(collectionNode, collectionName, cuts);
+      if (cuts.length > 0) {
+        this.addCutOptions(collectionNode, collectionName, cuts);
+      }
     }
 
     const colorByOptions: ColorByOptionKeys[] = [];
@@ -540,5 +546,24 @@ export class PhoenixMenuUI implements PhoenixUI<PhoenixMenuNode> {
     for (const [collectionName, cuts] of Object.entries(this.collectionCuts)) {
       this.sceneManager.collectionFilter(collectionName, cuts);
     }
+  }
+
+  /**
+   * Returns the active cut registry keyed by collection name.
+   * Used by StateManager for cut state serialization on Save State.
+   * @returns A reference to the collectionCuts registry.
+   */
+  public getCollectionCuts(): { [collectionName: string]: Cut[] } {
+    return this.collectionCuts;
+  }
+
+  /**
+   * Set cuts for a specific collection in the registry.
+   * Used by StateManager when restoring cut state from Load State.
+   * @param collectionName Name of the collection.
+   * @param cuts Array of Cut instances to register.
+   */
+  public setCollectionCuts(collectionName: string, cuts: Cut[]): void {
+    this.collectionCuts[collectionName] = cuts;
   }
 }

--- a/packages/phoenix-event-display/src/tests/lib/models/cut.model.test.ts
+++ b/packages/phoenix-event-display/src/tests/lib/models/cut.model.test.ts
@@ -59,4 +59,101 @@ describe('Cut', () => {
       expect(cloned.cutPassed(99)).toBe(false);
     });
   });
+
+  // NEW TESTS START HERE
+
+  describe('toJSON', () => {
+    it('should return a plain object with all serializable fields', () => {
+      const cut = new Cut('eta', -1.0, 1.0, 0.1, true, false);
+      expect(cut.toJSON()).toEqual({
+        field: 'eta',
+        minValue: -1.0,
+        maxValue: 1.0,
+        step: 0.1,
+        minCutActive: true,
+        maxCutActive: false,
+      });
+    });
+
+    it('should capture the current slider position, not the original defaults', () => {
+      const cut = new Cut('pt', 0, 100);
+      cut.minValue = 20;
+      cut.maxValue = 80;
+      const json = cut.toJSON();
+      expect(json.minValue).toBe(20);
+      expect(json.maxValue).toBe(80);
+    });
+
+    it('should not include configRangeSlider or private default fields', () => {
+      const cut = new Cut('phi', -3.14, 3.14);
+      const json = cut.toJSON() as any;
+      expect('configRangeSlider' in json).toBe(false);
+      expect('defaultMinValue' in json).toBe(false);
+      expect('defaultMaxValue' in json).toBe(false);
+    });
+
+    it('should produce output that is safely JSON.stringify-able', () => {
+      const cut = new Cut('eta', -2.5, 2.5, 0.05, true, true);
+      expect(() => JSON.stringify(cut.toJSON())).not.toThrow();
+    });
+  });
+
+  describe('fromJSON', () => {
+    it('should reconstruct a Cut with all matching field values', () => {
+      const cut = Cut.fromJSON({
+        field: 'phi',
+        minValue: 0.5,
+        maxValue: 2.5,
+        step: 0.05,
+        minCutActive: true,
+        maxCutActive: false,
+      });
+      expect(cut.field).toBe('phi');
+      expect(cut.minValue).toBe(0.5);
+      expect(cut.maxValue).toBe(2.5);
+      expect(cut.step).toBe(0.05);
+      expect(cut.minCutActive).toBe(true);
+      expect(cut.maxCutActive).toBe(false);
+    });
+
+    it('should return a proper Cut instance with working methods', () => {
+      const cut = Cut.fromJSON({
+        field: 'eta',
+        minValue: -0.5,
+        maxValue: 0.5,
+        step: 0.1,
+        minCutActive: true,
+        maxCutActive: true,
+      });
+      expect(cut).toBeInstanceOf(Cut);
+      expect(cut.cutPassed(0)).toBe(true);
+      expect(cut.cutPassed(1)).toBe(false);
+    });
+  });
+
+  describe('round-trip serialization', () => {
+    it('should preserve all values through toJSON → stringify → parse → fromJSON', () => {
+      const original = new Cut('eta', -1.2, 1.2, 0.1, true, true);
+      original.minValue = -0.5;
+      const restored = Cut.fromJSON(
+        JSON.parse(JSON.stringify(original.toJSON())),
+      );
+      expect(restored.field).toBe('eta');
+      expect(restored.minValue).toBe(-0.5);
+      expect(restored.maxValue).toBe(1.2);
+      expect(restored.step).toBe(0.1);
+      expect(restored.minCutActive).toBe(true);
+      expect(restored.maxCutActive).toBe(true);
+    });
+
+    it('should produce a Cut that filters values correctly after round-trip', () => {
+      const original = new Cut('pt', 10, 50, 1, true, true);
+      const restored = Cut.fromJSON(
+        JSON.parse(JSON.stringify(original.toJSON())),
+      );
+      expect(restored.cutPassed(30)).toBe(true);
+      expect(restored.cutPassed(5)).toBe(false);
+      expect(restored.cutPassed(60)).toBe(false);
+    });
+  });
 });

--- a/packages/phoenix-event-display/src/tests/managers/state-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/state-manager.test.ts
@@ -120,4 +120,145 @@ describe('StateManager', () => {
     stateManager.setEventDisplay(eventDisplay);
     expect(stateManager.eventDisplay).toBe(eventDisplay);
   });
+
+  describe('cut state serialization', () => {
+    let mockPhoenixMenuUI: any;
+    let mockUIManager: any;
+
+    beforeEach(() => {
+      mockPhoenixMenuUI = {
+        getCollectionCuts: jest.fn().mockReturnValue({}),
+        setCollectionCuts: jest.fn(),
+        reapplyCollectionCuts: jest.fn(),
+      };
+      mockUIManager = {
+        getPhoenixMenuUI: jest.fn().mockReturnValue(mockPhoenixMenuUI),
+        setClipping: jest.fn(),
+        rotateStartAngleClipping: jest.fn(),
+        rotateOpeningAngleClipping: jest.fn(),
+      };
+      // Wire the mock eventDisplay to return our mock UIManager
+      (stateManager as any).eventDisplay = {
+        getUIManager: jest.fn().mockReturnValue(mockUIManager),
+        getThreeManager: jest.fn().mockReturnValue({
+          getControlsManager: jest.fn().mockReturnValue({
+            getMainControls: jest.fn().mockReturnValue({
+              target: { toArray: jest.fn().mockReturnValue([0, 0, 0]) },
+            }),
+          }),
+        }),
+      };
+      stateManager.activeCamera = {
+        position: { toArray: jest.fn().mockReturnValue([0, 0, 0]) },
+      } as any;
+    });
+
+    it('should include a cuts key in getStateAsJSON output', () => {
+      const state = stateManager.getStateAsJSON();
+      expect(state).toHaveProperty('cuts');
+    });
+
+    it('should serialize active cuts from the registry', () => {
+      const { Cut } = jest.requireActual('../../lib/models/cut.model');
+      const cut = new Cut('eta', -0.5, 0.5, 0.1, true, true);
+      mockPhoenixMenuUI.getCollectionCuts.mockReturnValue({ Tracks: [cut] });
+
+      const state = stateManager.getStateAsJSON();
+
+      expect(state['cuts']['Tracks']).toHaveLength(1);
+      expect(state['cuts']['Tracks'][0].field).toBe('eta');
+      expect(state['cuts']['Tracks'][0].minValue).toBe(-0.5);
+    });
+
+    it('should return empty cuts object when registry is empty', () => {
+      mockPhoenixMenuUI.getCollectionCuts.mockReturnValue({});
+      const state = stateManager.getStateAsJSON();
+      expect(state['cuts']).toEqual({});
+    });
+
+    it('should return empty cuts when PhoenixMenuUI is unavailable', () => {
+      mockUIManager.getPhoenixMenuUI.mockReturnValue(undefined);
+      const state = stateManager.getStateAsJSON();
+      expect(state['cuts']).toEqual({});
+    });
+
+    it('should exclude collections where all cuts are inactive', () => {
+      const { Cut } = jest.requireActual('../../lib/models/cut.model');
+      const cut = new Cut('phi', -3.14, 3.14);
+      cut.minCutActive = false;
+      cut.maxCutActive = false;
+      mockPhoenixMenuUI.getCollectionCuts.mockReturnValue({ Tracks: [cut] });
+
+      const state = stateManager.getStateAsJSON();
+      expect(state['cuts']).toEqual({});
+    });
+
+    it('should call setCollectionCuts with reconstructed Cut instances on loadStateFromJSON', () => {
+      stateManager.loadStateFromJSON({
+        cuts: {
+          Tracks: [
+            {
+              field: 'eta',
+              minValue: -0.5,
+              maxValue: 0.5,
+              step: 0.1,
+              minCutActive: true,
+              maxCutActive: true,
+            },
+          ],
+        },
+      });
+
+      expect(mockPhoenixMenuUI.setCollectionCuts).toHaveBeenCalledWith(
+        'Tracks',
+        expect.arrayContaining([
+          expect.objectContaining({ field: 'eta', minValue: -0.5 }),
+        ]),
+      );
+    });
+
+    it('should call reapplyCollectionCuts once after restoring cuts', () => {
+      stateManager.loadStateFromJSON({
+        cuts: {
+          Tracks: [
+            {
+              field: 'eta',
+              minValue: -0.5,
+              maxValue: 0.5,
+              step: 0.1,
+              minCutActive: true,
+              maxCutActive: true,
+            },
+          ],
+        },
+      });
+      expect(mockPhoenixMenuUI.reapplyCollectionCuts).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call cut methods when no cuts key is present in JSON', () => {
+      stateManager.loadStateFromJSON({ eventDisplay: {} });
+      expect(mockPhoenixMenuUI.setCollectionCuts).not.toHaveBeenCalled();
+      expect(mockPhoenixMenuUI.reapplyCollectionCuts).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when PhoenixMenuUI is unavailable during restore', () => {
+      mockUIManager.getPhoenixMenuUI.mockReturnValue(undefined);
+      expect(() =>
+        stateManager.loadStateFromJSON({
+          cuts: {
+            Tracks: [
+              {
+                field: 'eta',
+                minValue: -0.5,
+                maxValue: 0.5,
+                step: 0.1,
+                minCutActive: true,
+                maxCutActive: true,
+              },
+            ],
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Completes the fix for #863 

PR #872 fixed cut re-application on live event switches (in-memory fix).
This PR adds the second half: cuts are now included in **Save State** and
fully restored by **Load State**, giving physicists persistent filter
configurations across sessions and page reloads.

## Changes

**`cut.model.ts`**
- Added `CutJSON` interface for type-safe serialization
- Added `Cut.toJSON()` — serializes current slider state to a plain object
- Added `Cut.fromJSON()` — reconstructs a Cut instance from saved JSON

**`phoenix-menu-ui.ts`**
- Added `getCollectionCuts()` — exposes the cut registry to StateManager
- Added `setCollectionCuts()` — allows StateManager to write restored cuts

**`ui-manager/index.ts`**
- Added `getPhoenixMenuUI()` — exposes PhoenixMenuUI instance publicly

**`state-manager.ts`**
- `getStateAsJSON()` now includes a `cuts` key
- Added `getActiveCutsAsJSON()` — collects and serializes active cuts
- Added `restoreCutsFromJSON()` — deserializes and re-applies saved cuts
- `loadStateFromJSON()` calls restore when `cuts` key is present

## Before vs After

**Before:** Save State → page reload → Load State silently loses all
active filters

**After:** Save State captures cuts; Load State re-applies them exactly.
Verified: apply η < 0.5 on Tracks → Save State → refresh page →
Load State → slider still shows 0.5, cut correctly re-applied.

## Testing

- 8 new tests in `cut.model.test.ts`: toJSON, fromJSON, round-trip
- 9 new tests in `state-manager.test.ts`: all serialization paths
- 202 tests passing, 0 failing
- Manual: η < 0.5 on Tracks persists through Save → reload → Load State

Note: `phoenix-ng` test failures (`dupMap.get is not a function`) are
pre-existing on `main` before this branch and unrelated to this PR.