### PR TITLE
fix: Prevent autoloader loop crash on individual file fetch errors

### DIFF
--- a/phoenix/packages/phoenix-event-display/src/helpers/event-autoloader.ts
+++ b/phoenix/packages/phoenix-event-display/src/helpers/event-autoloader.ts
@@ -113,10 +113,17 @@ export class EventAutoloader {
 
     const newFiles = this.parseApacheListing(html, url);
 
-    for (const fileUrl of newFiles) {
+   for (const fileUrl of newFiles) {
       if (this.seenFiles.has(fileUrl)) continue;
       this.seenFiles.add(fileUrl);
-      await this.fetchAndEmit(fileUrl);
+      
+      try {
+        await this.fetchAndEmit(fileUrl);
+      } catch (err: any) {
+        // Log it, but let the loop continue to the next file!
+        this.options.onError?.(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
     }
   }
 


### PR DESCRIPTION
### What changed?
Wrapped the `fetchAndEmit(fileUrl)` call inside a `try/catch` block within the directory polling loop. 

### Why is this needed?
Previously, if a single file failed, the uncaught error would break the entire `for` loop. This caused the autoloader to completely ignore any remaining new files in that batch. 

By isolating the fetch step, a failed file is now safely caught and passed to the `onError` handler, allowing the loop to continue processing the rest of the files without interruption.