### PR TITLE
 fix: restrict masterclass track selection to track-type collections 

### DIFF
--- a/packages/phoenix-event-display/src/helpers/invariant-mass.ts
+++ b/packages/phoenix-event-display/src/helpers/invariant-mass.ts
@@ -57,6 +57,12 @@ export interface MasterclassConfig {
    * Returns a short label like "e", "4e", "2e2m".
    */
   classifyEvent: (tagCounts: Record<string, number>) => string;
+  /**
+   * Collection types shown in the "Select tracks" dropdown, e.g. ['Tracks'].
+   * Restricts the list to taggable types so detector-level collections (hits
+   * such as CSCs, calo cells) do not appear. Defaults to ['Tracks'] when unset.
+   */
+  collectionTypes?: string[];
 }
 
 /**

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/masterclass-panel/masterclass-panel-overlay/masterclass-panel-overlay.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/masterclass-panel/masterclass-panel-overlay/masterclass-panel-overlay.component.test.ts
@@ -1,0 +1,59 @@
+import { MasterclassPanelOverlayComponent } from './masterclass-panel-overlay.component';
+
+/**
+ * Regression tests for #923: the "Select tracks" dropdown must list only
+ * track-type collections (default), not detector-level collections such as
+ * Hits (CSCs) or calo cells.
+ */
+describe('MasterclassPanelOverlayComponent collection filtering (#923)', () => {
+  function makeComponent(
+    grouped: { [type: string]: string[] },
+    config?: any,
+  ): MasterclassPanelOverlayComponent {
+    const eventDisplay: any = {
+      getCollections: jest.fn(() => grouped),
+      getCollection: jest.fn(() => []),
+      listenToDisplayedEventChange: jest.fn(() => jest.fn()),
+      highlightObject: jest.fn(),
+      emit: jest.fn(),
+    };
+    const component = new MasterclassPanelOverlayComponent(eventDisplay);
+    if (config) component.config = config;
+    return component;
+  }
+
+  it('shows only Tracks-type collections by default (drops CSCs / calo)', () => {
+    const c = makeComponent({
+      Hits: ['CSCs'],
+      Tracks: ['Tracks_', 'CombinedMuonTracks'],
+      CaloClusters: ['Clusters'],
+    });
+    (c as any).loadCollections();
+    expect(c.collectionNames).toEqual(['Tracks_', 'CombinedMuonTracks']);
+  });
+
+  it('honors a custom collectionTypes config', () => {
+    const c = makeComponent(
+      { Tracks: ['Tracks_'], CaloClusters: ['Clusters'], Hits: ['CSCs'] },
+      { collectionTypes: ['Tracks', 'CaloClusters'] },
+    );
+    (c as any).loadCollections();
+    expect(c.collectionNames).toEqual(['Tracks_', 'Clusters']);
+  });
+
+  it('clears selection + items when no track collections exist', () => {
+    const c = makeComponent({ Hits: ['CSCs'], CaloClusters: ['Clusters'] });
+    c.selectedCollection = 'stale';
+    (c as any).loadCollections();
+    expect(c.collectionNames).toEqual([]);
+    expect(c.selectedCollection).toBe('');
+    expect(c.collectionItems).toEqual([]);
+  });
+
+  it('reselects the first collection when the prior selection disappears', () => {
+    const c = makeComponent({ Tracks: ['Tracks_'] });
+    c.selectedCollection = 'GoneCollection';
+    (c as any).loadCollections();
+    expect(c.selectedCollection).toBe('Tracks_');
+  });
+});

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/masterclass-panel/masterclass-panel-overlay/masterclass-panel-overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/masterclass-panel/masterclass-panel-overlay/masterclass-panel-overlay.component.ts
@@ -95,12 +95,29 @@ export class MasterclassPanelOverlayComponent implements OnInit, OnDestroy {
 
   private loadCollections() {
     const grouped = this.eventDisplay.getCollections();
+    // Restrict to taggable types (default 'Tracks') so detector-level
+    // collections (hits like CSCs, calo cells) do not show up. See #923.
+    const types = this.config?.collectionTypes ?? ['Tracks'];
     this.collectionNames = [];
-    for (const [, names] of Object.entries(grouped) as [string, string[]][]) {
-      this.collectionNames.push(...names);
+    for (const type of types) {
+      if (grouped[type]) {
+        this.collectionNames.push(...grouped[type]);
+      }
     }
-    if (this.collectionNames.length > 0 && !this.selectedCollection) {
+
+    if (this.collectionNames.length === 0) {
+      this.selectedCollection = '';
+      this.collectionItems = [];
+      return;
+    }
+
+    if (
+      !this.selectedCollection ||
+      !this.collectionNames.includes(this.selectedCollection)
+    ) {
       this.selectCollection(this.collectionNames[0]);
+    } else {
+      this.selectCollection(this.selectedCollection);
     }
   }
 


### PR DESCRIPTION
Closes #923.

## Summary

 the masterclass **"Select tracks"** dropdown was listing CSCs (muon chamber hits) and other non-track collections instead of just tracks, which is confusing for students who are supposed to be selecting tracks.

The bug was in `loadCollections()` in the masterclass overlay. `getCollections()` returns collections grouped by type (`Tracks`, `Hits`, `CaloClusters`, etc.), and the old code simply flattened every group into the dropdown, so hit collections like CSCs leaked in.

This PR filters the list to the `Tracks` group only, matching how the kinematics panel already resolves collections (`config.collectionType ?? 'Tracks'`).

To keep this extensible, I also added an optional `collectionTypes` field to `MasterclassConfig`, so experiments can explicitly opt other collection types back in if needed (for example, calorimeter clusters for photon-focused exercises where there are no tracks).

## Testing

- Added 4 regression tests covering the collection filtering logic.
- Verified manually on `/atlas-masterclass`:
  - the dropdown now lists only track collections
  - CSC and other non-track collections no longer appear