### PR TITLE
chore(ci): bump actions off Node 20 and pin to release tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
         with:
           # Full history and tags, so the build can derive the version/commit.
           fetch-depth: 0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@main
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -42,14 +42,14 @@ jobs:
 
       - name: Code Coverage
         if: github.ref == 'refs/heads/main'
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           base-path: ./packages/phoenix-event-display
-          path-to-lcov: ./packages/phoenix-event-display/coverage/lcov.info
+          file: ./packages/phoenix-event-display/coverage/lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pre Deploy Pull Request
-        uses: jwalton/gh-find-current-pr@master
+        uses: jwalton/gh-find-current-pr@v1
         id: if_pr
 
       - name: Deploy
@@ -75,7 +75,7 @@ jobs:
 
       - name: Create Deployment and Status
         if: ${{ success() && (steps.if_pr.outputs.number || github.ref == 'refs/heads/main') }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DEPLOYMENT_ENV: ${{ steps.deploy.outputs.deployment_env }}
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}


### PR DESCRIPTION
Checked what each action actually declares before touching anything:

| action | before | `runs.using` | after | `runs.using` |
| --- | --- | --- | --- | --- |
| actions/checkout | `@main` | node24 | `@v7` | node24 |
| actions/setup-node | `@main` | node24 | `@v7` | node24 |
| actions/github-script | `@v7` | node20 | `@v9` | node24 |
| coverallsapp/github-action | `@master` | node16 | `@v2` | composite |
| jwalton/gh-find-current-pr | `@master` | node24 | `@v1` | node24 |

Two things worth knowing. `coverallsapp/github-action@master` is worse than the annotation suggests: their default branch is `main`, `master` last moved in April 2023, and it declares Node 16 rather than 20. And github-script is on v9 now, not the v8 the issue was expecting, so this jumps two majors. I read both sets of release notes against the script in the deploy step. v8 was Node 24 only. v9 breaks `require('@actions/github')` and scripts that redeclare `getOctokit`, and the step here uses neither, just `github.rest.repos.createDeployment`, `createDeploymentStatus`, `context` and `core.warning`.

I also switched the coveralls step from `path-to-lcov` to `file`, since `path-to-lcov` is marked deprecated in v2. `base-path` and `github-token` are unchanged.

On pinning: I used major tags rather than commit SHAs, because `release.yml`, `commitlint.yml` and `smoke_test.yml` all pin with `@v4` / `@v3` / `@v5` and a lone SHA in one file would be inconsistent without buying much. I can switch this file, or do a SHA pass across all the workflows, if you'd rather go that way.

actionlint 1.7.12 is clean on all the workflow files, before and after.

Closes #983
