### PR TITLE
docs(phoenix-ui-components): add NotificationService documentation (#909)

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/README.md
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/README.md
@@ -86,6 +86,7 @@ export class TestComponent {
   phoenixMenuRoot = new PhoenixMenuNode('Phoenix Menu', 'phoenix-menu');
 }
 ```
+
 ## Services
 
 ### NotificationService

--- a/packages/phoenix-ng/projects/phoenix-ui-components/README.md
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/README.md
@@ -86,3 +86,68 @@ export class TestComponent {
   phoenixMenuRoot = new PhoenixMenuNode('Phoenix Menu', 'phoenix-menu');
 }
 ```
+## Services
+
+### NotificationService
+
+`NotificationService` provides user-facing notifications with four severity levels and configurable auto-dismiss durations. It replaces silent console errors with actionable feedback visible directly in the UI.
+
+#### Severity levels and default durations
+
+| Severity  | Default duration | Behaviour               |
+|-----------|------------------|-------------------------|
+| `success` | 5000ms           | Auto-dismisses          |
+| `info`    | 5000ms           | Auto-dismisses          |
+| `warning` | 8000ms           | Auto-dismisses          |
+| `error`   | 0ms              | Requires manual dismiss |
+
+#### Usage
+
+Inject `NotificationService` into any Angular component or service:
+
+```ts
+import { NotificationService } from 'phoenix-ui-components';
+
+@Component({ ... })
+export class MyComponent {
+  constructor(private notificationService: NotificationService) {}
+
+  loadFile() {
+    try {
+      // ... load file
+      this.notificationService.success('File loaded successfully.');
+    } catch (error) {
+      this.notificationService.error(
+        'Could not parse event file. Please ensure it is valid JSON.',
+      );
+    }
+  }
+}
+```
+
+To display notifications, subscribe to the service and store the unsubscribe function:
+
+```ts
+private unsubscribe: () => void;
+
+ngOnInit() {
+  this.unsubscribe = this.notificationService.subscribeToNotifications(
+    (notification) => {
+      // notification.message   — the text to display
+      // notification.severity  — 'success' | 'info' | 'warning' | 'error'
+      // notification.duration  — auto-dismiss duration in ms (0 = no auto-dismiss)
+    },
+  );
+}
+
+ngOnDestroy() {
+  this.unsubscribe?.();
+}
+```
+
+A custom duration can be passed as an optional second argument:
+
+```ts
+this.notificationService.warning('Large file detected.', 12000);
+this.notificationService.error('Connection lost.', 10000);
+```

--- a/packages/phoenix-ng/projects/phoenix-ui-components/README.md
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/README.md
@@ -95,7 +95,7 @@ export class TestComponent {
 #### Severity levels and default durations
 
 | Severity  | Default duration | Behaviour               |
-|-----------|------------------|-------------------------|
+| --------- | ---------------- | ----------------------- |
 | `success` | 5000ms           | Auto-dismisses          |
 | `info`    | 5000ms           | Auto-dismisses          |
 | `warning` | 8000ms           | Auto-dismisses          |


### PR DESCRIPTION
Closes #909

### Changes
- Adds a new `## Services` section to `packages/phoenix-ng/projects/phoenix-ui-components/README.md`
- Documents the `NotificationService` (introduced in #895) with usage examples, severity levels, and subscription guidance.

### Summary
This PR adds clear documentation and usage examples for the `NotificationService` as requested in #909. No code changes — only the README was updated.