### PR TITLE
refactor(effects-manager): extract GLSL shaders to TypeScript modules (#886)

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/effects-manager.ts
@@ -14,6 +14,9 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
 import { OutlinePass } from 'three/examples/jsm/postprocessing/OutlinePass.js';
 import { Pass } from 'three/examples/jsm/postprocessing/Pass.js';
 
+import VERTEX_SHADER from './shaders/hover-vertex';
+import HOVER_FRAGMENT_SHADER from './shaders/hover-fragment';
+
 /**
  * Represents the possible visual states of objects managed
  * by EffectsManager. Provides typed state management instead
@@ -83,24 +86,6 @@ export class EffectsManager {
 
   /** Render function with (normal render) or without antialias (effects render). */
   public render: (scene: Scene, camera: Camera) => void;
-
-  /** Vertex shader for hover outline rendering. */
-  private static readonly VERTEX_SHADER = `
-    void main() {
-      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-    }
-  `;
-
-  /** Fragment shader for hover outlines. Color controlled via uniforms. */
-  private static readonly HOVER_FRAGMENT_SHADER = `
-    uniform float opacity;
-    uniform float colorR;
-    uniform float colorG;
-    uniform float colorB;
-    void main() {
-      gl_FragColor = vec4(colorR, colorG, colorB, opacity);
-    }
-  `;
 
   /**
    * Constructor for the effects manager.
@@ -401,8 +386,8 @@ export class EffectsManager {
     const edges = new EdgesGeometry(object.geometry, 15);
 
     const lineMaterial = new ShaderMaterial({
-      vertexShader: EffectsManager.VERTEX_SHADER,
-      fragmentShader: EffectsManager.HOVER_FRAGMENT_SHADER,
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: HOVER_FRAGMENT_SHADER,
       uniforms: {
         opacity: { value: 0.8 },
         colorR: { value: this._hoverColor.r },

--- a/packages/phoenix-event-display/src/managers/three-manager/shaders/hover-fragment.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/shaders/hover-fragment.ts
@@ -1,0 +1,13 @@
+/** Fragment shader for hover outline color. Color controlled via uniforms. */
+const hoverFragmentShader = `
+uniform float opacity;
+uniform float colorR;
+uniform float colorG;
+uniform float colorB;
+
+void main() {
+  gl_FragColor = vec4(colorR, colorG, colorB, opacity);
+}
+`;
+
+export default hoverFragmentShader;

--- a/packages/phoenix-event-display/src/managers/three-manager/shaders/hover-vertex.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/shaders/hover-vertex.ts
@@ -1,0 +1,8 @@
+/** Vertex shader for hover outline rendering. */
+const hoverVertexShader = `
+void main() {
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+export default hoverVertexShader;


### PR DESCRIPTION
## Summary

Phase 2a of the refactoring proposed in #886.

Extracts the two inline GLSL shader strings from`effects-manager.ts` into dedicated TypeScript modules.

## What changed

**New files:**
- `shaders/hover-vertex.ts` — vertex shader as TS default export
- `shaders/hover-fragment.ts` — fragment shader as TS default export

**Modified:**
- `effects-manager.ts` — imports shaders from modules instead of defining them as inline class properties

## Why TypeScript modules instead of .glsl files

Previous attempt (#933) used `.glsl` files with `raw-loader` but hit esbuild/Angular build pipeline issues in the Docker
smoke test. TypeScript modules work natively with all three build tools (webpack, esbuild, Jest) with zero configuration
changes.

## Scope
- 2 new files, 1 modified file
- Zero behavior change — shaders are identical
- All 25 effects-manager tests pass
- Part of #886 — Phase 2, PR 2a