### PR TITLE
fix(event-display): correct anglesAreSane docs and test argument order

### DIFF
--- a/packages/phoenix-event-display/src/helpers/coordinate-helper.ts
+++ b/packages/phoenix-event-display/src/helpers/coordinate-helper.ts
@@ -5,10 +5,13 @@ import { Vector3, Quaternion } from 'three';
  */
 export class CoordinateHelper {
   /**
-   * Checks if angles are within range: -PI < phi < PI and 0 < theta < 2PI
-   * @param theta equatorial angle
-   * @param phi azimuthal angle
-   * @returns
+   * Checks if angles are within range: 0 < theta < PI and -PI < phi < PI.
+   * Theta is the polar angle, which is only defined on [0, PI] - values
+   * outside it have no real pseudorapidity, since thetaToEta computes
+   * -log(tan(theta / 2)).
+   * @param theta polar angle in radians, expected in (0, PI)
+   * @param phi azimuthal angle in radians, expected in (-PI, PI)
+   * @returns true if both angles are within their expected ranges
    */
   public static anglesAreSane(theta: number, phi: number): boolean {
     const tmp1 = -Math.PI < phi && Math.PI > phi;

--- a/packages/phoenix-event-display/src/tests/helpers/coordinate-helper.test.ts
+++ b/packages/phoenix-event-display/src/tests/helpers/coordinate-helper.test.ts
@@ -1,10 +1,26 @@
 import { CoordinateHelper } from '../../helpers/coordinate-helper';
 
 describe('CoordinateHelper', () => {
-  it('should check if angles are within range: -PI < phi < PI and 0 < theta < 2PI', () => {
-    const phi = 1.0;
-    const theta = 3.0;
-    expect(CoordinateHelper.anglesAreSane(phi, theta)).toBe(true);
+  it('should accept angles within range: 0 < theta < PI and -PI < phi < PI', () => {
+    // Arguments are (theta, phi) - theta is the polar angle.
+    expect(CoordinateHelper.anglesAreSane(3.0, 1.0)).toBe(true);
+    expect(CoordinateHelper.anglesAreSane(Math.PI / 2, 0.0)).toBe(true);
+    expect(CoordinateHelper.anglesAreSane(0.1, -3.0)).toBe(true);
+  });
+
+  it('should reject a theta outside (0, PI)', () => {
+    expect(CoordinateHelper.anglesAreSane(4.0, 1.0)).toBe(false);
+    expect(CoordinateHelper.anglesAreSane(-0.1, 1.0)).toBe(false);
+    // Boundaries are exclusive, since thetaToEta diverges at 0 and PI.
+    expect(CoordinateHelper.anglesAreSane(0.0, 1.0)).toBe(false);
+    expect(CoordinateHelper.anglesAreSane(Math.PI, 1.0)).toBe(false);
+  });
+
+  it('should reject a phi outside (-PI, PI)', () => {
+    expect(CoordinateHelper.anglesAreSane(1.0, 4.0)).toBe(false);
+    expect(CoordinateHelper.anglesAreSane(1.0, -4.0)).toBe(false);
+    expect(CoordinateHelper.anglesAreSane(1.0, Math.PI)).toBe(false);
+    expect(CoordinateHelper.anglesAreSane(1.0, -Math.PI)).toBe(false);
   });
 
   it('should convert pseudorapidity eta to spherical coordinate theta', () => {


### PR DESCRIPTION
## Problem

The doc comment for `CoordinateHelper.anglesAreSane` states that the accepted range is:

`-PI < phi < PI` and `0 < theta < 2PI`

However, the implementation checks:

```ts
const tmp2 = 0 < theta && Math.PI > theta;
```

which enforces `0 < theta < PI`.

The documentation and implementation therefore disagree about the valid range of `theta` by a factor of two.

## Which one is right?

The implementation is correct, and the documentation is wrong.

* `theta` is the polar angle and is conventionally defined in the range `[0, PI]`.
* `thetaToEta` computes `-log(tan(theta / 2))`, which is only real-valued for `theta` in `(0, PI)`.
* In `jivexml-loader.ts`, `theta` is calculated using `Math.atan(1 / cotTheta[i])`, producing values in `(-PI/2, PI/2)`.
* Negative values are then normalised using:

```ts
if (theta < 0) theta += Math.PI;
```

resulting in `theta` values within `(0, PI)`.

Therefore, `anglesAreSane` correctly enforces `0 < theta < PI`. Widening the check to `2PI` would allow invalid theta values through, which could subsequently cause pseudorapidity calculations to produce `NaN`.

## Why the test did not catch it

The existing test calls `anglesAreSane` with its arguments swapped relative to the function signature:

```ts
anglesAreSane(theta, phi)
```

The test currently does:

```ts
const phi = 1.0;
const theta = 3.0;

expect(CoordinateHelper.anglesAreSane(phi, theta)).toBe(true);
```

With `phi = 1.0` and `theta = 3.0`, both argument orderings happen to return `true`. As a result, the swap is invisible, and neither parameter's boundary conditions are actually covered.

The test would still pass even if either parameter's bounds were implemented incorrectly.

## Changes

* Correct the `anglesAreSane` doc comment to document the enforced range:

  * `-PI < phi < PI`
  * `0 < theta < PI`
* Add documentation explaining why `theta` is restricted to `(0, PI)`.
* Replace the single swapped-argument assertion with tests that:

  * Pass arguments in the declared order.
  * Exercise `phi` and `theta` independently.
  * Verify the exclusive boundaries at `0` and `PI`.
  * Verify the exclusive boundaries at `-PI` and `PI` for `phi`.

## Behaviour

No runtime behaviour is changed.

The `anglesAreSane` implementation is left untouched. This is strictly a documentation and test-correctness fix, so track classification remains unchanged.
