### PR TITLE
Implement track cuts by distance of closest approach (DCA) and angle

### DIFF
--- a/packages/phoenix-event-display/src/helpers/pretty-symbols.ts
+++ b/packages/phoenix-event-display/src/helpers/pretty-symbols.ts
@@ -15,6 +15,8 @@ export class PrettySymbols {
     Energy: ['energy'],
     ET: ['et'],
     '|p|': ['momentum', 'mom'],
+    DCA: ['dca'],
+    Angle: ['angle'],
   };
 
   /**

--- a/packages/phoenix-event-display/src/loaders/object-type-registry.ts
+++ b/packages/phoenix-event-display/src/loaders/object-type-registry.ts
@@ -51,6 +51,8 @@ export function getDefaultObjectTypeConfigs(): ObjectTypeConfig[] {
         new Cut('pT', 0, 50000, 0.1),
         new Cut('z0', -30, 30, 0.1),
         new Cut('d0', -30, 30, 0.1),
+        new Cut('dca', 0, 5000, 0.1),
+        new Cut('angle', 0, 180, 0.1),
       ],
     },
     {

--- a/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
+++ b/packages/phoenix-event-display/src/loaders/objects/phoenix-objects.ts
@@ -40,6 +40,69 @@ import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUti
  */
 export class PhoenixObjects {
   /**
+   * Calculates and populates missing track properties (d0, z0, phi, eta, dca, angle) for cuts.
+   */
+  private static calculateTrackParams(track: any) {
+    if (track?.dparams) {
+      if (!track?.phi) {
+        track.phi = track.dparams[2];
+      }
+      if (!track?.eta) {
+        track.eta = CoordinateHelper.thetaToEta(track.dparams[3]);
+      }
+      if (!track?.d0) {
+        track.d0 = track.dparams[0];
+      }
+      if (!track?.z0) {
+        track.z0 = track.dparams[1];
+      }
+    }
+
+    const positions = track.pos;
+    if (positions && positions.length >= 2) {
+      const p0 = positions[0];
+      const p1 = positions[1];
+      const dx = p1[0] - p0[0];
+      const dy = p1[1] - p0[1];
+      const dz = p1[2] - p0[2];
+      const d_xy = Math.sqrt(dx * dx + dy * dy);
+      const v_len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+      if (!track.phi) {
+        track.phi = Math.atan2(dy, dx);
+      }
+      if (!track.eta && v_len > 0) {
+        const theta = Math.acos(dz / v_len);
+        track.eta = CoordinateHelper.thetaToEta(theta);
+      }
+      if (!track.d0) {
+        if (d_xy > 0) {
+          track.d0 = (p0[0] * dy - p0[1] * dx) / d_xy;
+        } else {
+          track.d0 = Math.sqrt(p0[0] * p0[0] + p0[1] * p0[1]);
+        }
+      }
+      if (!track.z0) {
+        if (d_xy > 0) {
+          track.z0 = p0[2] - (dz * (p0[0] * dx + p0[1] * dy)) / (d_xy * d_xy);
+        } else {
+          track.z0 = p0[2];
+        }
+      }
+      if (!track.dca) {
+        track.dca = Math.abs(track.d0);
+      }
+      if (!track.angle) {
+        if (track.dparams && track.dparams[3] !== undefined) {
+          track.angle = track.dparams[3] * (180 / Math.PI);
+        } else if (v_len > 0) {
+          track.angle = Math.acos(dz / v_len) * (180 / Math.PI);
+        }
+      }
+    }
+  }
+
+  /**
    * Get tracks as three.js obejct.
    * @param tracks Tracks params to construct tacks from.
    * @returns The object containing tracks.
@@ -68,20 +131,7 @@ export class PhoenixObjects {
       }
 
       // For cuts etc we currently need to have the cut parameters on the track
-      if (track?.dparams) {
-        if (!track?.phi) {
-          track.phi = track.dparams[2];
-        }
-        if (!track?.eta) {
-          track.eta = CoordinateHelper.thetaToEta(track.dparams[3]);
-        }
-        if (!track?.d0) {
-          track.d0 = track.dparams[0];
-        }
-        if (!track?.z0) {
-          track.z0 = track.dparams[1];
-        }
-      }
+      PhoenixObjects.calculateTrackParams(track);
 
       const points = track.pos.map(
         (p: (number | undefined)[]) => new Vector3(p[0], p[1], p[2]),
@@ -133,20 +183,7 @@ export class PhoenixObjects {
     }
 
     // For cuts etc we currently need to have the cut parameters on the track
-    if (trackParams?.dparams) {
-      if (!trackParams?.phi) {
-        trackParams.phi = trackParams.dparams[2];
-      }
-      if (!trackParams?.eta) {
-        trackParams.eta = CoordinateHelper.thetaToEta(trackParams.dparams[3]);
-      }
-      if (!trackParams?.d0) {
-        trackParams.d0 = trackParams.dparams[0];
-      }
-      if (!trackParams?.z0) {
-        trackParams.z0 = trackParams.dparams[1];
-      }
-    }
+    PhoenixObjects.calculateTrackParams(trackParams);
 
     // const length = 100;
     const objectColor = trackParams.color

--- a/packages/phoenix-event-display/src/tests/loaders/objects/phoenix-objects.test.ts
+++ b/packages/phoenix-event-display/src/tests/loaders/objects/phoenix-objects.test.ts
@@ -85,6 +85,29 @@ describe('PhoenixObjects', () => {
     expect(trackParams).toMatchObject(trackObject.userData);
   });
 
+  it('should dynamically calculate track parameters (dca, angle, d0, z0, phi, eta) from pos when missing', () => {
+    const trackParams: any = {
+      pos: [
+        [0.0, 10.0, 0.0],
+        [10.0, 10.0, 10.0],
+      ],
+      color: '0xffffff',
+    };
+
+    const trackObject = PhoenixObjects.getTrack(trackParams);
+
+    expect(trackParams).toHaveProperty('d0');
+    expect(trackParams).toHaveProperty('z0');
+    expect(trackParams).toHaveProperty('phi');
+    expect(trackParams).toHaveProperty('eta');
+    expect(trackParams).toHaveProperty('dca');
+    expect(trackParams).toHaveProperty('angle');
+
+    expect(trackParams.d0).toBeCloseTo(-10, 4);
+    expect(trackParams.dca).toBeCloseTo(10, 4);
+    expect(trackParams.angle).toBeCloseTo(45, 4);
+  });
+
   it('should create a Jet from the given parameters and get it as an object', () => {
     const jetParams = {
       eta: 1,


### PR DESCRIPTION
In certain experiments (such as LHCb), track collections are loaded containing only raw coordinate positions (pos) without track helix parameters (dparams). Because properties like $d_0$, $z_0$, $\phi$, and $\eta$ were not explicitly provided, these track cuts were completely filtered out from the user interface, preventing users from cutting away background tracks or parallel noise.

Solution
This PR introduces dynamic calculation of all missing track properties directly from their coordinates (pos), enabling the existing track cuts globally for all loaded track formats. It also introduces two new dedicated cuts specifically for filtering out parallel and displaced tracks:

DCA (Distance of Closest Approach) to the beamline.
Angle of the track relative to the beamline.
Mathematical Calculations
For any track, the tangent vector $\vec{v} = (v_x, v_y, v_z)$ is calculated using the first segment of the track (positions[1] - positions[0]):

Azimuthal Angle ($\phi$): Computed using Math.atan2(v_y, v_x).
Pseudorapidity ($\eta$): Computed from the polar angle $\theta$.
Transverse Impact Parameter ($d_0$): Calculated as the 2D distance of closest approach to the z-axis (beamline) in the XY plane: $$d_0 = \frac{x_0 v_y - y_0 v_x}{\sqrt{v_x^2 + v_y^2}}$$
Longitudinal Impact Parameter ($z_0$): Calculated at the point of closest approach in the XY plane: $$z_0 = z_0 - v_z \frac{x_0 v_x + y_0 v_y}{v_x^2 + v_y^2}$$
DCA: Computed as $|d_0|$.
Angle: Computed as the polar angle relative to the z-axis in degrees: $$\theta = \arccos\left(\frac{v_z}{|\vec{v}|}\right) \times \frac{180}{\pi}$$
Proposed Changes
packages/phoenix-event-display
src/loaders/objects/phoenix-objects.ts
Extracted track parameters logic into a reusable static method calculateTrackParams.
Integrated calculateTrackParams inside both getTrack and getTracks to automatically compute and assign dca, angle, d0, z0, phi, and eta from coordinate arrays if they are missing.
src/loaders/object-type-registry.ts
Registered the default dca (range 0 to 5000 mm) and angle (range 0 to 180 degrees) cuts in the track registry.
src/helpers/pretty-symbols.ts
Configured the mappings for dca $\rightarrow$ 'DCA' and angle $\rightarrow$ 'Angle' in the pretty symbols registry.
Verification & Testing
Unit Tests: Added a new test suite in phoenix-objects.test.ts verifying:
Exact property assignment of d0, z0, phi, eta, dca, and angle from track points.
Math correctness of signed transverse impact parameter ($d_0$), DCA, and polar angle.
Linting & Code Style: Clean ESLint check and auto-formatting applied. All 276 unit tests pass successfully.