### PR TITLE
fix(event-display): fix track 'Color by' when loading JSON with linke…

### DIFF
--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
@@ -239,10 +239,11 @@ export class PhoenixMenuNode {
       // console.log('nodeConfig', nodeConfig);
       if (nodeConfig) {
         for (const prop in configState) {
-          if (prop === 'options') {
+          if (prop === 'options' || prop === 'onChange') {
             // The available options of a `select` are structural (derived from
             // the loaded event data), not user state - a saved state must not
             // overwrite them.
+            // The function 'onChange' depends on the available options.
             continue;
           }
           const key = prop as keyof typeof nodeConfig;


### PR DESCRIPTION
**How to reproduce the bug :**
- Phoenix is launched on the LHCb project, loading default JSON data that does not have linked tracks.
- A second JSON file containing linked tracks is loaded right after ([selectedEvents.json](https://github.com/user-attachments/files/31261696/selectedEvents.json))
- The "Color by: Vertex" option for the tracks stopped working.

**Issue :**
When loading the new JSON file, a new Phoenix menu node is created based on the new data and compared against the previous menu node (see ` loadStateFromJSON()` in `phoenix-menu-node.ts`). For each configuration with the same label and type, the previous configuration's properties are kept, except for the property `options`, where the new one is adopted.
Consequently, for the "Color by" configuration (created in `color-options.ts`), the old version of the `onChange`  function was retained instead of using the new one. However, this function relies on the `colorByOptions` attribute, which did not contain a "Vertex" option during the initial load since the data lacked linked tracks. Therefore, when switching "Color by" to Vertex in the new load, nothing happens.

**Fix :**
    Keep not only the property `options`, but also the property `onChange`.