### PR TITLE
fix: Fix missing import icons

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.html
@@ -20,7 +20,9 @@
             class="file-input-button"
             (click)="eventDataFileInput.click()"
           >
-            <img src="assets/icons/eventData.svg" alt="Event data icon" />
+            <svg class="item-icon">
+              <use href="assets/icons/eventData.svg#eventData"></use>
+            </svg>
             Load {{ eventDataImportOption.fileType }}
           </button>
         </ng-container>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.scss
@@ -40,7 +40,8 @@
     }
   }
 
-  img {
+  img,
+  svg {
     max-height: 2em;
     display: block;
     width: 100%;


### PR DESCRIPTION
I noticed that the icons were missing for e.g. load json. 