### PR TITLE
Make cuts panel compact: inline checkbox+input per side, add scrollability

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.html
@@ -111,39 +111,41 @@
               />
 
               <div *ngSwitchCase="'rangeSlider'" class="range-slider">
-                <div class="range-slider-inputs d-flex justify-content-between">
-                  <mat-checkbox
-                    [(ngModel)]="config.enableMin"
-                    (change)="config.setEnableMin($event.checked)"
-                  ></mat-checkbox>
-                  <mat-checkbox
-                    [(ngModel)]="config.enableMax"
-                    (change)="config.setEnableMax($event.checked)"
-                  ></mat-checkbox>
-                </div>
-                <div class="range-slider-inputs d-flex justify-content-between">
-                  <input
-                    type="number"
-                    placeholder="Min"
-                    class="form-control form-control-sm"
-                    [(ngModel)]="config.value"
-                    (input)="
-                      config.value = $event.target.value;
-                      config.onChange(config)
-                    "
-                    step="config.step"
-                  />
-                  <input
-                    type="number"
-                    placeholder="Max"
-                    class="form-control form-control-sm"
-                    [(ngModel)]="config.highValue"
-                    (input)="
-                      config.highValue = $event.target.value;
-                      config.onChange(config)
-                    "
-                    step="config.step"
-                  />
+                <div class="range-slider-inputs d-flex align-items-center">
+                  <div class="range-slider-side">
+                    <mat-checkbox
+                      [(ngModel)]="config.enableMin"
+                      (change)="config.setEnableMin($event.checked)"
+                    ></mat-checkbox>
+                    <input
+                      type="number"
+                      placeholder="Min"
+                      class="form-control form-control-sm"
+                      [(ngModel)]="config.value"
+                      (input)="
+                        config.value = $event.target.value;
+                        config.onChange(config)
+                      "
+                      [step]="config.step"
+                    />
+                  </div>
+                  <div class="range-slider-side">
+                    <mat-checkbox
+                      [(ngModel)]="config.enableMax"
+                      (change)="config.setEnableMax($event.checked)"
+                    ></mat-checkbox>
+                    <input
+                      type="number"
+                      placeholder="Max"
+                      class="form-control form-control-sm"
+                      [(ngModel)]="config.highValue"
+                      (input)="
+                        config.highValue = $event.target.value;
+                        config.onChange(config)
+                      "
+                      [step]="config.step"
+                    />
+                  </div>
                 </div>
               </div>
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
@@ -65,6 +65,17 @@
       display: flex;
       flex-direction: column;
       z-index: 120;
+      max-height: 60vh;
+      overflow-y: auto;
+
+      /* Custom thin scrollbar to avoid clutter */
+      &::-webkit-scrollbar {
+        width: 4px;
+      }
+      &::-webkit-scrollbar-thumb {
+        background: var(--phoenix-text-color-secondary, #999);
+        border-radius: 4px;
+      }
 
       & > * {
         margin-bottom: 0.4rem;
@@ -166,6 +177,25 @@
 
 .range-slider {
   .range-slider-inputs {
-    gap: 20%;
+    gap: 4px;
+  }
+
+  .range-slider-side {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    gap: 3px;
+    min-width: 0;
+
+    mat-checkbox {
+      flex-shrink: 0;
+    }
+
+    input[type='number'] {
+      min-width: 0;
+      width: 100%;
+      padding: 0.1rem 0.2rem;
+      font-size: 0.7rem;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #953

The cuts panel for collections with many cuts (e.g. ATLAS Tracks with φ, η, χ², DOF, pT, z0, d0, DCA) was overflowing the bottom of the screen. This PR addresses both points raised in the issue:

1. **More compact layout** :  each cut now renders on a single row instead of two
2. **Scrollable panel** :  the cuts panel is now capped at 60vh and scrolls if needed

## Testing
- Verified all `ConfigRangeSlider` property bindings (`enableMin`, `enableMax`, `value`, `highValue`, `setEnableMin`, `setEnableMax`, `step`) match the type definition in `config-types.ts`
- No logic changes — only layout restructuring