### PR TITLE
fix(ui-components): close the dialog when a download animation cannot start

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/animate-camera.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/animate-camera.component.test.ts
@@ -1,8 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+jest.mock('recordrtc', () => {
+  const RecordRTCMock: any = jest.fn().mockImplementation(() => ({
+    startRecording: jest.fn(),
+    stopRecording: jest.fn((cb: () => void) => cb()),
+    getBlob: jest.fn(),
+  }));
+  RecordRTCMock.invokeSaveAsDialog = jest.fn();
+  return { __esModule: true, default: RecordRTCMock };
+});
+
 import { AnimateCameraComponent } from './animate-camera.component';
 import { EventDisplayService } from '../../../services/event-display.service';
 import { PhoenixUIModule } from '../../phoenix-ui.module';
+import { MatDialog } from '@angular/material/dialog';
 
 describe('AnimateCameraComponent', () => {
   let component: AnimateCameraComponent;
@@ -55,5 +66,52 @@ describe('AnimateCameraComponent', () => {
     jest.spyOn(mockEventDisplay, 'animateThroughEvent');
     component.animatePreset('test');
     expect(mockEventDisplay.animateThroughEvent).toHaveBeenCalled();
+  });
+
+  describe('downloadAnimation while an animation is already running', () => {
+    it('should close the progress dialog and stop the timer', () => {
+      jest.useFakeTimers();
+      const close = jest.fn();
+      const dialog = TestBed.inject(MatDialog);
+      jest.spyOn(dialog, 'open').mockReturnValue({ close } as any);
+
+      // The canvas is only reachable through the renderer, which the mock
+      // display does not build, so stub the capture path.
+      const canvas = document.createElement('canvas');
+      (canvas as any).captureStream = jest.fn().mockReturnValue({});
+      (mockEventDisplay as any).getRendererManager = jest
+        .fn()
+        .mockReturnValue({ getMainRenderer: () => ({ domElement: canvas }) });
+
+      // An animation is already in flight, so `animateCamera` bails out.
+      component.isAnimating = true;
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+      component.downloadAnimation();
+
+      expect(close).toHaveBeenCalled();
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('should leave the dialog open while the animation records', () => {
+      jest.useFakeTimers();
+      const close = jest.fn();
+      const dialog = TestBed.inject(MatDialog);
+      jest.spyOn(dialog, 'open').mockReturnValue({ close } as any);
+
+      const canvas = document.createElement('canvas');
+      (canvas as any).captureStream = jest.fn().mockReturnValue({});
+      (mockEventDisplay as any).getRendererManager = jest
+        .fn()
+        .mockReturnValue({ getMainRenderer: () => ({ domElement: canvas }) });
+
+      component.isAnimating = false;
+      component.downloadAnimation();
+
+      // The animation started, so the dialog stays up until it finishes.
+      expect(close).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
   });
 });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/animate-camera.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/animate-camera.component.ts
@@ -127,29 +127,47 @@ export class AnimateCameraComponent {
       });
     };
 
-    if (preset) {
-      this.animatePreset(preset, onEnd);
-    } else {
-      this.animateCamera(onEnd);
+    // `animateCamera` refuses to start while another animation is running. If
+    // it does not start, nothing will ever call `onEnd`, so the interval would
+    // run forever behind a dialog the user cannot dismiss.
+    const started = preset
+      ? this.animatePreset(preset, onEnd)
+      : this.animateCamera(onEnd);
+
+    if (!started) {
+      clearInterval(interval);
+      recorder.stopRecording(() => dialogRef.close());
     }
   }
 
-  animatePreset(preset: string, onEnd?: () => void) {
+  /**
+   * Animate through the given preset.
+   * @returns Whether the animation was started.
+   */
+  animatePreset(preset: string, onEnd?: () => void): boolean {
     this.setDetectorOpacity(0.2);
     this.eventDisplay.animatePreset(this.animationPresets[preset], () => {
       this.setDetectorOpacity(1);
       if (onEnd) onEnd();
     });
+    return true;
   }
 
-  animateCamera(onEnd?: () => void) {
-    if (!this.isAnimating) {
-      this.isAnimating = true;
-      this.eventDisplay.animateThroughEvent([11976, 7262, 11927], 3000, () => {
-        this.isAnimating = false;
-        if (onEnd) onEnd();
-      });
+  /**
+   * Animate the camera through the event.
+   * @returns Whether the animation was started. It is refused while another
+   * animation is already running.
+   */
+  animateCamera(onEnd?: () => void): boolean {
+    if (this.isAnimating) {
+      return false;
     }
+    this.isAnimating = true;
+    this.eventDisplay.animateThroughEvent([11976, 7262, 11927], 3000, () => {
+      this.isAnimating = false;
+      if (onEnd) onEnd();
+    });
+    return true;
   }
 
   private setDetectorOpacity(opacity: number) {


### PR DESCRIPTION
Fixes #1005

### What was wrong

Clicking **Download animation** while a camera animation was already running left a progress dialog on screen with no way to dismiss it, short of reloading the page. A `setInterval` timer and an active `RecordRTC` recorder were leaked alongside it, and no file was ever produced.

`downloadAnimation` opens the dialog, starts the interval and the recorder, then starts the animation and relies on its completion callback to tear all three down:

```ts
const onEnd = () => {
  clearInterval(interval);
  progress$.next(100);
  recorder.stopRecording(() => { /* save + dialogRef.close() */ });
};

if (preset) {
  this.animatePreset(preset, onEnd);
} else {
  this.animateCamera(onEnd);
}
```

`animateCamera` refuses to start while another animation is in flight, and returned nothing to signal it:

```ts
animateCamera(onEnd?: () => void) {
  if (!this.isAnimating) {
    // ...
  }
  // no else branch: onEnd is silently dropped
}
```

When that guard rejected the call, `onEnd` never ran, so the interval, the recorder and the dialog were never cleaned up. The caller had no way to detect that the animation had not started.

Introduced with the download feature in #943.

### The fix

`animateCamera` and `animatePreset` now return whether they actually started the animation. `downloadAnimation` checks that result, and when the animation was refused it clears the interval, stops the recorder and closes the dialog instead of waiting for a callback that will never come.

The behaviour when an animation *does* start is unchanged.

### Tests

Two cases added to `animate-camera.component.test.ts`:

- **Animation already running:** the progress dialog is closed and the timer cleared. This test fails on the current `main` and passes with the fix.
- **Animation starts normally:** the dialog stays open while recording, guarding against over-correction.

`recordrtc` is mocked at module level, and the canvas capture path is stubbed, since the mock event display does not build a renderer.

All 167 tests in the `ui-menu` suite pass. ESLint and Prettier are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
