### PR TITLE
fix(event-display): server staleness

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ yarn workspace phoenix-event-display tsc:build
 # then restart ng serve
 ```
 
-`yarn start` runs the library in watch mode alongside the dev server, so `dist` is rebuilt automatically — but the two start concurrently and `ng serve` often finishes bundling before the first library build has written `dist`, so the restart is still needed.
+`yarn start` builds the library once before handing over to the watch build and the dev server, so a fresh start always serves current code. That one-shot build matters: the watch build and `ng serve` run concurrently, and `ng serve` reliably wins the race, which used to leave it bundling a `dist` from the previous session.
 
 If a change is in `dist` but not in the running app, compare the timestamps — if `dist` is newer than the server, restart it:
 

--- a/README.md
+++ b/README.md
@@ -81,20 +81,40 @@ The two libraries reach the app by different routes, and only one of them hot re
 | `phoenix-ui-components` | a TypeScript path mapping straight to its source (`public_api.ts`)              | yes         |
 | `phoenix-event-display` | the `node_modules` symlink, whose `main` is `dist/index` — the **built** output | no          |
 
-So a change to `phoenix-event-display` needs its `dist` rebuilt _and_ the dev server restarted, because Angular's watcher does not watch inside `node_modules`:
+So a change to `phoenix-event-display` needs its `dist` rebuilt, and the dev server restarted, because Angular's watcher does not watch inside `node_modules`:
 
 ```sh
 yarn workspace phoenix-event-display tsc:build
 # then restart ng serve
 ```
 
-`yarn start` does run the library in watch mode, so `dist` is rebuilt automatically — but the two run concurrently, and `ng serve` often finishes bundling before the first library build has written `dist`. When that happens the app serves the previous build and nothing you do in the browser will show the change.
+`yarn start` runs the library in watch mode alongside the dev server, so `dist` is rebuilt automatically — but the two start concurrently and `ng serve` often finishes bundling before the first library build has written `dist`, so the restart is still needed.
 
-The symptom is a change that is present in `dist` but absent from the running app. To confirm, compare the timestamps — if `dist` is newer than the server, restart it:
+If a change is in `dist` but not in the running app, compare the timestamps — if `dist` is newer than the server, restart it:
 
 ```sh
 stat -f '%Sm' packages/phoenix-event-display/dist/loaders/<your-file>.js
 ps -eo pid,lstart,args | grep '[n]g serve'
+```
+
+#### Dependency pre-bundling
+
+Because `phoenix-event-display` resolves through `node_modules`, the dev server would treat it as a third-party dependency and pre-bundle it into `.angular/cache/**/vite/deps/`. That cache is keyed on package metadata rather than file contents, so rebuilding `dist` does not invalidate it and **even restarting the server keeps serving the stale copy** — a change can sit in `dist` for days while the browser shows the old code, with nothing to explain it.
+
+`packages/phoenix-ng/angular.json` therefore excludes it from pre-bundling:
+
+```jsonc
+"serve": {
+  "options": {
+    "prebundle": { "exclude": ["phoenix-event-display"] }
+  }
+}
+```
+
+If you ever see a change that is in `dist`, survives a restart, and still does not appear in the browser debugger, check whether that exclusion is still in place, and clear the cache:
+
+```sh
+rm -rf packages/phoenix-ng/.angular/cache
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -70,7 +70,32 @@ yarn start
 # e.g. if you are using an older version of node (we are currently using v20), then it may not work
 ```
 
-Now both the `phoenix-event-display` and `phoenix-app` will start in development/watch mode. Any changes made to the `phoenix-event-display` will rebuild and hot reload the `phoenix-app`. You can access the app by navigating to [`http://localhost:4200`](http://localhost:4200) on the browser.
+Now both the `phoenix-event-display` and `phoenix-app` will start in development/watch mode. You can access the app by navigating to [`http://localhost:4200`](http://localhost:4200) on the browser.
+
+### Picking up changes to `phoenix-event-display`
+
+The two libraries reach the app by different routes, and only one of them hot reloads:
+
+| Package                 | Resolved via                                                                    | Hot reloads |
+| ----------------------- | ------------------------------------------------------------------------------- | ----------- |
+| `phoenix-ui-components` | a TypeScript path mapping straight to its source (`public_api.ts`)              | yes         |
+| `phoenix-event-display` | the `node_modules` symlink, whose `main` is `dist/index` — the **built** output | no          |
+
+So a change to `phoenix-event-display` needs its `dist` rebuilt _and_ the dev server restarted, because Angular's watcher does not watch inside `node_modules`:
+
+```sh
+yarn workspace phoenix-event-display tsc:build
+# then restart ng serve
+```
+
+`yarn start` does run the library in watch mode, so `dist` is rebuilt automatically — but the two run concurrently, and `ng serve` often finishes bundling before the first library build has written `dist`. When that happens the app serves the previous build and nothing you do in the browser will show the change.
+
+The symptom is a change that is present in `dist` but absent from the running app. To confirm, compare the timestamps — if `dist` is newer than the server, restart it:
+
+```sh
+stat -f '%Sm' packages/phoenix-event-display/dist/loaders/<your-file>.js
+ps -eo pid,lstart,args | grep '[n]g serve'
+```
 
 ## Docker
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "postinstall": "node scripts/patch-jsroot-three.js && yarn workspace phoenix-event-display prepare && husky",
-    "start": "lerna run start",
+    "start": "yarn workspace phoenix-event-display tsc:build && lerna run start",
     "start:ssl": "yarn workspace phoenix-ng start:ssl",
     "test:ci": "lerna run test:ci",
     "test:coverage": "lerna run test:coverage",

--- a/packages/phoenix-ng/README.md
+++ b/packages/phoenix-ng/README.md
@@ -26,7 +26,16 @@ This application uses the [`phoenix-event-display`](https://www.npmjs.com/packag
 
 ## Development flow
 
-The source code of packages `phoenix-event-display` and `phoenix-ui-components` is linked to this application (`phoenix-ng`) through [TypeScript configuration](./tsconfig.json). So running this application in development mode (`yarn start`) and making any changes to either of the packages will rebuild and hot reload the application.
+`phoenix-ui-components` is linked to this application through a [TypeScript path mapping](./tsconfig.json) that points at its source, so running in development mode (`yarn start`) and changing it will rebuild and hot reload the application.
+
+`phoenix-event-display` is **not** path mapped. It resolves through the `node_modules` symlink to its `main`, `dist/index`, so the app consumes its built output. Angular's watcher does not watch inside `node_modules`, which means a change there needs the library rebuilt _and_ the dev server restarted:
+
+```sh
+yarn workspace phoenix-event-display tsc:build
+# then restart ng serve
+```
+
+`yarn start` from the repository root runs the library in watch mode alongside the dev server, but the two start concurrently and `ng serve` frequently bundles before the first library build lands — so the restart is still needed. See [the root README](../../README.md#picking-up-changes-to-phoenix-event-display) for how to spot it.
 
 ## Deploy the application
 

--- a/packages/phoenix-ng/README.md
+++ b/packages/phoenix-ng/README.md
@@ -35,7 +35,9 @@ yarn workspace phoenix-event-display tsc:build
 # then restart ng serve
 ```
 
-`yarn start` from the repository root runs the library in watch mode alongside the dev server, but the two start concurrently and `ng serve` frequently bundles before the first library build lands — so the restart is still needed. See [the root README](../../README.md#picking-up-changes-to-phoenix-event-display) for how to spot it.
+`yarn start` from the repository root runs the library in watch mode alongside the dev server, but the two start concurrently and `ng serve` frequently bundles before the first library build lands — so the restart is still needed.
+
+For the same reason the dev server would otherwise pre-bundle `phoenix-event-display` as a third-party dependency and cache it under `.angular/cache`, where a `dist` rebuild does not invalidate it and even a restart keeps serving the stale copy. `angular.json` excludes it from pre-bundling to prevent that. See [the root README](../../README.md#picking-up-changes-to-phoenix-event-display) for the details and how to spot it.
 
 ## Deploy the application
 

--- a/packages/phoenix-ng/angular.json
+++ b/packages/phoenix-ng/angular.json
@@ -172,7 +172,10 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "buildTarget": "phoenix-app:build"
+            "buildTarget": "phoenix-app:build",
+            "prebundle": {
+              "exclude": ["phoenix-event-display"]
+            }
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
This is an attempt to fix the ongoing problem that yarn start has not been picking up all the backend changes.