### PR TITLE
fix(color-manager): preserve manually-set vertex colors in Color by Vertex

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
@@ -165,10 +165,16 @@ export class ColorManager {
         return;
       }
 
-      // Deterministic distinct color per vertex (golden ratio hue steps),
-      // unless the vertex has an explicit color.
+      // Use explicit vertex color if set in event data, otherwise the current
+      // material color (e.g. set by the user via the UI), otherwise deterministic
+      // distinct color per vertex (golden ratio hue steps).
+      const materialColor =
+        vertexObject instanceof Mesh
+          ? ((vertexObject.material as any)?.color as Color | undefined)
+          : undefined;
       const vertexColor =
         vertexObject.userData.color ??
+        materialColor ??
         new Color().setHSL((vertexIndex * 0.618034) % 1, 0.9, 0.55);
 
       setColorForObject(vertexObject, vertexColor);


### PR DESCRIPTION
When applying "Color by Vertex", the vertex color should come from:
1. Explicit vertex color in the event data (userData.color)
2. Current material color (if user has manually set it via the UI)
3. Deterministic golden-ratio color (fallback)

Previously, the code skipped step 2, so manually-set colors (e.g. green vertices) were replaced with deterministic colors when applying Color by Vertex to linked tracks. Now those manual colors are preserved.

Fixes the issue where setting Vertices_xAOD to green, then applying Color by Vertex to InDetTrackParticles_xAOD, would result in random-looking colors instead of the green tracks/vertices.