### PR TITLE
feat(app): fix for #950, allows setting of precise clipping angles

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.html
@@ -12,12 +12,14 @@
       (click)="$event.stopPropagation()"
       (change)="toggleClipping($event)"
     >
-      Clipping
+      Clipping Enabled
     </mat-checkbox>
   </button>
+  <div class="angle-label">Start Angle</div>
   <button
     class="slider-btn"
     mat-menu-item
+    (click)="$event.stopPropagation()"
     (focus)="startingAngleSlider.focus()"
   >
     <mat-slider min="0" max="360" step="1" thumbLabel>
@@ -28,9 +30,27 @@
         (valueChange)="changeStartClippingAngle($event)"
       />
     </mat-slider>
-    Start Angle
+    <input
+      #startAngleInput
+      class="angle-input"
+      type="number"
+      min="0"
+      max="360"
+      step="1"
+      [value]="startClippingAngle"
+      (click)="$event.stopPropagation()"
+      (keydown)="$event.stopPropagation()"
+      (change)="changeStartClippingAngle(startAngleInput.valueAsNumber)"
+    />
   </button>
-  <button class="slider-btn" mat-menu-item (focus)="openingAngleSlider.focus()">
+
+  <div class="angle-label">Opening Angle</div>
+  <button
+    class="slider-btn"
+    mat-menu-item
+    (click)="$event.stopPropagation()"
+    (focus)="openingAngleSlider.focus()"
+  >
     <mat-slider min="0" max="360" step="1" thumbLabel>
       <input
         #openingAngleSlider
@@ -39,7 +59,18 @@
         (valueChange)="changeOpeningClippingAngle($event)"
       />
     </mat-slider>
-    Opening Angle
+    <input
+      #openingAngleInput
+      class="angle-input"
+      type="number"
+      min="0"
+      max="360"
+      step="1"
+      [value]="openingClippingAngle"
+      (click)="$event.stopPropagation()"
+      (keydown)="$event.stopPropagation()"
+      (change)="changeOpeningClippingAngle(openingAngleInput.valueAsNumber)"
+    />
   </button>
 </mat-menu>
 

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/object-clipping/object-clipping.component.scss
@@ -2,7 +2,21 @@
   overflow: visible;
 }
 
+.angle-label {
+  padding: 0.5rem 1rem 0;
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
 mat-slider {
   margin-left: 0.75rem;
   margin-right: 0.75rem;
+}
+
+.angle-input {
+  width: 4.5rem;
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.35rem;
+  text-align: right;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
fix #950 by adding text input boxes to allow the precise setting of input angles.

<img width="253" height="180" alt="image" src="https://github.com/user-attachments/assets/32f37ee2-c002-49b7-b500-cb09c161591c" />
