### PR TITLE
Enhance UI components stacking and panel behavior

### DIFF
--- a/packages/phoenix-event-display/package.json
+++ b/packages/phoenix-event-display/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "jspdf": "*"
+  },
+  "browser": {
+    "@resvg/resvg-js": false
   }
 }

--- a/packages/phoenix-ng/package.json
+++ b/packages/phoenix-ng/package.json
@@ -61,5 +61,8 @@
   },
   "peerDependencies": {
     "jspdf": "*"
+  },
+  "browser": {
+    "@resvg/resvg-js": false
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
@@ -151,6 +151,17 @@
 .phoenix-menu-children {
   margin-left: 0.5rem;
   border-left: 1px solid var(--phoenix-accent);
+  max-height: 35vh;
+  overflow-y: auto;
+
+  /* Custom thin scrollbar to avoid clutter */
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--phoenix-text-color-secondary, #999);
+    border-radius: 4px;
+  }
 }
 
 .range-slider {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.html
@@ -4,6 +4,7 @@
   icon="eventData"
   [resizable]="true"
   [active]="showObjectsInfo"
+  accordionId="right-dock"
 >
   <!-- Using ngIf to remove it from DOM since this panel requires heavy computing -->
   <div *ngIf="showObjectsInfo" class="collectionsInfo m-2">

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info-overlay/collections-info-overlay.component.ts
@@ -44,17 +44,23 @@ export class CollectionsInfoOverlayComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.unsubscribes.push(
-      this.eventDisplay.listenToDisplayedEventChange(() => {
-        const collectionsGrouped: { [key: string]: string[] } =
-          this.eventDisplay.getCollections();
+    const updateCollections = () => {
+      const collectionsGrouped: { [key: string]: string[] } =
+        this.eventDisplay.getCollections();
+      if (collectionsGrouped) {
         this.collections = Object.entries(collectionsGrouped).map(
           ([type, collections]: [string, string[]]) => ({
             type,
             collections,
           }),
         );
-      }),
+      }
+    };
+
+    updateCollections();
+
+    this.unsubscribes.push(
+      this.eventDisplay.listenToDisplayedEventChange(() => updateCollections()),
     );
 
     this.activeObject = this.eventDisplay.getActiveObjectId();

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info.component.html
@@ -1,5 +1,5 @@
 <app-menu-toggle
-  tooltip="Event data collections info"
+  tooltip="Collections Info"
   icon="eventData"
   [active]="showObjectsInfo"
   (click)="toggleOverlay()"

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info.component.test.ts
@@ -18,6 +18,10 @@ describe('CollectionsInfoComponent', () => {
       enableHighlighting: jest.fn(),
     },
     destroy: jest.fn(),
+    position: jest.fn().mockReturnThis(),
+    global: jest.fn().mockReturnThis(),
+    bottom: jest.fn().mockReturnThis(),
+    right: jest.fn().mockReturnThis(),
   };
 
   beforeEach(() => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/collections-info/collections-info.component.ts
@@ -4,9 +4,9 @@ import {
   ComponentRef,
   type OnDestroy,
 } from '@angular/core';
+import { CollectionsInfoOverlayComponent } from './collections-info-overlay/collections-info-overlay.component';
 import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { CollectionsInfoOverlayComponent } from './collections-info-overlay/collections-info-overlay.component';
 
 @Component({
   standalone: false, // this is now required when using NgModule
@@ -21,7 +21,13 @@ export class CollectionsInfoComponent implements OnInit, OnDestroy {
   constructor(private overlay: Overlay) {}
 
   ngOnInit() {
-    const overlayRef = this.overlay.create();
+    const positionStrategy = this.overlay
+      .position()
+      .global()
+      .bottom('80px')
+      .right('15px');
+
+    const overlayRef = this.overlay.create({ positionStrategy });
     const overlayPortal = new ComponentPortal(CollectionsInfoOverlayComponent);
     this.overlayWindow = overlayRef.attach(overlayPortal);
     this.overlayWindow.instance.showObjectsInfo = this.showObjectsInfo;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/eta-phi-panel/eta-phi-panel.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/eta-phi-panel/eta-phi-panel.component.ts
@@ -7,6 +7,7 @@ import {
 import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { EtaPhiPanelOverlayComponent } from './eta-phi-panel-overlay/eta-phi-panel-overlay.component';
+import { OverlayCascadeService } from '../../../services/overlay-cascade.service';
 
 @Component({
   standalone: false,
@@ -18,10 +19,14 @@ export class EtaPhiPanelComponent implements OnInit, OnDestroy {
   showPanel = false;
   overlayWindow: ComponentRef<EtaPhiPanelOverlayComponent>;
 
-  constructor(private overlay: Overlay) {}
+  constructor(
+    private overlay: Overlay,
+    private overlayCascade: OverlayCascadeService,
+  ) {}
 
   ngOnInit() {
-    const overlayRef = this.overlay.create();
+    const positionStrategy = this.overlayCascade.getCascadePositionStrategy();
+    const overlayRef = this.overlay.create({ positionStrategy });
     const overlayPortal = new ComponentPortal(EtaPhiPanelOverlayComponent);
     this.overlayWindow = overlayRef.attach(overlayPortal);
     this.overlayWindow.instance.showPanel = this.showPanel;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-browser/event-browser-overlay/event-browser-overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-browser/event-browser-overlay/event-browser-overlay.component.html
@@ -1,7 +1,9 @@
 <app-overlay
   overlayTitle="Event Browser"
   icon="event-browser"
+  [resizable]="true"
   [active]="showEventBrowser"
+  accordionId="right-dock"
 >
   <div *ngIf="showEventBrowser" class="event-browser m-2">
     <!-- Search box -->

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-browser/event-browser.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/event-browser/event-browser.component.ts
@@ -4,9 +4,9 @@ import {
   ComponentRef,
   type OnDestroy,
 } from '@angular/core';
+import { EventBrowserOverlayComponent } from './event-browser-overlay/event-browser-overlay.component';
 import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
-import { EventBrowserOverlayComponent } from './event-browser-overlay/event-browser-overlay.component';
 
 @Component({
   standalone: false,
@@ -21,7 +21,13 @@ export class EventBrowserComponent implements OnInit, OnDestroy {
   constructor(private overlay: Overlay) {}
 
   ngOnInit() {
-    const overlayRef = this.overlay.create();
+    const positionStrategy = this.overlay
+      .position()
+      .global()
+      .bottom('15px')
+      .right('15px');
+
+    const overlayRef = this.overlay.create({ positionStrategy });
     const overlayPortal = new ComponentPortal(EventBrowserOverlayComponent);
     this.overlayWindow = overlayRef.attach(overlayPortal);
     this.overlayWindow.instance.showEventBrowser = this.showEventBrowser;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/geometry-browser/geometry-browser-overlay/geometry-browser-overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/geometry-browser/geometry-browser-overlay/geometry-browser-overlay.component.html
@@ -4,6 +4,7 @@
   icon="info"
   [resizable]="true"
   [active]="browseDetectorParts"
+  accordionId="right-dock"
 >
   <!-- Using ngIf to remove it from DOM since this panel requires heavy computing -->
   <div *ngIf="browseDetectorParts" class="collectionsInfo m-2">

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/geometry-browser/geometry-browser.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/geometry-browser/geometry-browser.component.test.ts
@@ -20,6 +20,10 @@ describe('GeometryBrowserComponent', () => {
       enableHighlighting: jest.fn(),
     },
     destroy: jest.fn(),
+    position: jest.fn().mockReturnThis(),
+    global: jest.fn().mockReturnThis(),
+    bottom: jest.fn().mockReturnThis(),
+    right: jest.fn().mockReturnThis(),
   };
 
   beforeEach(() => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/geometry-browser/geometry-browser.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/geometry-browser/geometry-browser.component.ts
@@ -1,10 +1,10 @@
-import { GeometryBrowserOverlayComponent } from './geometry-browser-overlay/geometry-browser-overlay.component';
 import {
   Component,
   type OnInit,
   ComponentRef,
   type OnDestroy,
 } from '@angular/core';
+import { GeometryBrowserOverlayComponent } from './geometry-browser-overlay/geometry-browser-overlay.component';
 import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 
@@ -21,7 +21,13 @@ export class GeometryBrowserComponent implements OnInit, OnDestroy {
   constructor(private overlay: Overlay) {}
 
   ngOnInit() {
-    const overlayRef = this.overlay.create();
+    const positionStrategy = this.overlay
+      .position()
+      .global()
+      .bottom('150px')
+      .right('15px');
+
+    const overlayRef = this.overlay.create({ positionStrategy });
     const overlayPortal = new ComponentPortal(GeometryBrowserOverlayComponent);
     this.overlayWindow = overlayRef.attach(overlayPortal);
     this.overlayWindow.instance.browseDetectorParts = this.browseDetectorParts;
@@ -34,9 +40,10 @@ export class GeometryBrowserComponent implements OnInit, OnDestroy {
   toggleOverlay() {
     this.browseDetectorParts = !this.browseDetectorParts;
     this.overlayWindow.instance.browseDetectorParts = this.browseDetectorParts;
-    // eslint-disable-next-line
-    this.browseDetectorParts
-      ? this.overlayWindow.instance.enableHighlighting()
-      : this.overlayWindow.instance.disableHighlighting();
+    if (this.browseDetectorParts) {
+      this.overlayWindow.instance.enableHighlighting();
+    } else {
+      this.overlayWindow.instance.disableHighlighting();
+    }
   }
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/info-panel/info-panel.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/info-panel/info-panel.component.test.ts
@@ -15,6 +15,10 @@ describe('InfoPanelComponent', () => {
     overlayWindow: jest.fn().mockReturnThis(),
     instance: jest.fn().mockReturnThis(),
     destroy: jest.fn(),
+    position: jest.fn().mockReturnThis(),
+    global: jest.fn().mockReturnThis(),
+    top: jest.fn().mockReturnThis(),
+    left: jest.fn().mockReturnThis(),
   };
 
   beforeEach(() => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/info-panel/info-panel.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/info-panel/info-panel.component.ts
@@ -7,6 +7,7 @@ import {
 import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { InfoPanelOverlayComponent } from './info-panel-overlay/info-panel-overlay.component';
+import { OverlayCascadeService } from '../../../services/overlay-cascade.service';
 
 /**
  * Component for toggling info panel overlay
@@ -27,13 +28,17 @@ export class InfoPanelComponent implements OnInit, OnDestroy {
    * Create the info panel toggle
    * @param overlay Info panel overlay containing logger data
    */
-  constructor(private overlay: Overlay) {}
+  constructor(
+    private overlay: Overlay,
+    private overlayCascade: OverlayCascadeService,
+  ) {}
 
   /**
    * Create the info panel overlay
    */
   ngOnInit() {
-    const overlayRef = this.overlay.create();
+    const positionStrategy = this.overlayCascade.getCascadePositionStrategy();
+    const overlayRef = this.overlay.create({ positionStrategy });
     const overlayPortal = new ComponentPortal(InfoPanelOverlayComponent);
     this.overlayWindow = overlayRef.attach(overlayPortal);
     this.overlayWindow.instance.showInfoPanel = this.showInfoPanel;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/kinematics-panel/kinematics-panel-overlay/kinematics-panel-overlay.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/kinematics-panel/kinematics-panel-overlay/kinematics-panel-overlay.component.scss
@@ -1,5 +1,6 @@
 .kinematics-panel {
-  height: 95%;
+  width: 620px;
+  height: 450px;
   display: flex;
   flex-direction: column;
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/kinematics-panel/kinematics-panel.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/kinematics-panel/kinematics-panel.component.ts
@@ -11,6 +11,7 @@ import { Overlay } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { KinematicsPanelOverlayComponent } from './kinematics-panel-overlay/kinematics-panel-overlay.component';
 import type { KinematicsConfig } from 'phoenix-event-display';
+import { OverlayCascadeService } from '../../../services/overlay-cascade.service';
 
 @Component({
   standalone: false,
@@ -23,10 +24,14 @@ export class KinematicsPanelComponent implements OnInit, OnDestroy, OnChanges {
   overlayWindow: ComponentRef<KinematicsPanelOverlayComponent>;
   @Input() config?: KinematicsConfig;
 
-  constructor(private overlay: Overlay) {}
+  constructor(
+    private overlay: Overlay,
+    private overlayCascade: OverlayCascadeService,
+  ) {}
 
   ngOnInit() {
-    const overlayRef = this.overlay.create();
+    const positionStrategy = this.overlayCascade.getCascadePositionStrategy();
+    const overlayRef = this.overlay.create({ positionStrategy });
     const overlayPortal = new ComponentPortal(KinematicsPanelOverlayComponent);
     this.overlayWindow = overlayRef.attach(overlayPortal);
     this.overlayWindow.instance.showKinematics = this.showKinematics;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/more-info/more-info.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/more-info/more-info.component.html
@@ -1,4 +1,3 @@
-<!-- Sub-components kept outside the mat-menu so their overlays persist when the menu closes -->
 <div class="hidden-panels">
   <app-info-panel #infoPanel *ngIf="uiConfig?.showInfoPanel"></app-info-panel>
   <app-event-browser

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/more-info/more-info.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/more-info/more-info.component.scss
@@ -13,3 +13,8 @@
   margin-inline-end: 0.5rem;
   fill: currentColor;
 }
+
+::ng-deep .cdk-overlay-pane:has(.mat-mdc-menu-panel),
+::ng-deep .cdk-overlay-pane:has(.mat-menu-panel) {
+  z-index: 99999 !important;
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.html
@@ -2,7 +2,10 @@
   #overlayCard
   class="overlay-card card"
   [hidden]="!active"
+  (mousedown)="bringToFront()"
+  (touchstart)="bringToFront()"
   cdkDrag
+  cdkDragRootElement=".cdk-overlay-pane"
   cdkDragBoundary="body"
 >
   <div
@@ -22,7 +25,7 @@
       matTooltip="Expand / Collapse"
       matTooltipPosition="right"
       [ngClass]="{ expand: showBody }"
-      (click)="showBody = !showBody"
+      (click)="toggleBodyAndEmit()"
     >
       <svg>
         <use href="assets/icons/expand.svg#expand"></use>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.scss
@@ -1,11 +1,13 @@
 .overlay-card.card {
   color: var(--phoenix-text-color);
   background: none;
-  max-width: 100vw;
+  max-width: 85vw;
   font-size: 12px;
   /* Same min-width as overlay.component.ts MIN_RES_WIDTH */
   min-width: 300px;
-  height: 100%;
+  height: auto;
+  display: flex;
+  flex-direction: column;
   box-shadow: none;
   border: none;
   position: relative;
@@ -59,6 +61,7 @@
     border-top-left-radius: 0;
     overflow: auto;
     height: 100%;
+    max-height: 40vh;
 
     &.transparent-bg {
       background: none;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
@@ -3,14 +3,17 @@ import {
   ContentChild,
   Input,
   ViewChild,
+  type OnInit,
   type AfterViewInit,
   type OnDestroy,
   ViewEncapsulation,
+  ElementRef,
 } from '@angular/core';
-import type { ElementRef } from '@angular/core';
 import { ResizeSensor } from 'css-element-queries';
 
 import { EventDisplayService } from '../../../services/event-display.service';
+
+let maxZIndex = 100;
 
 /**
  * Component for overlay panel.
@@ -22,11 +25,23 @@ import { EventDisplayService } from '../../../services/event-display.service';
   styleUrls: ['./overlay.component.scss'],
   encapsulation: ViewEncapsulation.None,
 })
-export class OverlayComponent implements AfterViewInit, OnDestroy {
+export class OverlayComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Title of the overlay. */
   @Input() overlayTitle: string;
   /** If the overlay is open or not. */
-  @Input() active: boolean = false;
+  private _active: boolean = false;
+
+  @Input()
+  set active(value: boolean) {
+    this._active = value;
+    if (value) {
+      setTimeout(() => this.bringToFront(), 0);
+    }
+  }
+
+  get active(): boolean {
+    return this._active;
+  }
   /** Icon of the overlay header. */
   @Input() icon: string;
   /** If the overlay is resizable. */
@@ -60,11 +75,38 @@ export class OverlayComponent implements AfterViewInit, OnDestroy {
   /** Minimum resizable height */
   private MIN_RES_HEIGHT: number = 100;
 
-  constructor(private eventDisplay: EventDisplayService) {}
+  constructor(
+    private eventDisplay: EventDisplayService,
+    private elementRef: ElementRef,
+  ) {}
+
+  ngOnInit() {}
+
+  toggleBodyAndEmit() {
+    this.showBody = !this.showBody;
+  }
+
+  /** Bring the overlay to the front. */
+  bringToFront() {
+    maxZIndex++;
+    const wrapper = this.elementRef.nativeElement.closest(
+      '.cdk-global-overlay-wrapper',
+    );
+    if (wrapper) {
+      wrapper.style.zIndex = maxZIndex.toString();
+    }
+    const pane = this.elementRef.nativeElement.closest('.cdk-overlay-pane');
+    if (pane) {
+      pane.style.zIndex = maxZIndex.toString();
+    }
+  }
+
   /**
    * Move the resizable handle to the bottom right after the component is created.
    */
   ngAfterViewInit() {
+    this.bringToFront();
+
     if (this.resizable) {
       const resizeHandleElement = this.resizeHandleCorner.nativeElement;
       resizeHandleElement.style.bottom = '0';
@@ -105,15 +147,36 @@ export class OverlayComponent implements AfterViewInit, OnDestroy {
         height = width / this.aspectRatio;
       }
 
-      const oldratioW = width / this.overlayWindow.nativeElement.width;
-      const oldratioH = height / this.overlayWindow.nativeElement.height;
-      this.eventDisplay
-        .getThreeManager()
-        .getOverlayRenderer()
-        .setSize(width, height);
-      this.eventDisplay
-        .getThreeManager()
-        .syncOverlayViewPort(oldratioW, oldratioH);
+      if (this.overlayWindow?.nativeElement) {
+        const oldratioW = width / this.overlayWindow.nativeElement.width;
+        const oldratioH = height / this.overlayWindow.nativeElement.height;
+        this.eventDisplay
+          .getThreeManager()
+          .getOverlayRenderer()
+          .setSize(width, height);
+        this.eventDisplay
+          .getThreeManager()
+          .syncOverlayViewPort(oldratioW, oldratioH);
+      } else {
+        // Fallback for generic content that does not have a 3D canvas
+        this.overlayCard.nativeElement.style.width = width + 'px';
+        this.overlayCard.nativeElement.style.height = height + 'px';
+        const contentWrapper = this.overlayCard.nativeElement.querySelector(
+          '.overlay-card-content',
+        );
+        if (contentWrapper) {
+          contentWrapper.style.flex = '1';
+          contentWrapper.style.overflow = 'hidden';
+          contentWrapper.style.maxHeight = 'none';
+          const contentBody = contentWrapper.firstElementChild as HTMLElement;
+          if (contentBody) {
+            contentBody.style.width = '100%';
+            contentBody.style.height = '100%';
+            contentBody.style.maxWidth = 'none';
+            contentBody.style.maxHeight = 'none';
+          }
+        }
+      }
     }
   }
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/index.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/index.ts
@@ -2,3 +2,4 @@ export * from './event-display.service';
 export * from './extras/event-data-import';
 export * from './extras/attribute.pipe';
 export * from './notification.service';
+export * from './overlay-cascade.service';

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/overlay-accordion.service.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/overlay-accordion.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OverlayAccordionService {
+  private activePanel = new Subject<string>();
+  activePanel$ = this.activePanel.asObservable();
+
+  setActivePanel(panelId: string) {
+    this.activePanel.next(panelId);
+  }
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/overlay-cascade.service.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/services/overlay-cascade.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { GlobalPositionStrategy, Overlay } from '@angular/cdk/overlay';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OverlayCascadeService {
+  private cascadeCount = 0;
+  private topOffset = 130;
+  private leftOffset = 15;
+  private step = 40;
+
+  constructor(private overlay: Overlay) {}
+
+  public getCascadePositionStrategy(): GlobalPositionStrategy {
+    const strategy = this.overlay
+      .position()
+      .global()
+      .top(`${this.topOffset + this.cascadeCount * this.step}px`)
+      .left(`${this.leftOffset + this.cascadeCount * this.step}px`);
+
+    this.cascadeCount++;
+    return strategy;
+  }
+}


### PR DESCRIPTION
## Overview
This PR improves the behavior and usability of floating data panels in the Phoenix UI and also addresses issue #925.


https://github.com/user-attachments/assets/32367184-d8a1-46a7-8f3e-6ebcbcaea2d2


## Key Changes

- Made `Collections Info`, `Event Browser`, and `Geometry Browser` fully independent floating panels.
- Added better default positioning for panels to avoid overlap and improve layout consistency.
- Added scrolling constraints (`max-width: 85vw`, `max-height: 40vh`) for large tables instead of letting panels overflow the screen.
- Fixed z-index issues so Angular Material menus and tooltips correctly appear above overlays.