### PR TITLE
fix(ui-components): tear down grid-shift subscriptions on destroy

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.test.ts
@@ -40,10 +40,23 @@ describe('CartesianGridConfigComponent', () => {
     originChangedEmit: jest.fn().mockReturnThis(),
   };
 
+  // Several tests swap in Subjects so the subscriptions stay open; put the
+  // default completing observables back afterwards.
+  const restoreObservables = () => {
+    mockEventDisplay.originChanged = of(gridOrigin) as any;
+    mockEventDisplay.stopShifting = of(true) as any;
+  };
+
   const mockData = {
     gridVisible: true,
     scale: 3000,
   };
+
+  afterEach(() => {
+    // Restore the default completing observables, even if a test failed part
+    // way through, so a swapped-in Subject cannot leak into the next test.
+    restoreObservables();
+  });
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -147,10 +160,13 @@ describe('CartesianGridConfigComponent', () => {
   });
 
   it('should unsubscribe on destroy when shifting never stopped', () => {
-    // A Subject never emits on its own, so the subscriptions stay live until
-    // the component is destroyed - the leak when the dialog is closed without
-    // right-clicking to stop shifting.
+    // Subjects never complete on their own, so the subscriptions stay live
+    // until the component is destroyed - the leak when the dialog is closed
+    // without right-clicking to stop shifting. (`of()` completes immediately
+    // and so auto-closes its subscription, which would mask the leak.)
+    const originChanged = new Subject<Vector3>();
     const stopShifting = new Subject<boolean>();
+    mockEventDisplay.originChanged = originChanged as any;
     mockEventDisplay.stopShifting = stopShifting as any;
 
     component.shiftCartesianGridByPointer();
@@ -166,12 +182,12 @@ describe('CartesianGridConfigComponent', () => {
     expect(stopShiftingSub.closed).toBe(true);
     expect(component.originChangedSub).toBeNull();
     expect(component.stopShiftingSub).toBeNull();
-
-    mockEventDisplay.stopShifting = of(true) as any;
   });
 
   it('should not accumulate subscriptions across repeated shifts', () => {
+    const originChanged = new Subject<Vector3>();
     const stopShifting = new Subject<boolean>();
+    mockEventDisplay.originChanged = originChanged as any;
     mockEventDisplay.stopShifting = stopShifting as any;
 
     component.shiftCartesianGridByPointer();
@@ -184,11 +200,12 @@ describe('CartesianGridConfigComponent', () => {
     expect(component.originChangedSub.closed).toBe(false);
 
     component.ngOnDestroy();
-    mockEventDisplay.stopShifting = of(true) as any;
   });
 
   it('should unsubscribe when stopShifting emits after subscribing', () => {
+    const originChanged = new Subject<Vector3>();
     const stopShifting = new Subject<boolean>();
+    mockEventDisplay.originChanged = originChanged as any;
     mockEventDisplay.stopShifting = stopShifting as any;
 
     component.shiftCartesianGridByPointer();
@@ -199,8 +216,8 @@ describe('CartesianGridConfigComponent', () => {
 
     expect(originChangedSub.closed).toBe(true);
     expect(stopShiftingSub.closed).toBe(true);
-
-    mockEventDisplay.stopShifting = of(true) as any;
+    expect(component.originChangedSub).toBeNull();
+    expect(component.stopShiftingSub).toBeNull();
   });
 
   it('should shift cartesian grid by values', () => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.test.ts
@@ -6,6 +6,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { Vector3 } from 'three';
 import { of } from 'rxjs/internal/observable/of';
+import { Subject } from 'rxjs';
 
 describe('CartesianGridConfigComponent', () => {
   let component: CartesianGridConfigComponent;
@@ -121,29 +122,85 @@ describe('CartesianGridConfigComponent', () => {
   });
 
   it('should shift cartesian grid by a mouse click', () => {
+    const translateSpy = jest.spyOn(component, 'translateGrid');
+
     component.shiftCartesianGridByPointer();
 
-    mockEventDisplay.getUIManager().shiftCartesianGridByPointer(true);
+    expect(
+      mockEventDisplay.getUIManager().shiftCartesianGridByPointer,
+    ).toHaveBeenCalled();
+    // `originChanged` is mocked with `of(gridOrigin)`, so the handler runs
+    // synchronously on subscribe.
+    expect(translateSpy).toHaveBeenCalledWith(gridOrigin);
+    // `stopShifting` is mocked with `of(true)`, so shifting stops immediately
+    // and both subscriptions are torn down.
+    expect(component.originChangedSub).toBeNull();
+    expect(component.stopShiftingSub).toBeNull();
+  });
 
-    mockEventDisplay.getThreeManager().originChanged.subscribe((intersect) => {
-      expect(component.translateGrid).toHaveBeenCalledWith(intersect);
-    });
+  it('should not throw when stopShifting emits synchronously', () => {
+    // `of(true)` emits during `subscribe`, so the handler runs before
+    // `stopShiftingSub` is assigned. Previously this threw a TypeError.
+    expect(() => component.shiftCartesianGridByPointer()).not.toThrow();
+    expect(component.originChangedSub).toBeNull();
+    expect(component.stopShiftingSub).toBeNull();
+  });
 
-    const originChangedUnSpy = jest.spyOn(
-      component.originChangedSub,
-      'unsubscribe',
-    );
-    const stopShiftingUnSpy = jest.spyOn(
-      component.stopShiftingSub,
-      'unsubscribe',
-    );
+  it('should unsubscribe on destroy when shifting never stopped', () => {
+    // A Subject never emits on its own, so the subscriptions stay live until
+    // the component is destroyed - the leak when the dialog is closed without
+    // right-clicking to stop shifting.
+    const stopShifting = new Subject<boolean>();
+    mockEventDisplay.stopShifting = stopShifting as any;
 
-    mockEventDisplay.getThreeManager().stopShifting.subscribe((stop) => {
-      if (stop) {
-        expect(originChangedUnSpy).toHaveBeenCalled();
-        expect(stopShiftingUnSpy).toHaveBeenCalled();
-      }
-    });
+    component.shiftCartesianGridByPointer();
+
+    const originChangedSub = component.originChangedSub;
+    const stopShiftingSub = component.stopShiftingSub;
+    expect(originChangedSub.closed).toBe(false);
+    expect(stopShiftingSub.closed).toBe(false);
+
+    component.ngOnDestroy();
+
+    expect(originChangedSub.closed).toBe(true);
+    expect(stopShiftingSub.closed).toBe(true);
+    expect(component.originChangedSub).toBeNull();
+    expect(component.stopShiftingSub).toBeNull();
+
+    mockEventDisplay.stopShifting = of(true) as any;
+  });
+
+  it('should not accumulate subscriptions across repeated shifts', () => {
+    const stopShifting = new Subject<boolean>();
+    mockEventDisplay.stopShifting = stopShifting as any;
+
+    component.shiftCartesianGridByPointer();
+    const firstSub = component.originChangedSub;
+
+    component.shiftCartesianGridByPointer();
+
+    // The first shift's subscription must be torn down, not left behind.
+    expect(firstSub.closed).toBe(true);
+    expect(component.originChangedSub.closed).toBe(false);
+
+    component.ngOnDestroy();
+    mockEventDisplay.stopShifting = of(true) as any;
+  });
+
+  it('should unsubscribe when stopShifting emits after subscribing', () => {
+    const stopShifting = new Subject<boolean>();
+    mockEventDisplay.stopShifting = stopShifting as any;
+
+    component.shiftCartesianGridByPointer();
+    const originChangedSub = component.originChangedSub;
+    const stopShiftingSub = component.stopShiftingSub;
+
+    stopShifting.next(true);
+
+    expect(originChangedSub.closed).toBe(true);
+    expect(stopShiftingSub.closed).toBe(true);
+
+    mockEventDisplay.stopShifting = of(true) as any;
   });
 
   it('should shift cartesian grid by values', () => {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.ts
@@ -1,4 +1,9 @@
-import { Component, Inject, type OnInit } from '@angular/core';
+import {
+  Component,
+  Inject,
+  type OnDestroy,
+  type OnInit,
+} from '@angular/core';
 import { Vector3 } from 'three';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
@@ -11,7 +16,7 @@ import { Subscription } from 'rxjs';
   templateUrl: './cartesian-grid-config.component.html',
   styleUrls: ['./cartesian-grid-config.component.scss'],
 })
-export class CartesianGridConfigComponent implements OnInit {
+export class CartesianGridConfigComponent implements OnInit, OnDestroy {
   cartesianPos = new Vector3();
   originChangedSub: Subscription = null;
   stopShiftingSub: Subscription = null;
@@ -54,20 +59,49 @@ export class CartesianGridConfigComponent implements OnInit {
   shiftCartesianGridByPointer() {
     this.shiftGrid = true;
     this.eventDisplay.getUIManager().shiftCartesianGridByPointer();
+    // Drop any subscriptions from a previous shift before starting a new one.
+    this.clearShiftSubscriptions();
     this.originChangedSub = this.eventDisplay
       .getThreeManager()
       .originChanged.subscribe((intersect) => {
         this.translateGrid(intersect);
       });
+    // `stopShifting` may emit synchronously during `subscribe`, in which case
+    // the handler runs before `stopShiftingSub` has been assigned. Track that
+    // with a flag so the teardown still happens (and never dereferences null).
+    let stoppedDuringSubscribe = false;
     this.stopShiftingSub = this.eventDisplay
       .getThreeManager()
       .stopShifting.subscribe((stop) => {
-        if (stop) {
-          this.originChangedSub.unsubscribe();
-          this.stopShiftingSub.unsubscribe();
+        if (!stop) {
+          return;
+        }
+        if (this.stopShiftingSub) {
+          this.clearShiftSubscriptions();
+        } else {
+          stoppedDuringSubscribe = true;
         }
       });
+    if (stoppedDuringSubscribe) {
+      this.clearShiftSubscriptions();
+    }
     this.onClose();
+  }
+
+  /**
+   * Unsubscribe from the grid-shifting subscriptions, if any are active.
+   */
+  private clearShiftSubscriptions() {
+    this.originChangedSub?.unsubscribe();
+    this.originChangedSub = null;
+    this.stopShiftingSub?.unsubscribe();
+    this.stopShiftingSub = null;
+  }
+
+  ngOnDestroy(): void {
+    // The dialog closes as soon as pointer shifting starts, so without this the
+    // subscriptions outlive the component and leak on every reopen.
+    this.clearShiftSubscriptions();
   }
 
   shiftCartesianGridByValues(position: Vector3) {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/cartesian-grid-config/cartesian-grid-config.component.ts
@@ -1,9 +1,4 @@
-import {
-  Component,
-  Inject,
-  type OnDestroy,
-  type OnInit,
-} from '@angular/core';
+import { Component, Inject, type OnDestroy, type OnInit } from '@angular/core';
 import { Vector3 } from 'three';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';


### PR DESCRIPTION
## Problem

`shiftCartesianGridByPointer` subscribed to `originChanged` and `stopShifting`, then immediately called `onClose()` to dismiss the dialog. Both subscriptions were only unsubscribed from inside the `stopShifting` handler, which fires on right-click, and the component did not implement `ngOnDestroy`.

As a result, closing the dialog without right-clicking left both subscriptions active for the lifetime of the page. Reopening the dialog accumulated another pair of subscriptions each time, and the stale `originChanged` handler could continue translating the grid after the component had been destroyed.

The teardown also had a synchronous emission bug. `stopShifting` can emit synchronously during `subscribe`, causing its handler to run before `stopShiftingSub` has been assigned. Calling `this.stopShiftingSub.unsubscribe()` in that situation throws a `TypeError`. The component's existing test mocks use `of(true)`, which emits synchronously and exposes this issue.

## Changes

* Implement `OnDestroy` so all active shift subscriptions are cleaned up when the component is destroyed.
* Introduce a single `clearShiftSubscriptions` helper responsible for:

  * Unsubscribing from both subscriptions when present.
  * Nulling the subscription fields after teardown.
  * Being safe to call repeatedly.
  * Being safe to call before a subscription has been assigned.
  * Being safe to call when no shift is currently active.
* Clear any existing shift subscriptions before starting a new shift, preventing repeated shifts from accumulating subscriptions.
* Handle synchronous `stopShifting` emissions using a local flag rather than checking the subscription's `closed` state. A plain synchronous observable does not necessarily report the subscription as closed at the point the handler executes.
* Update the existing `should shift cartesian grid by a mouse click` test.

  * The previous test placed its expectations inside `subscribe` callbacks, so the assertions were never actually executed.
  * The test now verifies the observable behaviour directly.

## Verification

The updated teardown logic safely handles component destruction, repeated shifts, synchronous observable emissions, and normal stop events without leaking subscriptions.

Fixes #989
