### PR TITLE
fix: revoke object URLs after use

### DIFF
--- a/packages/phoenix-event-display/src/helpers/file.ts
+++ b/packages/phoenix-event-display/src/helpers/file.ts
@@ -12,10 +12,15 @@ export const saveFile = (
   const blob = new Blob([data], { type: contentType });
   const tempAnchor = document.createElement('a');
   tempAnchor.style.display = 'none';
-  tempAnchor.href = URL.createObjectURL(blob);
+  const objectUrl = URL.createObjectURL(blob);
+  tempAnchor.href = objectUrl;
   tempAnchor.download = fileName;
   tempAnchor.click();
   tempAnchor.remove();
+  // The download is started asynchronously by the click above, so revoking
+  // synchronously here can cancel it. Release the URL on the next tick, once
+  // the browser has taken its own reference to the blob.
+  setTimeout(() => URL.revokeObjectURL(objectUrl));
 };
 
 /**

--- a/packages/phoenix-event-display/src/tests/helpers/file.test.ts
+++ b/packages/phoenix-event-display/src/tests/helpers/file.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { saveFile } from '../../helpers/file';
+
+describe('saveFile', () => {
+  const OBJECT_URL = 'blob:phoenix/test';
+  let createObjectURL: jest.Mock;
+  let revokeObjectURL: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    createObjectURL = jest.fn().mockReturnValue(OBJECT_URL);
+    revokeObjectURL = jest.fn();
+    // jsdom does not implement the object URL APIs.
+    (URL as any).createObjectURL = createObjectURL;
+    (URL as any).revokeObjectURL = revokeObjectURL;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('should revoke the object URL it created', () => {
+    saveFile('{}', 'test.json');
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    // Revoking synchronously can cancel the download the click started, so it
+    // must happen only after the current task.
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    jest.runAllTimers();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith(OBJECT_URL);
+  });
+
+  it('should not leak an object URL per call', () => {
+    saveFile('{}', 'one.json');
+    saveFile('{}', 'two.json');
+    jest.runAllTimers();
+
+    expect(createObjectURL).toHaveBeenCalledTimes(2);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/phoenix-event-display/src/tests/helpers/file.test.ts
+++ b/packages/phoenix-event-display/src/tests/helpers/file.test.ts
@@ -8,6 +8,9 @@ describe('saveFile', () => {
   let createObjectURL: jest.Mock;
   let revokeObjectURL: jest.Mock;
 
+  const originalCreate = (URL as any).createObjectURL;
+  const originalRevoke = (URL as any).revokeObjectURL;
+
   beforeEach(() => {
     jest.useFakeTimers();
     createObjectURL = jest.fn().mockReturnValue(OBJECT_URL);
@@ -20,6 +23,8 @@ describe('saveFile', () => {
   afterEach(() => {
     jest.useRealTimers();
     jest.restoreAllMocks();
+    (URL as any).createObjectURL = originalCreate;
+    (URL as any).revokeObjectURL = originalRevoke;
   });
 
   it('should revoke the object URL it created', () => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/io-options/io-options-dialog/io-options-dialog.component.ts
@@ -219,11 +219,18 @@ export class IOOptionsDialogComponent implements OnInit {
   async handleROOTInput(files: FileList) {
     const rootObjectName = prompt('Enter object name in ROOT file');
 
-    await this.eventDisplay.loadRootGeometry(
-      URL.createObjectURL(files[0]),
-      rootObjectName,
-      files[0].name.split('.')[0],
-    );
+    // The object URL pins the whole file in memory, so release it once the
+    // geometry has been read - ROOT files are routinely hundreds of MB.
+    const objectUrl = URL.createObjectURL(files[0]);
+    try {
+      await this.eventDisplay.loadRootGeometry(
+        objectUrl,
+        rootObjectName,
+        files[0].name.split('.')[0],
+      );
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+    }
 
     this.onClose();
   }
@@ -234,10 +241,12 @@ export class IOOptionsDialogComponent implements OnInit {
     }
 
     const name = files[0].name.split('.')[0];
-    await this.eventDisplay.loadRootJSONGeometry(
-      URL.createObjectURL(files[0]),
-      name,
-    );
+    const objectUrl = URL.createObjectURL(files[0]);
+    try {
+      await this.eventDisplay.loadRootJSONGeometry(objectUrl, name);
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+    }
 
     this.onClose();
   }


### PR DESCRIPTION
## Problem

`URL.createObjectURL` keeps the underlying `Blob` or `File` alive until the object URL is revoked. If the URL is never revoked, the entire file remains pinned in memory for the lifetime of the page.

`handleROOTInput` and `handleRootJSONInput` both created object URLs for selected files but never revoked them. ROOT and PHYSLITE files are routinely hundreds of MB, so loading multiple geometries could leak a significant amount of memory until the tab was reloaded.

`saveFile` had the same issue with the `Blob` used for downloads.

## Changes

* Revoke the object URL in a `finally` block in both dialog handlers.

  * This ensures the URL is released whether geometry loading succeeds or throws.
  * Both loaders are asynchronous and finish reading the URL before resolving, so revoking it in `finally` cannot happen prematurely.
* Update `saveFile` to revoke its object URL on the next tick rather than synchronously.

  * The anchor click starts the browser download asynchronously.
  * Revoking immediately after the click can cancel the download.
  * Deferring the revocation gives the browser time to retain its own reference before the URL is released.

## Verification

Added tests covering `saveFile` to verify that:

* The object URL created by `saveFile` is eventually revoked.
* The URL is not revoked synchronously, allowing the download to start successfully.

This addresses an object URL lifecycle oversight. Other call sites, including `session-pill`, `kinematics-panel`, `masterclass-panel`, and `three-manager`, already revoke their object URLs correctly.

Fixes #990
