### PR TITLE
fix(ci): deploy PR previews for pull requests from forks

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,180 @@
+name: Deploy PR Preview
+
+# Deploys the site built by `phoenix-ci` for a pull request to surge.sh.
+#
+# This is deliberately a separate workflow: GitHub withholds secrets from
+# workflows triggered by a pull request from a fork, so `phoenix-ci` cannot
+# deploy. A `workflow_run` workflow instead runs in the context of this
+# repository (with secrets) *after* the PR build has finished, and only ever
+# consumes the already-built artifact - it never checks out or executes the
+# pull request's code.
+on:
+  workflow_run:
+    workflows: ['phoenix-ci']
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  deployments: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+          github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      # Every successful pull request run of `phoenix-ci` uploads this artifact,
+      # so a missing one is a bug and should fail loudly rather than quietly
+      # skipping the deployment.
+      - name: Download preview artifact
+        id: download
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-preview
+          path: preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number from artifact
+        id: meta
+        run: |
+          set -euo pipefail
+
+          # The artifact is produced by an untrusted build, so strip its contents
+          # to the expected character set before using them anywhere.
+          pr_number=$(tr -dc '0-9' < preview/pr-number | head -c 10)
+
+          if [[ -z "$pr_number" ]]; then
+            echo "::error::Missing or invalid PR number in artifact"
+            exit 1
+          fi
+          if [[ ! -d preview/site ]]; then
+            echo "::error::Artifact does not contain a site directory"
+            exit 1
+          fi
+
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      # The PR number comes from the untrusted artifact, so on its own it could
+      # name *any* pull request - letting one PR overwrite another's preview or
+      # comment on it. `workflow_run.head_sha` is supplied by GitHub and cannot
+      # be forged, so require the named PR to actually be the one that was built.
+      - name: Verify the PR owns this build
+        id: verify
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const headSha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.head.sha !== headSha) {
+              core.setFailed(
+                `PR #${prNumber} has head ${pr.head.sha}, but this build was for ` +
+                  `${headSha}. Refusing to deploy.`,
+              );
+              return;
+            }
+
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('head_sha', headSha);
+            core.setOutput('url', `http://phoenix-pr-${prNumber}.surge.sh`);
+
+      - name: Deploy to surge.sh
+        env:
+          DEPLOYMENT_URL: ${{ steps.verify.outputs.url }}
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN2 }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN2 }}
+        run: npx surge --project ./preview/site/ --domain "$DEPLOYMENT_URL"
+
+      - name: Publish deployment status and comment
+        uses: actions/github-script@v9
+        env:
+          DEPLOYMENT_URL: ${{ steps.verify.outputs.url }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr_number }}
+          PR_SHA: ${{ steps.verify.outputs.head_sha }}
+        with:
+          script: |
+            const environmentUrl = process.env.DEPLOYMENT_URL;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const prSha = process.env.PR_SHA;
+            const { owner, repo } = context.repo;
+
+            // A fork's head commit does not exist in this repository, but the
+            // pull request's `refs/pull/<n>/head` ref always does.
+            try {
+              const deployment = await github.rest.repos.createDeployment({
+                owner,
+                repo,
+                ref: `refs/pull/${prNumber}/head`,
+                environment: 'pull-request',
+                required_contexts: [],
+                auto_merge: false,
+                transient_environment: true,
+              });
+              if (deployment.data.id) {
+                await github.rest.repos.createDeploymentStatus({
+                  owner,
+                  repo,
+                  deployment_id: deployment.data.id,
+                  state: 'success',
+                  target_url: environmentUrl,
+                  environment_url: environmentUrl,
+                  description: 'Deployed preview for pull request',
+                });
+              } else {
+                core.warning(
+                  `Deployment not created: ${deployment.data.message || 'unknown reason'}`,
+                );
+              }
+            } catch (error) {
+              // A missing deployment should not fail the run - the comment below
+              // still gives reviewers the preview link.
+              core.warning(`Could not create deployment: ${error.message}`);
+            }
+
+            const marker = '<!-- phoenix-preview-deployment -->';
+            const body = [
+              marker,
+              `🚀 **Preview deployed:** ${environmentUrl}`,
+              '',
+              `Built from ${prSha.slice(0, 7)}.`,
+            ].join('\n');
+
+            // Update the existing comment instead of adding one per push.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 },
+            );
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,46 +48,35 @@ jobs:
           file: ./packages/phoenix-event-display/coverage/lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pre Deploy Pull Request
-        uses: jwalton/gh-find-current-pr@v1
-        id: if_pr
+      - name: Build web app
+        if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
+        run: yarn deploy:web
 
-      - name: Deploy
+      # Pushes to main are trusted, so they can deploy directly using the secrets.
+      - name: Deploy to dev
         id: deploy
-        if: ${{ steps.if_pr.outputs.number || github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
-          PR_URL: http://phoenix-pr-${{ steps.if_pr.outputs.number }}.surge.sh
           DEV_URL: http://phoenix-dev2.surge.sh
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN2 }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN2 }}
         run: |
-          yarn deploy:web
-          if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
-            export DEPLOYMENT_URL=$DEV_URL
-            export DEPLOYMENT_ENV=dev
-          else
-            export DEPLOYMENT_URL=$PR_URL
-            export DEPLOYMENT_ENV=pull-request
-          fi
-          npx surge --project ./packages/phoenix-ng/docs/ --domain $DEPLOYMENT_URL
-          echo "deployment_url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
-          echo "deployment_env=$DEPLOYMENT_ENV" >> "$GITHUB_OUTPUT"
+          npx surge --project ./packages/phoenix-ng/docs/ --domain "$DEV_URL"
+          echo "deployment_url=$DEV_URL" >> "$GITHUB_OUTPUT"
 
       - name: Create Deployment and Status
-        if: ${{ success() && (steps.if_pr.outputs.number || github.ref == 'refs/heads/main') }}
+        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: actions/github-script@v9
         env:
-          DEPLOYMENT_ENV: ${{ steps.deploy.outputs.deployment_env }}
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment_url }}
         with:
           script: |
-            const environment = process.env.DEPLOYMENT_ENV;
             const environmentUrl = process.env.DEPLOYMENT_URL;
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.ref,
-              environment,
+              environment: 'dev',
               required_contexts: [],
               auto_merge: false,
             });
@@ -102,5 +91,28 @@ jobs:
               state: 'success',
               target_url: environmentUrl,
               environment_url: environmentUrl,
-              description: `Deployed to environment ${environment}`,
+              description: 'Deployed to environment dev',
             });
+
+      # Pull requests (including those from forks) cannot deploy here: GitHub
+      # withholds secrets from workflows triggered by a fork, and handing them to
+      # unreviewed code would leak them. Instead the built site is passed to the
+      # `deploy-preview` workflow, which runs in this repository's trusted
+      # context. See .github/workflows/deploy-preview.yml.
+      - name: Stage preview artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p preview/site
+          cp -r ./packages/phoenix-ng/docs/. preview/site/
+          echo "$PR_NUMBER" > preview/pr-number
+
+      - name: Upload preview artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-preview
+          path: preview
+          retention-days: 3
+          if-no-files-found: error

--- a/guides/developers/test-setup.md
+++ b/guides/developers/test-setup.md
@@ -119,3 +119,29 @@ and you can automatically fix them with:
 yarn lint:fix
 ```
 (obviously you will then need to commit and push the fixes).
+
+## Pull request preview deployments
+
+Every pull request gets a preview of the app deployed to
+`http://phoenix-pr-<number>.surge.sh`, and a bot comment on the PR links to it.
+
+This is done by two workflows rather than one. GitHub deliberately withholds
+secrets from workflows triggered by a pull request from a fork, so the surge
+credentials are not available while the PR is being built - a fork's code is
+unreviewed, and giving it the token would let any contributor steal it.
+
+So the work is split:
+
+- `.github/workflows/main.yml` (`phoenix-ci`) builds the app and uploads the
+  result as a `pr-preview` artifact. It has no access to the secrets.
+- `.github/workflows/deploy-preview.yml` then runs on `workflow_run`, in the
+  trusted context of this repository, downloads that artifact and deploys it.
+  It never checks out or runs the pull request's code.
+
+Two consequences worth knowing:
+
+- Changes to `deploy-preview.yml` only take effect once they are merged into
+  `main`, because `workflow_run` workflows are always taken from the default
+  branch. You cannot fully test a change to it from a pull request.
+- The preview appears a little after the CI run finishes, since it is a
+  separate workflow that starts once `phoenix-ci` completes.


### PR DESCRIPTION
Preview deployments never ran for pull requests opened from a fork, which is most external contributions. The Deploy step was skipped rather than failing, so CI stayed green while quietly deploying nothing.

There were two causes. `jwalton/gh-find-current-pr` looks up the PR by asking this repository which pull requests are associated with the head commit, but a fork's commit does not exist here, so it returned nothing and the step's condition was never met. Even with that fixed the step could not have worked: GitHub withholds secrets from workflows triggered by a fork, so the surge credentials would have been empty.

Split the work in two so the credentials are never exposed to unreviewed code. `phoenix-ci` now only builds the app and uploads it as an artifact, and a new `deploy-preview` workflow runs on `workflow_run` in this repository's trusted context to deploy it. It consumes only the built output and never checks out or executes the pull request's code.

The PR number has to travel through the artifact, as `workflow_run` does not carry it for forks. Since that value comes from an untrusted build it is stripped to digits, and the named PR must have the same head commit as the build being deployed - otherwise a pull request could overwrite another one's preview or comment on it.

Pushes to main still deploy directly, as they are trusted and have access to the secrets. `gh-find-current-pr` is no longer needed, as the PR number is available directly on the pull_request event.