### PR TITLE
fix(ci): use github-script for deployments and fix deploy outputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,35 +70,37 @@ jobs:
             export DEPLOYMENT_ENV=pull-request
           fi
           npx surge --project ./packages/phoenix-ng/docs/ --domain $DEPLOYMENT_URL
-          echo "{deployment_url}={$DEPLOYMENT_URL}" >> $GITHUB_OUTPUT
-          echo "{deployment_env}={$DEPLOYMENT_ENV}" >> $GITHUB_OUTPUT
+          echo "deployment_url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+          echo "deployment_env=$DEPLOYMENT_ENV" >> "$GITHUB_OUTPUT"
 
-      - name: Create Deployment
-        id: create_deployment
+      - name: Create Deployment and Status
         if: ${{ success() && (steps.if_pr.outputs.number || github.ref == 'refs/heads/main') }}
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYMENT_ENV: ${{ steps.deploy.outputs.deployment_env }}
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
         with:
-          route: POST /repos/{repository}/deployments
-          repository: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          environment: ${{ steps.deploy.outputs.deployment_env }}
-          required_contexts: '[]'
-          auto_merge: false
-
-      - name: Create Deployment Status
-        if: ${{ success() && (steps.if_pr.outputs.number || github.ref == 'refs/heads/main') }}
-        uses: octokit/request-action@v2.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          route: POST /repos/{repository}/deployments/{deployment_id}/statuses
-          repository: ${{ github.repository }}
-          deployment_id: ${{ fromJSON(steps.create_deployment.outputs.data).id }}
-          state: success
-          target_url: ${{ steps.deploy.outputs.deployment_url }}
-          description: Deployed to environment ${{ steps.deploy.outputs.deployment_env }}
-          environment: ${{ steps.deploy.outputs.deployment_env }}
-          environment_url: ${{ steps.deploy.outputs.deployment_url }}
-          mediaType: '{ "previews": ["flash", "ant-man"] }'
+          script: |
+            const environment = process.env.DEPLOYMENT_ENV;
+            const environmentUrl = process.env.DEPLOYMENT_URL;
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.ref,
+              environment,
+              required_contexts: [],
+              auto_merge: false,
+            });
+            if (!deployment.data.id) {
+              core.warning(`Deployment not created: ${deployment.data.message || 'unknown reason'}`);
+              return;
+            }
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              target_url: environmentUrl,
+              environment_url: environmentUrl,
+              description: `Deployed to environment ${environment}`,
+            });


### PR DESCRIPTION
Follow-up cleanup to #981.

## Warnings

The `phoenix-ci` runs currently emit runner warnings on the deployment steps:

```
Unexpected input(s) 'repository', 'deployment_id', 'state', 'target_url', 'description', 'environment', 'environment_url', valid inputs are ['route', 'mediaType']
```

Per [`octokit/request-action`'s own README](https://github.com/octokit/request-action#warnings), this warning fires for **any** `with:` key other than `route`/`mediaType`, because the action can't declare route-specific params in its `action.yml`. There's no way to pass the deployment params through that action without the warning.

This PR replaces the two `octokit/request-action` steps (Create Deployment + Create Deployment Status) with a single [`actions/github-script`](https://github.com/actions/github-script) step calling `github.rest.repos.createDeployment` / `createDeploymentStatus` directly. No warnings, one fewer step, and it authenticates via the workflow's existing `GITHUB_TOKEN` (the job already has `permissions: write-all`).

## Pre-existing bug fixed too

While rewriting, I found the Deploy step wrote its outputs with the malformed form:

```bash
echo "{deployment_url}={$DEPLOYMENT_URL}" >> $GITHUB_OUTPUT
```

`$GITHUB_OUTPUT` expects `name=value`, so this created an output literally named `{deployment_url}` and `steps.deploy.outputs.deployment_url` was always **empty**. The old deployment-status step therefore recorded an empty `target_url`/`environment_url`. Fixed to:

```bash
echo "deployment_url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
```

so the real surge URL flows through to the deployment status.

## Notes
- No functional change to the build/test/deploy behaviour; deployments now get correct URLs and the log is warning-free.
- YAML validated locally.