### PR TITLE
docs: add documentation for Event Dataset Browser, PHYSLITE loader, and Event Autoloader (#910, #913, #914)

### DIFF
--- a/packages/phoenix-event-display/README.md
+++ b/packages/phoenix-event-display/README.md
@@ -102,3 +102,38 @@ Without building, you can include the bundle directly from [CDN](https://cdn.jsd
 
 - [Usage in Angular (as a service)](https://github.com/HSF/phoenix/blob/main/packages/phoenix-ng/projects/phoenix-app/src/app/sections/lhcb/lhcb.component.ts)
 - [Usage in React](https://github.com/9inpachi/phoenix-react/blob/main/src/App.js#L6-L31)
+
+## Event Data Loaders
+
+Phoenix supports multiple event data formats through specialized loader classes.
+
+### PHYSLITELoader
+
+`PHYSLITELoader` parses ATLAS DAOD_PHYSLITE `.root` files directly in the browser using [JSROOT](https://root.cern/js/). It reads calibrated physics objects from the ROOT `CollectionTree` branch and converts them into Phoenix event format.
+
+#### Supported Collections
+
+- **Jets**: Calibrated jet momentum and energy.
+- **Tracks**: InDetTrackParticles, MuonSpectrometerTrackParticles, CombinedMuonTrackParticles, GSFTrackParticles.
+- **Electrons & Muons**: Four-momentum ($p_T, \eta, \phi, m$).
+- **Photons**: Energy clusters and trajectories.
+- **Missing Energy (MET)**: `AnalysisMET` transverse energy vector ($E_{Tx}, E_{Ty}$).
+- **Primary Vertices & Calorimeter Clusters**.
+
+#### Usage Example
+
+```js
+import { EventDisplay, PHYSLITELoader } from 'phoenix-event-display';
+
+const eventDisplay = new EventDisplay();
+const physliteLoader = new PHYSLITELoader();
+
+// Load ROOT file buffer
+fetch('path/to/DAOD_PHYSLITE.root')
+  .then((res) => res.arrayBuffer())
+  .then((buffer) => {
+    physliteLoader.loadEvents(buffer, (events) => {
+      eventDisplay.parsePhoenixEvents(events);
+    });
+  });
+```

--- a/packages/phoenix-ng/projects/phoenix-ui-components/README.md
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/README.md
@@ -152,3 +152,40 @@ A custom duration can be passed as an optional second argument:
 this.notificationService.warning('Large file detected.', 12000);
 this.notificationService.error('Connection lost.', 10000);
 ```
+
+## Components & Overlays
+
+### Event Dataset Browser (`EventBrowserOverlayComponent`)
+
+The **Event Dataset Browser** pre-scans all loaded events in the session and renders a sortable, filterable summary table with physics object counts per collection type, Missing Energy (MET), and run/event metadata.
+
+#### Features
+
+- **Physics-Aware Column Ordering**: Reconstructed physics objects (Jets, Muons, Electrons, Photons, Tracks) are ordered first, followed by detector-level collections (`CaloCells`, `Hits`).
+- **Sortable & Filterable**: Support for column filters (`>=`, `<=`, `=`), minimum MET filters, and live search by event number.
+- **Direct Event Navigation**: Clicking any event row jumps directly to that event in the 3D display.
+- **Keyboard Navigation**: Arrow keys to navigate table rows + `Shift + Left/Right` to switch events globally.
+
+#### Template Usage
+
+```html
+<app-event-browser-overlay></app-event-browser-overlay>
+```
+
+---
+
+### Event Autoloader & Live Cycling (`CycleEventsComponent`)
+
+`CycleEventsComponent` provides automated event cycling and live event feed reloading for beam monitoring and event slideshows.
+
+#### Operational Modes
+
+1. **Inactive**: Cycling paused.
+2. **Active (Looping)**: Automatically advances through the list of loaded events at a fixed interval.
+3. **Active + Reloading**: Automatically fetches/reloads new event data upon reaching the end of the event list (ideal for live event feeds).
+
+#### Template Usage
+
+```html
+<app-cycle-events [interval]="3000" tooltip="Cycle through loaded events" icon="play"> </app-cycle-events>
+```


### PR DESCRIPTION
## Summary
Resolves #910, #913, #914 (sub-issues of parent #908): Adds documentation for recently introduced core features across `phoenix-event-display` and `phoenix-ui-components`.

## Documentation Added
1. **PHYSLITE ROOT Loader (#914):**
   - Added `PHYSLITELoader` section to `packages/phoenix-event-display/README.md` explaining ATLAS DAOD_PHYSLITE ROOT parsing via JSROOT `TSelector`, list of supported physics collections, and code usage example.
2. **Event Dataset Browser (#913):**
   - Added `EventBrowserOverlayComponent` section to `packages/phoenix-ng/projects/phoenix-ui-components/README.md` documenting the summary table features (physics object sorting, column filters `>=`, `<=`, `=`, MET threshold, event search, keyboard navigation).
3. **Event Autoloader & Live Cycling (#910):**
   - Added `CycleEventsComponent` section to `packages/phoenix-ng/projects/phoenix-ui-components/README.md` documenting the 3 operational modes (Inactive, Active looping, Active + Reloading for live event feeds) and template usage example.