### PR TITLE
fix(event-display): keep loading a zip when one JSON entry is malformed

### DIFF
--- a/packages/phoenix-event-display/src/managers/url-options-manager.ts
+++ b/packages/phoenix-event-display/src/managers/url-options-manager.ts
@@ -213,7 +213,16 @@ export class URLOptionsManager {
     Object.keys(filesWithData)
       .filter((fileName) => fileName.endsWith('.json'))
       .forEach((fileName) => {
-        Object.assign(allEventsObject, JSON.parse(filesWithData[fileName]));
+        // The zip comes from a URL, so an entry may not be valid JSON. Report
+        // the bad file and carry on, rather than losing the whole archive.
+        try {
+          Object.assign(allEventsObject, JSON.parse(filesWithData[fileName]));
+        } catch (error) {
+          console.error(`Could not parse ${fileName} - invalid JSON.`, error);
+          this.eventDisplay
+            .getInfoLogger()
+            .add(`Could not parse ${fileName}`, 'Error');
+        }
       });
 
     // JiveXML event data

--- a/packages/phoenix-event-display/src/tests/managers/url-options-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/url-options-manager.test.ts
@@ -27,6 +27,11 @@ jest.mock('../../event-display', () => {
   };
 });
 
+jest.mock('../../helpers/zip', () => ({
+  readZipFile: jest.fn(),
+}));
+import { readZipFile } from '../../helpers/zip';
+
 describe('URLOptionsManager', () => {
   let urlOptionsManager: URLOptionsManager;
   let urlOptionsManagerPrivate: any;
@@ -188,6 +193,43 @@ describe('URLOptionsManager', () => {
       expect(opts.credentials).toBe('omit');
       expect(opts.referrerPolicy).toBe('no-referrer');
       expect(opts.signal).toBeDefined();
+    });
+  });
+
+  describe('handleZipFileEvents', () => {
+    /** Build a manager whose event display records what it is handed. */
+    const setUpManager = () => {
+      const parsePhoenixEvents = jest.fn();
+      const infoLoggerAdd = jest.fn();
+      const display: any = {
+        parsePhoenixEvents,
+        getInfoLogger: () => ({ add: infoLoggerAdd }),
+      };
+      window.fetch = jest.fn().mockResolvedValue({
+        arrayBuffer: async () => new ArrayBuffer(8),
+      }) as any;
+      const manager: any = new URLOptionsManager(display, configuration);
+      return { manager, parsePhoenixEvents, infoLoggerAdd };
+    };
+
+    it('should skip a malformed JSON entry and still load the valid ones', async () => {
+      (readZipFile as jest.Mock).mockResolvedValue({
+        'broken.json': '{ this is not valid json',
+        'good.json': '{"validEvent": {"event number": 1}}',
+      });
+      const { manager, parsePhoenixEvents, infoLoggerAdd } = setUpManager();
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        manager.handleZipFileEvents('https://example.com/events.zip'),
+      ).resolves.not.toThrow();
+
+      expect(parsePhoenixEvents).toHaveBeenCalled();
+      expect(parsePhoenixEvents.mock.calls[0][0]).toHaveProperty('validEvent');
+      expect(infoLoggerAdd).toHaveBeenCalledWith(
+        'Could not parse broken.json',
+        'Error',
+      );
     });
   });
 });


### PR DESCRIPTION
## Problem

`handleZipFileEvents` called `JSON.parse` on every `.json` entry of a zip loaded from a URL with no error handling. The `try`/`catch` above it only covers `readZipFile`, so a `SyntaxError` from a bad entry escaped past it and rejected the promise, where nothing caught it.

The damage went well beyond skipping the bad file:

- The JiveXML block below never ran, so valid `.xml` entries in the same archive were dropped too.
- `parsePhoenixEvents` was never reached, so nothing from the archive loaded at all.
- The rejection was unhandled, so the user saw an empty display with no indication of what went wrong.

A zip bundles many events, so one corrupt or truncated file discarded all the others.

## Fix

Wrap the parse per file, report the bad entry through `console.error` and the info logger, and carry on with the rest of the archive.

This matches the convention established in #994 for #991, which guarded the two `loadFile` sites in `state-manager.ts` and `ui-manager/index.ts`. This zip path has the same defect and was not part of that change; the `readZipFile` failure directly above it already reports through the info logger this way.

## Tests

Added a test covering that a malformed entry is reported and skipped while the valid entries still load. It fails before this change and passes after.

The rest of the `phoenix-event-display` suite is unaffected: 361 passing.

Fixes #1003
