### PR TITLE
Add page-scoped dark-theme toggle on the home page

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.html
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.html
@@ -1,3 +1,5 @@
+<app-dark-theme class="home-theme-toggle"></app-dark-theme>
+
 <div class="container">
   <div class="pricing-header p-3 pt-md-5 pb-md-4 text-center">
     <img

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/home/home.component.scss
@@ -1,3 +1,10 @@
+.home-theme-toggle {
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 10000;
+}
+
 h1 {
   font-family: 'Circular';
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/nav/nav.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/nav/nav.component.html
@@ -1,3 +1,8 @@
-<a id="mainLogo" class="main-logo fixed-top p-2 mx-auto mt-2" routerLink="/">
-  <img src="assets/images/logo-text.svg" />
+<a
+  id="mainLogo"
+  class="main-logo fixed-top p-2 mx-auto mt-2"
+  routerLink="/"
+  aria-label="Phoenix home"
+>
+  <img src="assets/images/logo-text.svg" alt="Phoenix logo" />
 </a>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/dark-theme/dark-theme.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/dark-theme/dark-theme.component.html
@@ -1,5 +1,5 @@
 <app-menu-toggle
-  tooltip="Dark theme"
+  tooltip="Switch Dark/Light theme"
   [active]="darkTheme"
   icon="dark"
   (click)="setDarkTheme()"

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu-wrapper/ui-menu-wrapper.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu-wrapper/ui-menu-wrapper.component.html
@@ -1,6 +1,8 @@
 <div id="uiMenu">
   <button
     id="hideUIMenu"
+    type="button"
+    aria-label="Toggle toolbar visibility"
     [matTooltip]="hideUIMenu ? 'Show toolbar' : 'Hide toolbar'"
     matTooltipPosition="above"
     (click)="hideUIMenu = !hideUIMenu"


### PR DESCRIPTION
This change places the existing dark/light theme toggle on the home page only, in the top-right corner. 

## Changes
- Added the theme toggle to the home page view

https://github.com/user-attachments/assets/aa5c5813-acc0-4943-b2e0-3a2fe6b0cace

- Positioned it at the top-right of the page