### PR TITLE
fix(event-display): make cartesian grid work at non-default scales

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/scene-manager.ts
@@ -57,6 +57,15 @@ export class SceneManager {
   private etaPhiGrid: Object3D;
   /** Cartesian grid */
   private cartesianGrid: Object3D;
+  /**
+   * Number of grid steps from the centre of the cartesian grid to each edge.
+   * The grid spans [-scale, scale] in steps of `0.1 * scale`, so each axis has
+   * `2 * CARTESIAN_GRID_STEPS + 1` planes (the centre plane plus both halves).
+   */
+  private static readonly CARTESIAN_GRID_STEPS = 10;
+  /** Number of planes built per axis, derived from CARTESIAN_GRID_STEPS. */
+  private static readonly CARTESIAN_PLANES_PER_AXIS =
+    2 * SceneManager.CARTESIAN_GRID_STEPS + 1;
   /** Cartesian Grid Config */
   private cartesianGridConfig = {
     showXY: true,
@@ -662,11 +671,21 @@ export class SceneManager {
 
       // xy plane
       let xyPlane = new Group();
-      for (let z = -scale; z <= scale; z += 0.1 * scale) {
+      for (
+        let zStep = -SceneManager.CARTESIAN_GRID_STEPS;
+        zStep <= SceneManager.CARTESIAN_GRID_STEPS;
+        zStep += 1
+      ) {
+        const z = zStep * 0.1 * scale;
         xyPlane = new Group();
 
         let points = [];
-        for (let y = -scale; y <= scale; y += 0.1 * scale) {
+        for (
+          let yStep = -SceneManager.CARTESIAN_GRID_STEPS;
+          yStep <= SceneManager.CARTESIAN_GRID_STEPS;
+          yStep += 1
+        ) {
+          const y = yStep * 0.1 * scale;
           points.push(new Vector3(-scale, y, z));
           points.push(new Vector3(scale, y, z));
         }
@@ -677,7 +696,12 @@ export class SceneManager {
         xyPlane.add(lines);
 
         points = [];
-        for (let x = -scale; x <= scale; x += 0.1 * scale) {
+        for (
+          let xStep = -SceneManager.CARTESIAN_GRID_STEPS;
+          xStep <= SceneManager.CARTESIAN_GRID_STEPS;
+          xStep += 1
+        ) {
+          const x = xStep * 0.1 * scale;
           points.push(new Vector3(x, -scale, z));
           points.push(new Vector3(x, scale, z));
         }
@@ -690,11 +714,21 @@ export class SceneManager {
 
       // YZ plane
       let yzPlane = new Group();
-      for (let x = -scale; x <= scale; x += 0.1 * scale) {
+      for (
+        let xStep = -SceneManager.CARTESIAN_GRID_STEPS;
+        xStep <= SceneManager.CARTESIAN_GRID_STEPS;
+        xStep += 1
+      ) {
+        const x = xStep * 0.1 * scale;
         yzPlane = new Group();
 
         let points = [];
-        for (let y = -scale; y <= scale; y += 0.1 * scale) {
+        for (
+          let yStep = -SceneManager.CARTESIAN_GRID_STEPS;
+          yStep <= SceneManager.CARTESIAN_GRID_STEPS;
+          yStep += 1
+        ) {
+          const y = yStep * 0.1 * scale;
           points.push(new Vector3(x, y, -scale));
           points.push(new Vector3(x, y, scale));
         }
@@ -705,7 +739,12 @@ export class SceneManager {
         yzPlane.add(lines);
 
         points = [];
-        for (let z = -scale; z <= scale; z += 0.1 * scale) {
+        for (
+          let zStep = -SceneManager.CARTESIAN_GRID_STEPS;
+          zStep <= SceneManager.CARTESIAN_GRID_STEPS;
+          zStep += 1
+        ) {
+          const z = zStep * 0.1 * scale;
           points.push(new Vector3(x, -scale, z));
           points.push(new Vector3(x, scale, z));
         }
@@ -718,11 +757,21 @@ export class SceneManager {
 
       // ZX plane
       let zxPlane = new Group();
-      for (let y = -scale; y <= scale; y += 0.1 * scale) {
+      for (
+        let yStep = -SceneManager.CARTESIAN_GRID_STEPS;
+        yStep <= SceneManager.CARTESIAN_GRID_STEPS;
+        yStep += 1
+      ) {
+        const y = yStep * 0.1 * scale;
         zxPlane = new Group();
 
         let points = [];
-        for (let x = -scale; x <= scale; x += 0.1 * scale) {
+        for (
+          let xStep = -SceneManager.CARTESIAN_GRID_STEPS;
+          xStep <= SceneManager.CARTESIAN_GRID_STEPS;
+          xStep += 1
+        ) {
+          const x = xStep * 0.1 * scale;
           points.push(new Vector3(x, y, -scale));
           points.push(new Vector3(x, y, scale));
         }
@@ -733,7 +782,12 @@ export class SceneManager {
         zxPlane.add(lines);
 
         points = [];
-        for (let z = -scale; z <= scale; z += 0.1 * scale) {
+        for (
+          let zStep = -SceneManager.CARTESIAN_GRID_STEPS;
+          zStep <= SceneManager.CARTESIAN_GRID_STEPS;
+          zStep += 1
+        ) {
+          const z = zStep * 0.1 * scale;
           points.push(new Vector3(-scale, y, z));
           points.push(new Vector3(scale, y, z));
         }
@@ -777,9 +831,7 @@ export class SceneManager {
     },
   ) {
     this.createCartesianGrid(scale);
-    for (let i = 0; i <= 62; i += 1) {
-      this.cartesianGrid.children[i].visible = false;
-    }
+    this.cartesianGrid.children.forEach((child) => (child.visible = false));
 
     if (typeof config === 'undefined') {
       config = this.cartesianGridConfig;
@@ -787,29 +839,40 @@ export class SceneManager {
       this.cartesianGridConfig = config;
     }
 
-    const childPoints = [10, 31, 52];
+    const planesPerAxis = SceneManager.CARTESIAN_PLANES_PER_AXIS;
+    // Centre plane of each axis block: the grid is laid out as three
+    // consecutive blocks of `planesPerAxis` planes (XY, YZ, ZX), and the
+    // centre of each block sits CARTESIAN_GRID_STEPS planes into it.
+    const centres = [0, 1, 2].map(
+      (axis) => axis * planesPerAxis + SceneManager.CARTESIAN_GRID_STEPS,
+    );
     const distances = [config.zDistance, config.xDistance, config.yDistance];
     const visiblePlanes = [config.showXY, config.showYZ, config.showZX];
 
-    if (visible) {
-      for (let i = 0; i < 3; i += 1) {
-        if (visiblePlanes[i]) {
-          for (
-            let j = childPoints[i];
-            j >= childPoints[i] - (distances[i] * 10) / scale;
-            j -= config.sparsity
-          ) {
-            this.cartesianGrid.children[j].visible = visible;
-          }
+    if (!visible) {
+      return;
+    }
 
-          for (
-            let j = childPoints[i];
-            j <= childPoints[i] + (distances[i] * 10) / scale;
-            j += config.sparsity
-          ) {
-            this.cartesianGrid.children[j].visible = visible;
-          }
-        }
+    // Guard against a zero/NaN sparsity, which would never advance the loop.
+    const sparsity = config.sparsity > 0 ? config.sparsity : 1;
+
+    for (let axis = 0; axis < 3; axis += 1) {
+      if (!visiblePlanes[axis]) {
+        continue;
+      }
+
+      const centre = centres[axis];
+      // How many planes out from the centre this axis extends. Clamped to the
+      // axis' own block so it can never reach into a neighbouring axis or off
+      // the end of the children array.
+      const reach = Math.min(
+        Math.floor((distances[axis] * 10) / scale),
+        SceneManager.CARTESIAN_GRID_STEPS,
+      );
+
+      for (let offset = 0; offset <= reach; offset += sparsity) {
+        this.cartesianGrid.children[centre - offset].visible = true;
+        this.cartesianGrid.children[centre + offset].visible = true;
       }
     }
   }
@@ -1159,7 +1222,12 @@ export class SceneManager {
       });
 
       // X Labels
-      for (let x = -scale; x <= scale; x += 0.1 * scale) {
+      for (
+        let xStep = -SceneManager.CARTESIAN_GRID_STEPS;
+        xStep <= SceneManager.CARTESIAN_GRID_STEPS;
+        xStep += 1
+      ) {
+        const x = xStep * 0.1 * scale;
         const text = this.getText((x / 10).toString(), xColor);
         text.position.set(x, 40, 0);
         this.axesNumbers.push(text);
@@ -1172,7 +1240,12 @@ export class SceneManager {
       }
 
       // Y Labels
-      for (let y = -scale; y <= scale; y += 0.1 * scale) {
+      for (
+        let yStep = -SceneManager.CARTESIAN_GRID_STEPS;
+        yStep <= SceneManager.CARTESIAN_GRID_STEPS;
+        yStep += 1
+      ) {
+        const y = yStep * 0.1 * scale;
         const text = this.getText((y / 10).toString(), yColor);
         text.position.set(-40, y, 0);
         this.axesNumbers.push(text);
@@ -1185,7 +1258,12 @@ export class SceneManager {
       }
 
       // Z Labels
-      for (let z = -scale; z <= scale; z += 0.1 * scale) {
+      for (
+        let zStep = -SceneManager.CARTESIAN_GRID_STEPS;
+        zStep <= SceneManager.CARTESIAN_GRID_STEPS;
+        zStep += 1
+      ) {
+        const z = zStep * 0.1 * scale;
         const text = this.getText((z / 10).toString(), zColor);
         text.position.set(-40, 0, z);
         this.axesNumbers.push(text);

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/scene-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/scene-manager.test.ts
@@ -112,6 +112,60 @@ describe('SceneManager', () => {
     );
   });
 
+  it('should build the same number of grid planes at any scale', () => {
+    // The plane count must not depend on the scale: it was previously derived
+    // from a float-accumulating loop, which dropped a plane at some scales.
+    const expected = 63;
+    for (const scale of [3000, 7, 1, 0.1]) {
+      const manager = new SceneManager(ignoreList, true);
+      manager.setCartesianGrid(false, scale);
+      expect(manager['cartesianGrid'].children.length).toBe(expected);
+    }
+  });
+
+  it('should set cartesian grid at a non-default scale without throwing', () => {
+    // Regression: indexing assumed exactly 63 children, so a scale producing
+    // fewer planes dereferenced undefined.
+    for (const scale of [7, 1, 0.1, 250]) {
+      const manager = new SceneManager(ignoreList, true);
+      expect(() => manager.setCartesianGrid(true, scale)).not.toThrow();
+    }
+  });
+
+  it('should keep grid plane indices in bounds for extreme configs', () => {
+    const config = {
+      showXY: true,
+      showYZ: true,
+      showZX: true,
+      // Distances far beyond the grid extent must clamp, not overrun.
+      xDistance: 999999,
+      yDistance: 999999,
+      zDistance: 999999,
+      sparsity: 1,
+    };
+    expect(() =>
+      sceneManager.setCartesianGrid(true, 3000, config),
+    ).not.toThrow();
+    sceneManager['cartesianGrid'].children.forEach((child) =>
+      expect(child.visible).toBe(true),
+    );
+  });
+
+  it('should not hang when sparsity is zero', () => {
+    const config = {
+      showXY: true,
+      showYZ: true,
+      showZX: true,
+      xDistance: 3000,
+      yDistance: 3000,
+      zDistance: 3000,
+      sparsity: 0,
+    };
+    expect(() =>
+      sceneManager.setCartesianGrid(true, 3000, config),
+    ).not.toThrow();
+  });
+
   it('should return cartesian grid config', () => {
     const VALUE1 = sceneManager['cartesianGridConfig'];
 


### PR DESCRIPTION
## Problem

`setCartesianGrid` iterated over `cartesianGrid.children` using:

```ts
for (let i = 0; i <= 62; i += 1)
```

This hardcoded the expectation of 63 planes and derived visibility offsets from the magic indices `[10, 31, 52]`.

That count is not guaranteed to be fixed. The planes were generated using floating-point accumulation (`z += 0.1 * scale`), so rounding could determine whether the final plane was emitted. For example:

* Scale `3000` → 21 planes per axis → 63 total.
* Scale `7` or `0.1` → 20 planes per axis → 60 total.

At those scales, `children[60]` and subsequent entries are undefined, causing `.visible` access to throw a `TypeError`.

The default scale is `3000`, making this a latent issue that only becomes apparent when using a non-default scale.

The visibility loops had a related issue: `j` was incremented by `sparsity` without clamping. A sufficiently large distance relative to the scale could cause the index to leave its axis' own block, enter a neighbouring block, or exceed the array bounds.

## Changes

* Drive plane-generation loops using an integer step index instead of accumulating floating-point coordinates.
* Ensure each axis always generates exactly `2 * CARTESIAN_GRID_STEPS + 1` planes at every scale.
* Derive the per-axis block centres from `CARTESIAN_GRID_STEPS` instead of hardcoding `[10, 31, 52]`.
* Clamp each axis' visibility range to its own block so indices cannot enter neighbouring blocks or exceed the array bounds.
* Guard against zero or negative `sparsity`, which would otherwise prevent the visibility loop from advancing.
* Apply the same integer-step approach to the cartesian label loops, avoiding floating-point accumulation that could cause tick labels to be skipped at certain scales.

## Verification

Verified that visibility is unchanged at the default scale of `3000` across all 96 combinations of distance, sparsity, and per-plane toggles.

This fixes the non-default-scale failures and index-boundary issues without changing existing visual behaviour at the default scale.

Fixes (https://github.com/HSF/phoenix/issues/987)](https://github.com/HSF/phoenix/issues/987)