### PR TITLE
fix(event-display): handle malformed JSON in user-loaded files

### DIFF
--- a/packages/phoenix-event-display/src/managers/state-manager.ts
+++ b/packages/phoenix-event-display/src/managers/state-manager.ts
@@ -74,7 +74,19 @@ export class StateManager {
           label: 'Load state',
           onClick: () => {
             loadFile((data) => {
-              this.loadStateFromJSON(JSON.parse(data));
+              // The file comes from the user, so it may not be valid JSON.
+              // Report the problem instead of throwing out of the callback.
+              let state: any;
+              try {
+                state = JSON.parse(data);
+              } catch (error) {
+                console.error(
+                  'Could not parse state file - invalid JSON.',
+                  error,
+                );
+                return;
+              }
+              this.loadStateFromJSON(state);
             });
           },
         });

--- a/packages/phoenix-event-display/src/managers/ui-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/index.ts
@@ -585,7 +585,15 @@ export class UIManager {
     if (eventDataLoader && labelsObject) {
       loadFile((data) => {
         console.log('UIManager: loading Labels');
-        const labelsObject = JSON.parse(data);
+        // The file comes from the user, so it may not be valid JSON. Report
+        // the problem instead of throwing out of the callback.
+        let labelsObject: any;
+        try {
+          labelsObject = JSON.parse(data);
+        } catch (error) {
+          console.error('Could not parse labels file - invalid JSON.', error);
+          return;
+        }
         // This contains the names of the labels, but not their colours.
         for (const eventDataType of Object.keys(labelsObject)) {
           for (const collection of Object.keys(labelsObject[eventDataType])) {

--- a/packages/phoenix-event-display/src/tests/managers/state-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/state-manager.test.ts
@@ -51,6 +51,27 @@ describe('StateManager', () => {
     expect(stateManager.eventMetadata.eventNumber).toBe('000');
   });
 
+  it('should not throw when the loaded state file is not valid JSON', () => {
+    const phoenixMenuRoot = new PhoenixMenuNode('root');
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    // Feed the 'Load state' button a malformed file.
+    jest
+      .spyOn(file, 'loadFile')
+      .mockImplementation((onFileRead) => onFileRead('not json'));
+    const loadSpy = jest.spyOn(stateManager, 'loadStateFromJSON');
+
+    stateManager.setPhoenixMenuRoot(phoenixMenuRoot);
+    const loadStateButton = phoenixMenuRoot.configs.find(
+      (config: any) => config.label === 'Load state',
+    ) as any;
+
+    expect(() => loadStateButton.onClick()).not.toThrow();
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
+  });
+
   it('should load the state of the event display from JSON', () => {
     stateManager.phoenixMenuRoot = new PhoenixMenuNode('root');
 


### PR DESCRIPTION
## Problem

`Load state` and `Load labels` both call `JSON.parse` on the contents of a user-selected file inside a `loadFile` callback without any error handling.

If the selected file contains invalid JSON, `JSON.parse` throws a `SyntaxError` from inside the callback. Nothing catches the error, so the load silently fails and the user receives no indication of what went wrong.

`session-codec.ts` already guards its JSON parsing this way, so these two call sites were simply not updated to follow the same pattern.

## Changes

* Wrap the `JSON.parse` calls in both `Load state` and `Load labels` with error handling.
* Report malformed JSON via `console.error`, matching the error-handling behaviour used by the surrounding managers.
* Return immediately after a parse failure so invalid data is never applied.
* Leave valid state and label loading behaviour unchanged.

## Verification

Added a test covering malformed state files to verify that:

* The parsing failure is reported instead of escaping as an uncaught exception.
* `loadStateFromJSON` is not called with invalid/garbage data.

This brings the two file-loading paths in line with the existing error-handling approach in `session-codec.ts`.

Fixes #991
