### PR TITLE
feat: add shortcuts dialog and enable independent drag

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/loader/loader.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/loader/loader.component.html
@@ -10,9 +10,4 @@
   <div class="loading-bar" *ngIf="progress !== undefined">
     <span [style]="{ width: progress + '%' }"></span>
   </div>
-
-  <p *ngIf="error" class="text-danger mt-4" style="max-width: 80%">
-    An error occurred while loading the application. Please try refreshing the
-    page if it does not load.
-  </p>
 </div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/loader/loader.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/loader/loader.component.html
@@ -2,20 +2,17 @@
   class="loader-wrapper d-flex position-absolute flex-column justify-content-center align-items-center w-100 h-100 p-5 text-center"
   [ngClass]="{ 'load-complete': loaded }"
 >
-  <ng-container *ngIf="error === undefined; else errorContainer">
-    <img src="assets/images/logo-small.svg" alt="Loader" />
-    <p class="mt-5">
-      Loading...<br />
-      <small class="text-muted">(This may take a while)</small>
-    </p>
-    <div class="loading-bar" *ngIf="progress !== undefined">
-      <span [style]="{ width: progress + '%' }"></span>
-    </div>
-  </ng-container>
-  <ng-template #errorContainer>
-    <p>
-      An error occurred while loading the application. Please try refreshing the
-      page.
-    </p>
-  </ng-template>
+  <img src="assets/images/logo-small.svg" alt="Loader" />
+  <p class="mt-5">
+    Loading...<br />
+    <small class="text-muted">(This may take a while)</small>
+  </p>
+  <div class="loading-bar" *ngIf="progress !== undefined">
+    <span [style]="{ width: progress + '%' }"></span>
+  </div>
+
+  <p *ngIf="error" class="text-danger mt-4" style="max-width: 80%">
+    An error occurred while loading the application. Please try refreshing the
+    page if it does not load.
+  </p>
 </div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/index.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/index.ts
@@ -1,3 +1,4 @@
 export * from './config/config-slider/config-slider.component';
 export * from './phoenix-menu-item/phoenix-menu-item.component';
 export * from './phoenix-menu.component';
+export * from './shortcuts-dialog/shortcuts-dialog.component';

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
@@ -54,8 +54,6 @@
 
     .item-config {
       position: absolute;
-      /* Has to be the same value (but negated) as `:host > top` of `phoenix-menu.component.scss`. */
-      margin-top: -5rem;
       right: 100%;
       width: 14rem;
       padding: 0.5rem;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.ts
@@ -24,8 +24,17 @@ export class PhoenixMenuItemComponent {
 
   calculateConfigTop() {
     if (this.phoenixMenuItem) {
-      this.configTop =
-        this.phoenixMenuItem.nativeElement.getBoundingClientRect().top;
+      const itemRect =
+        this.phoenixMenuItem.nativeElement.getBoundingClientRect();
+      const dragContainer = document.querySelector(
+        '.phoenix-menu-drag-container',
+      );
+      if (dragContainer) {
+        const containerRect = dragContainer.getBoundingClientRect();
+        this.configTop = itemRect.top - containerRect.top;
+      } else {
+        this.configTop = itemRect.top;
+      }
       this.cdr.detectChanges();
     }
   }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.html
@@ -1,3 +1,14 @@
-<div id="phoenixMenu">
-  <app-phoenix-menu-item [currentNode]="rootNode"></app-phoenix-menu-item>
+<div class="phoenix-menu-drag-container" cdkDrag cdkDragBoundary="body">
+  <div id="phoenixMenu" cdkDragHandle>
+    <app-phoenix-menu-item [currentNode]="rootNode"></app-phoenix-menu-item>
+  </div>
+</div>
+<div class="shortcuts-button-wrapper mt-2" cdkDrag cdkDragBoundary="body">
+  <button class="shortcuts-btn" (click)="openShortcutsDialog()">
+    <mat-icon
+      style="font-size: 16px; width: 16px; height: 16px; vertical-align: middle"
+      >keyboard</mat-icon
+    >
+    <span style="vertical-align: middle">Shortcuts</span>
+  </button>
 </div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.scss
@@ -18,3 +18,26 @@
     top: 4rem;
   }
 }
+
+.shortcuts-button-wrapper {
+  text-align: right;
+  pointer-events: auto;
+}
+
+.shortcuts-btn {
+  background-color: var(--phoenix-background-color-secondary);
+  color: var(--phoenix-text-color);
+  border: none;
+  padding: 5px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--phoenix-box-shadow);
+  transition: background-color 0.2s ease;
+}
+
+.shortcuts-btn:hover {
+  background-color: var(--phoenix-menu-item-hover-color, #444);
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
 import type { PhoenixMenuNode } from 'phoenix-event-display';
+import { MatDialog } from '@angular/material/dialog';
+import { ShortcutsDialogComponent } from './shortcuts-dialog/shortcuts-dialog.component';
 
 @Component({
   standalone: false,
@@ -9,4 +11,12 @@ import type { PhoenixMenuNode } from 'phoenix-event-display';
 })
 export class PhoenixMenuComponent {
   @Input() rootNode: PhoenixMenuNode;
+
+  constructor(private dialog: MatDialog) {}
+
+  openShortcutsDialog() {
+    this.dialog.open(ShortcutsDialogComponent, {
+      panelClass: 'dialog',
+    });
+  }
 }

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/shortcuts-dialog/shortcuts-dialog.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/shortcuts-dialog/shortcuts-dialog.component.html
@@ -1,0 +1,55 @@
+<div class="dialog">
+  <h1 mat-dialog-title>Keyboard Shortcuts</h1>
+  <div mat-dialog-content class="dialog-content pb-3">
+    <p class="text-center mt-2 mb-3"><b>Event & Session Controls</b></p>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Next event</span>
+      <span class="badge badge-secondary p-2">Shift + ArrowRight</span>
+    </div>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Previous event</span>
+      <span class="badge badge-secondary p-2">Shift + ArrowLeft</span>
+    </div>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Toggle session recording</span>
+      <span class="badge badge-secondary p-2">Shift + S</span>
+    </div>
+
+    <hr />
+    <p class="text-center mb-3"><b>Camera & Viewport Controls</b></p>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Toggle auto-rotation</span>
+      <span class="badge badge-secondary p-2">Shift + R</span>
+    </div>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Zoom in</span>
+      <span class="badge badge-secondary p-2">Shift + +</span>
+    </div>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Zoom out</span>
+      <span class="badge badge-secondary p-2">Shift + -</span>
+    </div>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Revert main camera</span>
+      <span class="badge badge-secondary p-2">Shift + V</span>
+    </div>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Toggle local clipping</span>
+      <span class="badge badge-secondary p-2">Shift + C</span>
+    </div>
+
+    <hr />
+    <p class="text-center mb-3"><b>UI & Theming Controls</b></p>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Toggle dark theme</span>
+      <span class="badge badge-secondary p-2">Shift + T</span>
+    </div>
+    <div class="d-flex justify-content-between mb-2">
+      <span>Preset views (if configured)</span>
+      <span class="badge badge-secondary p-2">Shift + 1-9</span>
+    </div>
+  </div>
+  <div mat-dialog-actions class="d-flex justify-content-end">
+    <button mat-button (click)="onClose()">Close</button>
+  </div>
+</div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/shortcuts-dialog/shortcuts-dialog.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/shortcuts-dialog/shortcuts-dialog.component.scss
@@ -1,0 +1,16 @@
+.dialog {
+  min-width: 400px;
+  max-height: 80vh;
+  background-color: var(--phoenix-background-color-secondary, #222);
+  color: var(--phoenix-text-color, #fff);
+
+  .dialog-content {
+    overflow-y: auto;
+    max-height: calc(80vh - 120px);
+
+    span {
+      display: flex;
+      align-items: center;
+    }
+  }
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/shortcuts-dialog/shortcuts-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/shortcuts-dialog/shortcuts-dialog.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  standalone: false,
+  selector: 'app-shortcuts-dialog',
+  templateUrl: './shortcuts-dialog.component.html',
+  styleUrls: ['./shortcuts-dialog.component.scss'],
+})
+export class ShortcutsDialogComponent {
+  constructor(public dialogRef: MatDialogRef<ShortcutsDialogComponent>) {}
+
+  onClose(): void {
+    this.dialogRef.close();
+  }
+}

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-ui.module.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-ui.module.ts
@@ -23,6 +23,7 @@ import {
   PhoenixMenuComponent,
   PhoenixMenuItemComponent,
   ConfigSliderComponent,
+  ShortcutsDialogComponent,
 } from './phoenix-menu';
 
 import {
@@ -147,6 +148,7 @@ const PHOENIX_COMPONENTS: Type<any>[] = [
   MasterclassPanelComponent,
   MasterclassPanelOverlayComponent,
   SessionPillComponent,
+  ShortcutsDialogComponent,
 ];
 
 @NgModule({


### PR DESCRIPTION
### Description
This PR introduces a new dedicated Keyboard Shortcuts dialog and enhances the UI's draggability.

**Key Changes:**
* **Shortcuts Dialog:** Created a clean, Angular Material-based modal to display all global application shortcuts.
* **UI Toggle Button:** Added a "Shortcuts" button directly beneath the Phoenix Menu that perfectly matches the existing theme styling.
* **Independent Dragging:** Enabled independent drag-and-drop (`cdkDrag`) for both the Phoenix Menu and the Shortcuts button.


https://github.com/user-attachments/assets/f7917f44-c845-4e6b-894e-f65e78be28cb

