### PR TITLE
fix(event-display): Fix loading json bug

### DIFF
--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
@@ -253,12 +253,16 @@ export class PhoenixMenuNode {
       jsonObject = json;
     }
 
-    this.childrenActive = jsonObject['childrenActive'];
-    this.toggleState = jsonObject['toggleState'];
+    if (jsonObject['childrenActive'] !== undefined) {
+      this.childrenActive = jsonObject['childrenActive'];
+    }
 
-    this.onToggle?.(this.toggleState);
+    if (jsonObject['toggleState'] !== undefined) {
+      this.toggleState = jsonObject['toggleState'];
+      this.onToggle?.(this.toggleState);
+    }
 
-    for (const configState of jsonObject['configs']) {
+    for (const configState of jsonObject['configs'] ?? []) {
       const nodeConfigs = this.configs.filter(
         (nodeConfig) =>
           nodeConfig.type === configState['type'] &&
@@ -271,10 +275,16 @@ export class PhoenixMenuNode {
       }
 
       if (nodeConfigs.length === 0) {
-        console.error(
-          'No config found with label and type in phoenix menu node. Aborting.',
+        // The menu is built from the event data, so a state saved with one
+        // event can name configs another event has no equivalent of - a cut on
+        // an attribute its objects do not have, for example. The rest of the
+        // state still describes this node and its children, so only the config
+        // which is gone is skipped.
+        console.warn(
+          `Ignoring "${configState['label']}" of "${this.name}" from the ` +
+            'saved state, as the menu has no such option.',
         );
-        return;
+        continue;
       }
 
       const nodeConfig = nodeConfigs[0];
@@ -298,7 +308,7 @@ export class PhoenixMenuNode {
     }
 
     // Now handle children
-    for (const childState of jsonObject['children']) {
+    for (const childState of jsonObject['children'] ?? []) {
       const nodeChild = this.children.filter(
         (nodeChild) =>
           nodeChild.name === childState.name &&

--- a/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-node.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-node.test.ts
@@ -3,6 +3,13 @@
  */
 import { PhoenixMenuNode } from '../../../../managers/ui-manager/phoenix-menu/phoenix-menu-node';
 
+/**
+ * The state of a node as it would be read back from a saved file, rather than
+ * the live configs `getNodeState` hands out references to.
+ */
+const savedState = (node: PhoenixMenuNode) =>
+  JSON.parse(JSON.stringify(node.getNodeState()));
+
 describe('PhoenixMenuNode', () => {
   describe('loadStateFromJSON', () => {
     it('should restore the value of a select config and apply it', () => {
@@ -141,6 +148,74 @@ describe('PhoenixMenuNode', () => {
 
       expect(onCheckboxChange).toHaveBeenCalledWith(false);
       expect(onSliderChange).toHaveBeenCalledWith(0);
+    });
+
+    it('should restore the rest of a node when a saved config is gone', () => {
+      // The menu is built from the event data, so a state saved with one event
+      // can hold configs another event has no equivalent of - a cut on an
+      // attribute its objects do not have, for example.
+      const onChange = jest.fn();
+      const node = new PhoenixMenuNode('Collection');
+      node.addConfig({
+        type: 'color',
+        label: 'Color',
+        color: '#ff0000',
+        onChange,
+      });
+
+      const state = savedState(node);
+      state['configs'].unshift({
+        type: 'rangeSlider',
+        label: 'A cut this event does not have',
+        value: 1,
+        highValue: 2,
+      });
+      state['configs'][1].color = '#0adb2d';
+
+      node.loadStateFromJSON(state);
+
+      expect(onChange).toHaveBeenCalledWith('#0adb2d');
+    });
+
+    it('should restore child nodes when a saved config is gone', () => {
+      const onChange = jest.fn();
+      const node = new PhoenixMenuNode('Collection');
+      const child = node.addChild('Color Options');
+      child.addConfig({
+        type: 'color',
+        label: 'Color',
+        color: '#ff0000',
+        onChange,
+      });
+
+      const state = savedState(node);
+      state['configs'].push({
+        type: 'checkbox',
+        label: 'An option this event does not have',
+        isChecked: true,
+      });
+      state['children'][0].configs[0].color = '#0adb2d';
+
+      node.loadStateFromJSON(state);
+
+      expect(onChange).toHaveBeenCalledWith('#0adb2d');
+    });
+
+    it('should restore what it can from a partial state', () => {
+      const onChange = jest.fn();
+      const node = new PhoenixMenuNode('Collection');
+      node.addConfig({
+        type: 'color',
+        label: 'Color',
+        color: '#ff0000',
+        onChange,
+      });
+
+      // A hand written config file need not spell out every node.
+      expect(() =>
+        node.loadStateFromJSON({ name: 'Collection' }),
+      ).not.toThrow();
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('should apply the color of a Labels node when the config is added', () => {


### PR DESCRIPTION
Loading a saved state stopped at the first option it named which the menu did not have, abandoning the rest of that node and everything below it. Nothing said so beyond a message on the console, so most of a state could silently fail to be restored.

An option which is gone is now skipped on its own, naming itself on the console, and the rest of the state is restored. A state which does not spell out its configs or children, as a hand written one need not, no longer throws.