### PR TITLE
fix(event-display): stop leaking a contextmenu listener per grid shift

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/index.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/index.ts
@@ -102,6 +102,8 @@ export class ThreeManager {
     null;
   /** 'click' event listener callback to show 3D distance between two clicked points */
   private show3DDistanceCallback: ((event: MouseEvent) => void) | null = null;
+  /** 'contextmenu' event listener callback to stop shifting the cartesian grid */
+  private stopShiftingCallback: ((event: MouseEvent) => void) | null = null;
 
   /** Origin of the cartesian grid w.r.t. world origin */
   public origin: Vector3 = new Vector3(0, 0, 0);
@@ -733,19 +735,33 @@ export class ThreeManager {
       };
     }
 
-    const rightClickCallback = (_event: any) => {
-      if (this.shiftCartesianGridCallback) {
-        window.removeEventListener('click', this.shiftCartesianGridCallback);
-      }
+    // Drop the listeners from a previous shift before adding new ones, so
+    // repeated shifts do not stack up duplicate handlers on window.
+    this.removeShiftGridListeners();
+
+    this.stopShiftingCallback = () => {
       this.stopShifting.emit(true);
       this.shiftGrid = false;
-      window.removeEventListener('contextmenu', rightClickCallback);
+      this.removeShiftGridListeners();
     };
 
     if (this.shiftCartesianGridCallback) {
       window.addEventListener('click', this.shiftCartesianGridCallback);
     }
-    window.addEventListener('contextmenu', rightClickCallback);
+    window.addEventListener('contextmenu', this.stopShiftingCallback);
+  }
+
+  /**
+   * Remove the window listeners used while shifting the cartesian grid.
+   */
+  private removeShiftGridListeners() {
+    if (this.shiftCartesianGridCallback) {
+      window.removeEventListener('click', this.shiftCartesianGridCallback);
+    }
+    if (this.stopShiftingCallback) {
+      window.removeEventListener('contextmenu', this.stopShiftingCallback);
+      this.stopShiftingCallback = null;
+    }
   }
 
   /**
@@ -1808,10 +1824,8 @@ export class ThreeManager {
       window.removeEventListener('mousemove', this.mousemoveCallback);
       this.mousemoveCallback = null;
     }
-    if (this.shiftCartesianGridCallback) {
-      window.removeEventListener('click', this.shiftCartesianGridCallback);
-      this.shiftCartesianGridCallback = null;
-    }
+    this.removeShiftGridListeners();
+    this.shiftCartesianGridCallback = null;
 
     // Clean up any dangling DOM elements from interactive features
     document.getElementById('3dcoordinates')?.remove();

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/grid-shift-listeners.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/grid-shift-listeners.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { ThreeManager } from '../../../managers/three-manager/index';
+
+/**
+ * These exercise the window-listener bookkeeping of `shiftCartesianGrid`
+ * directly, so they do not need a WebGL context.
+ */
+describe('ThreeManager grid shifting listeners', () => {
+  let three: any;
+  let listeners: { type: string; callback: any }[];
+  let origAdd: any;
+  let origRemove: any;
+
+  /** Number of listeners currently registered for a given event type. */
+  const countFor = (type: string) =>
+    listeners.filter((l) => l.type === type).length;
+
+  beforeEach(() => {
+    listeners = [];
+    origAdd = window.addEventListener;
+    origRemove = window.removeEventListener;
+    window.addEventListener = jest.fn((type: string, callback: any) => {
+      listeners.push({ type, callback });
+    }) as any;
+    window.removeEventListener = jest.fn((type: string, callback: any) => {
+      const index = listeners.findIndex(
+        (l) => l.type === type && l.callback === callback,
+      );
+      if (index >= 0) listeners.splice(index, 1);
+    }) as any;
+
+    three = Object.create(ThreeManager.prototype);
+    three.shiftCartesianGridCallback = null;
+    three.show3DPointsCallback = null;
+    three.show3DDistanceCallback = null;
+    three.mousemoveCallback = null;
+    three.keydownHandler = null;
+    three.shiftGrid = false;
+    three.stopShifting = { emit: jest.fn() };
+    three.filterRayIntersect = jest.fn();
+  });
+
+  afterEach(() => {
+    window.addEventListener = origAdd;
+    window.removeEventListener = origRemove;
+  });
+
+  it('should not stack up listeners over repeated shifts', () => {
+    three.shiftCartesianGrid();
+    three.shiftCartesianGrid();
+    three.shiftCartesianGrid();
+
+    expect(countFor('contextmenu')).toBe(1);
+    expect(countFor('click')).toBe(1);
+  });
+
+  it('should remove both listeners when shifting is stopped by right click', () => {
+    three.shiftCartesianGrid();
+    const stopShifting = listeners.find((l) => l.type === 'contextmenu');
+    stopShifting?.callback(new MouseEvent('contextmenu'));
+
+    expect(three.stopShifting.emit).toHaveBeenCalledWith(true);
+    expect(three.shiftGrid).toBe(false);
+    expect(countFor('contextmenu')).toBe(0);
+    expect(countFor('click')).toBe(0);
+  });
+
+  it('should remove the listeners it added on cleanup', () => {
+    three.shiftCartesianGrid();
+    ThreeManager.prototype.cleanup.call(three);
+
+    expect(countFor('contextmenu')).toBe(0);
+    expect(countFor('click')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`shiftCartesianGrid` attached its stop-shifting handler to `window` as `rightClickCallback`, a fresh closure created on every call and held only in a local variable.

Nothing removed the previous closure before adding the next one, so starting the pointer shift N times left N `'contextmenu'` listeners on `window`. Only the most recent one could remove itself, and each retained `this`, keeping the manager alive with it.

`cleanup()` could not remove them at all. It only knew about the `'click'` callback, which is stored in a field; the local `rightClickCallback` was unreachable from there, so every `'contextmenu'` listener ever added survived teardown.

This is the same class of leak as #989, fixed on the component side in #993. That fix tore down the `stopShifting` subscription in the dialog component; the window listener underneath it still leaked.

## Fix

- Store the stop-shifting callback in a field, the way `shiftCartesianGridCallback` and the other interactive callbacks already are.
- Share one `removeShiftGridListeners` helper between the right-click path, the start of a new shift, and `cleanup()`, so the listeners are removed on all three routes.

Behaviour on the happy path is unchanged: right-clicking still emits `stopShifting`, clears `shiftGrid`, and detaches both listeners.

## Tests

There was no existing coverage for this. Added three tests covering that repeated shifts do not stack up listeners, that right-clicking removes both listeners, and that `cleanup()` removes them. The first and third fail before this change and pass after.

The rest of the `phoenix-event-display` suite is unaffected: 363 passing.

Fixes #1001
