### PR TITLE
feat(ui): move dark theme toggle into view options menu (#903)

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.html
@@ -9,9 +9,6 @@
 
   <app-auto-rotate></app-auto-rotate>
 
-  <!-- Dark theme toggle -->
-  <app-dark-theme></app-dark-theme>
-
   <!-- Toggle for clipping geometries -->
   <app-object-clipping
     *ngIf="uiConfig.showObjectClipping"

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.html
@@ -84,6 +84,21 @@
   </button>
   <button
     mat-menu-item
+    (click)="
+      $event.stopPropagation();
+      darkThemeCheckbox._inputElement.nativeElement.click()
+    "
+  >
+    <mat-checkbox
+      #darkThemeCheckbox
+      [checked]="darkTheme"
+      (click)="$event.stopPropagation()"
+      (change)="setDarkTheme($event)"
+      >Dark Theme
+    </mat-checkbox>
+  </button>
+  <button
+    mat-menu-item
     *ngFor="let view of views"
     (click)="displayView($event, view)"
   >

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.test.ts
@@ -22,6 +22,8 @@ describe('ViewOptionsComponent', () => {
     getUIManager: jest.fn().mockReturnThis(),
     getThreeManager: jest.fn().mockReturnThis(),
     getPresetViews: jest.fn().mockReturnValue([]),
+    getDarkTheme: jest.fn().mockReturnValue(false),
+    setDarkTheme: jest.fn().mockReturnThis(),
     displayView: jest.fn().mockReturnThis(),
     setShowAxis: jest.fn().mockReturnThis(),
     setShowEtaPhiGrid: jest.fn().mockReturnThis(),
@@ -178,6 +180,19 @@ describe('ViewOptionsComponent', () => {
     component.toggleShowDistance(event);
 
     expect(mockEventDisplay.getUIManager().show3DDistance).toHaveBeenCalledWith(
+      VALUE,
+    );
+  });
+
+  it('should toggle the dark theme', () => {
+    const VALUE = true;
+    const event = new MatCheckboxChange();
+    event.checked = VALUE;
+
+    component.setDarkTheme(event);
+
+    expect(component.darkTheme).toBe(VALUE);
+    expect(mockEventDisplay.getUIManager().setDarkTheme).toHaveBeenCalledWith(
       VALUE,
     );
   });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.ts
@@ -25,6 +25,7 @@ export class ViewOptionsComponent implements OnInit, OnDestroy {
   scale: number = 3000;
   views: PresetView[];
   show3DPoints: boolean;
+  darkTheme: boolean = false;
   origin: Vector3 = new Vector3(0, 0, 0);
   sub: Subscription;
 
@@ -35,6 +36,7 @@ export class ViewOptionsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.views = this.eventDisplay.getUIManager().getPresetViews();
+    this.darkTheme = this.eventDisplay.getUIManager().getDarkTheme();
     this.sub = this.eventDisplay
       .getThreeManager()
       .originChanged.subscribe((intersect) => {
@@ -89,6 +91,11 @@ export class ViewOptionsComponent implements OnInit, OnDestroy {
   toggleShowDistance(change: MatCheckboxChange) {
     this.trigger.closeMenu();
     this.eventDisplay.getUIManager().show3DDistance(change.checked);
+  }
+
+  setDarkTheme(change: MatCheckboxChange) {
+    this.darkTheme = change.checked;
+    this.eventDisplay.getUIManager().setDarkTheme(this.darkTheme);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Summary
Resolves Part 1 of #903 (Clean up Phoenix bar): Moves the Dark Theme toggle directly into the **View Options** menu (`ViewOptionsComponent`) and removes the standalone dark theme button from the primary bottom menu bar to reduce interface clutter.

## Visual Changes & Screenshots

 Light Theme & Clean Toolbar  

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/a9e952de-e297-421b-9023-e7936764a888" />

 Dark Theme Active on ATLAS Detector

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/b690ea9a-f6ad-443c-8c79-45e898755ff9" />

### Highlights:
1. **Decluttered Bottom Toolbar:** Removed standalone `<app-dark-theme>` button from `ui-menu.component.html`, opening up toolbar space.
2. **View Options Integration:** Added `[✓] Dark Theme` Material checkbox directly inside the View Options dropdown menu (`view-options.component.html`).
3. **Instant Toggle:** Toggling Dark Theme inside View Options seamlessly updates `UIManager` dark mode state across 3D detector viewports.

## Changes Made
- **`ViewOptionsComponent`:**
  - Added `darkTheme` state property initialized from `UIManager.getDarkTheme()`.
  - Added `setDarkTheme(change: MatCheckboxChange)` handler to toggle dark theme.
  - Added Dark Theme checkbox menu item to `view-options.component.html`.
  - Added unit test suite in `view-options.component.test.ts`.
- **`ui-menu.component.html`:**
  - Removed standalone `<app-dark-theme>` component tag from the main bottom menu wrapper.

## Test Plan
- Unit tests added and passing in `view-options.component.test.ts`.
- Verified locally on `http://localhost:4200/` and `http://localhost:4200/atlas`.
