### PR TITLE
fix(app,event-display): removed deprecated tsconfig.json options to fix build errors

### DIFF
--- a/packages/phoenix-event-display/tsconfig.json
+++ b/packages/phoenix-event-display/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
     "rootDir": "src",
     "declaration": true,
     "target": "es2020",

--- a/packages/phoenix-ng/tsconfig.json
+++ b/packages/phoenix-ng/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
@@ -14,6 +13,8 @@
     "target": "esnext",
     "module": "esnext",
     "lib": ["es2018", "dom"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
     "paths": {
       "phoenix-ui-components": [
         "./projects/phoenix-ui-components/lib/public_api.ts"
@@ -22,8 +23,6 @@
   },
   "angularCompilerOptions": {
     "strictTemplates": true,
-    "strictDomEventTypes": false,
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true
+    "strictDomEventTypes": false
   }
 }


### PR DESCRIPTION
As per title, fixes some build warnings