### PR TITLE
fix(ci): revert dev deploy domain to phoenix-dev2.surge.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ steps.if_pr.outputs.number || github.ref == 'refs/heads/main' }}
         env:
           PR_URL: http://phoenix-pr-${{ steps.if_pr.outputs.number }}.surge.sh
-          DEV_URL: http://phoenix-dev.surge.sh
+          DEV_URL: http://phoenix-dev2.surge.sh
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN2 }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN2 }}
         run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Phoenix is supported by the [HEP Software Foundation](https://hepsoftwarefoundat
 
 It was selected for Google Summer of Code support in 2019, 2020 and 2021.
 
-You can see the stable version at [https://hepsoftwarefoundation.org/phoenix](https://hepsoftwarefoundation.org/phoenix/) and the development version at [http://phoenix-dev.surge.sh](http://phoenix-dev.surge.sh).
+You can see the stable version at [https://hepsoftwarefoundation.org/phoenix](https://hepsoftwarefoundation.org/phoenix/) and the development version at [http://phoenix-dev2.surge.sh](http://phoenix-dev2.surge.sh).
 
 ## Demo
 


### PR DESCRIPTION
## Problem

CI's `phoenix-ci` workflow has been failing on every push to `main` since #980 with:

```
Aborted - you do not have permission to publish to phoenix-dev.surge.sh
```

#980 renamed the deploy target from `phoenix-dev2.surge.sh` to `phoenix-dev.surge.sh` (intending to point at what looked like the 'real' live dev site), and simultaneously turned on `push: branches: [main]` as a trigger for the first time — so this was the first time the main-branch deploy step ever actually ran.

Confirmed directly with the surge CLI:

```
$ surge phoenix-dev.surge.sh usage
Unauthorized - Insufficient permission to access domain.

$ surge phoenix-dev2.surge.sh usage
Empty - Insufficient data.
```

The account behind the `SURGE_LOGIN2`/`SURGE_TOKEN2` repo secrets does not have publish rights on `phoenix-dev.surge.sh` (owned by a different/unreachable account), but does have rights on `phoenix-dev2.surge.sh`.

## Fix

Revert the deploy `DEV_URL` back to `phoenix-dev2.surge.sh` in `.github/workflows/main.yml`, and update the corresponding README link, so CI can actually publish with the credentials we have access to.

If someone regains publish access to `phoenix-dev.surge.sh` in the future we can switch back.