### PR TITLE
Update session recording shortcut to Ctrl+Alt+V

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -993,15 +993,15 @@ export class EventDisplay {
       document.removeEventListener('keydown', this.sessionRecordKeydownHandler);
     }
 
-    // Ctrl+Alt+V = toggle session recording
+    // Shift+S = toggle session recording
     this.sessionRecordKeydownHandler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       const isTyping = ['input', 'textarea', 'select'].includes(
         target?.tagName.toLowerCase(),
       );
       if (isTyping) return;
-      if (!(e.ctrlKey || e.metaKey) || !e.altKey) return;
-      if (e.code !== 'KeyV') return;
+      if (!e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return;
+      if (e.code !== 'KeyS') return;
 
       e.preventDefault();
       this.getSessionManager().toggleRecording();

--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -56,7 +56,7 @@ export class EventDisplay {
     new Set();
   /** Session recorder/player coordinator for #883 (lazy initialized). */
   private sessionManager: SessionManager | null = null;
-  /** Stored keydown handler for session recording shortcut (Shift+Ctrl+R). */
+  /** Stored keydown handler for session recording shortcut. */
   private sessionRecordKeydownHandler: ((e: KeyboardEvent) => void) | null =
     null;
   /** Three manager for three.js operations. */
@@ -993,16 +993,16 @@ export class EventDisplay {
       document.removeEventListener('keydown', this.sessionRecordKeydownHandler);
     }
 
-    // Shift+Ctrl+R = toggle session recording (#883). Plain Ctrl+R is left
-    // alone so the browser refresh keeps working.
+    // Ctrl+Alt+V = toggle session recording
     this.sessionRecordKeydownHandler = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       const isTyping = ['input', 'textarea', 'select'].includes(
         target?.tagName.toLowerCase(),
       );
       if (isTyping) return;
-      if (!e.shiftKey || !(e.ctrlKey || e.metaKey)) return;
-      if (e.code !== 'KeyR') return;
+      if (!(e.ctrlKey || e.metaKey) || !e.altKey) return;
+      if (e.code !== 'KeyV') return;
+
       e.preventDefault();
       this.getSessionManager().toggleRecording();
     };

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/session-pill/session-pill.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/session-pill/session-pill.component.html
@@ -10,7 +10,7 @@
       type="button"
       class="action stop"
       (click)="onStopRecording()"
-      title="Stop recording (Ctrl+Alt+V)"
+      title="Stop recording (Shift+S)"
       aria-label="Stop recording"
     >
       ■

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/session-pill/session-pill.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/session-pill/session-pill.component.html
@@ -10,7 +10,7 @@
       type="button"
       class="action stop"
       (click)="onStopRecording()"
-      title="Stop recording (Shift+Ctrl+R)"
+      title="Stop recording (Ctrl+Alt+V)"
       aria-label="Stop recording"
     >
       ■


### PR DESCRIPTION
### What changed?
Changed the screen recording shortcut from `Ctrl+Shift+R` to `Shift+S`.

### Why?
`Ctrl+Shift+R` is the standard browser shortcut for a "Hard Refresh" (bypassing the cache). Using it as an application shortcut causes conflicts and triggers unexpected page reloads for users. Changing it to `Shift+S` resolves this issue while maintaining an accessible shortcut for screen recording.