### PR TITLE
feat(event-display): Allow vertices to be linked to different track t…

### DIFF
--- a/packages/phoenix-event-display/src/lib/types/event-data.ts
+++ b/packages/phoenix-event-display/src/lib/types/event-data.ts
@@ -194,9 +194,9 @@ export interface VertexParams {
   /** Color for rendering. */
   color?: string | number;
   /** Indices of the tracks associated with this vertex, used to color tracks by vertex. */
-  linkedTracks?: number[];
+  linkedTracks?: number[][];
   /** Name of the track collection the linked track indices refer to. */
-  linkedTrackCollection?: string;
+  linkedTrackCollection?: string[];
   /** UUID assigned after object creation. Set internally. */
   uuid?: string;
   /** Extra experiment-specific properties. */

--- a/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
+++ b/packages/phoenix-event-display/src/loaders/phoenix-loader.ts
@@ -281,6 +281,7 @@ export class PhoenixLoader implements EventDataLoader {
           ? object[collectionName][0].color
           : 0xffffff,
       );
+
       this.ui.addCollection(
         typeName,
         collectionName,
@@ -328,7 +329,7 @@ export class PhoenixLoader implements EventDataLoader {
       (vertexCollection) =>
         vertexCollection?.some(
           (vertex) =>
-            vertex.linkedTrackCollection === collectionName &&
+            vertex.linkedTrackCollection?.includes(collectionName) &&
             vertex.linkedTracks?.length,
         ),
     );

--- a/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
@@ -159,12 +159,13 @@ export class ColorManager {
       const { linkedTrackCollection, linkedTracks } = vertexObject.userData;
       if (
         !trackCollection ||
-        linkedTrackCollection !== collectionName ||
+        !linkedTrackCollection?.includes(collectionName) ||
         !linkedTracks
       ) {
         return;
       }
 
+      const collectionIndex = linkedTrackCollection.indexOf(collectionName);
       // Use explicit vertex color if set in event data, otherwise the current
       // material color (e.g. set by the user via the UI), otherwise deterministic
       // distinct color per vertex (golden ratio hue steps).
@@ -178,7 +179,7 @@ export class ColorManager {
         new Color().setHSL((vertexIndex * 0.618034) % 1, 0.9, 0.55);
 
       setColorForObject(vertexObject, vertexColor);
-      linkedTracks.forEach((trackIndex: number) => {
+      linkedTracks[collectionIndex].forEach((trackIndex: number) => {
         const track =
           tracksByIndex.get(trackIndex) ?? trackCollection.children[trackIndex];
         track?.traverse((trackObject) => {


### PR DESCRIPTION
Converts `linkedTracksCollection`  to a list of strings to allow tracks from different collections to be linked to the same vertex. Track IDs are now grouped in sublists by collection type inside `linkedTracks`.