### PR TITLE
fix(event-display): stop VR movement when the session ends mid-press

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/xr/vr-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/xr/vr-manager.ts
@@ -26,6 +26,8 @@ export class VRManager extends XRManager {
   private onControllerSelectStart: () => void;
   /** Listener for when the "Select Start" button is released. */
   private onControllerSelectEnd: () => void;
+  /** Interval moving the camera while the controller trigger is held. */
+  private movementIntervalId: ReturnType<typeof setInterval> | null = null;
 
   /**
    * Create the VR manager.
@@ -69,6 +71,20 @@ export class VRManager extends XRManager {
       'selectend',
       this.onControllerSelectEnd,
     );
+
+    // The session can end while the trigger is still held, in which case
+    // "selectend" never fires and the movement interval would run forever.
+    this.stopMovement();
+  }
+
+  /**
+   * Stop the interval moving the camera, if one is running.
+   */
+  private stopMovement() {
+    if (this.movementIntervalId !== null) {
+      clearInterval(this.movementIntervalId);
+      this.movementIntervalId = null;
+    }
   }
 
   /**
@@ -112,8 +128,6 @@ export class VRManager extends XRManager {
     const stepDistance = 30;
     // Unit vector in camera direction
     const direction = new Vector3();
-    // Interval ID for the movement interval
-    let intervalId: NodeJS.Timeout;
 
     this.onControllerSelectStart = () => {
       console.log(
@@ -125,14 +139,15 @@ export class VRManager extends XRManager {
       );
 
       // Start movement in camera direction
-      intervalId = setInterval(() => {
+      this.stopMovement();
+      this.movementIntervalId = setInterval(() => {
         this.moveInDirection(direction, stepDistance);
       }, 20);
     };
 
     this.onControllerSelectEnd = () => {
       // Stop the movement
-      clearInterval(intervalId);
+      this.stopMovement();
     };
 
     this.controller1.addEventListener(

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/xr/vr-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/xr/vr-manager.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { VRManager } from '../../../../managers/three-manager/xr/vr-manager';
+
+describe('VRManager', () => {
+  it('should stop the movement interval when the session ends mid-press', () => {
+    jest.useFakeTimers();
+
+    const vrManager: any = Object.create(VRManager.prototype);
+
+    const controller = {
+      position: { toArray: () => [0, 0, 0] },
+      add: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    vrManager.renderer = {
+      xr: {
+        getController: () => controller,
+        getControllerGrip: () => ({ add: jest.fn() }),
+      },
+    };
+    vrManager.getCameraGroup = () => ({ add: jest.fn() });
+    vrManager.cameraGroup = { position: { toArray: () => [0, 0, 0] } };
+    vrManager.moveInDirection = jest.fn();
+    vrManager.currentXRSession = { removeEventListener: jest.fn() };
+
+    vrManager.setupVRControls();
+
+    // The trigger is pressed, which starts the movement interval.
+    vrManager.onControllerSelectStart();
+    jest.advanceTimersByTime(100);
+    expect(vrManager.moveInDirection).toHaveBeenCalled();
+
+    // The session ends while the trigger is still held, so "selectend" never fires.
+    vrManager.onXRSessionEnded();
+
+    vrManager.moveInDirection.mockClear();
+    jest.advanceTimersByTime(1000);
+
+    expect(vrManager.moveInDirection).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Problem

`setupVRControls` starts a `setInterval` that walks the camera forward while the controller trigger is held, and stores its id in `let intervalId`, a local inside `setupVRControls`. Only the `selectend` listener clears it.

Ending a VR session does not fire `selectend`. If the session ends while the trigger is still down, `onXRSessionEnded` removes both controller listeners but cannot reach `intervalId`, so the interval is left running. It calls `moveInDirection` every 20ms for the lifetime of the page, drifting `cameraGroup.position` and `xrCamera.position` long after the session is gone.

Since each press overwrites `intervalId`, an interval orphaned this way can never be cleared by a later press either.

## Changes

* Track the interval on the manager as `movementIntervalId` instead of in the closure, so teardown can reach it.
* Add a `stopMovement` helper that clears the interval when one is running and is safe to call repeatedly.
* Call it from `onXRSessionEnded`, so ending a session always stops the movement.
* Call it at the start of `onControllerSelectStart` as well, so repeated presses cannot stack timers.

## Tests

Adds `src/tests/managers/three-manager/xr/vr-manager.test.ts` with `should stop the movement interval when the session ends mid-press`.

It presses the trigger, advances fake timers to confirm movement started, ends the session without a `selectend`, then advances the timers again and asserts `moveInDirection` is no longer called.

**This test fails before the change**, with `moveInDirection` called 50 more times after the session ended:

```
expect(jest.fn()).not.toHaveBeenCalled()
Expected number of calls: 0
Received number of calls: 50
```

The test builds the manager with `Object.create(VRManager.prototype)` and stubs only what `setupVRControls` touches, so it needs no WebXR device or real WebGL context.

## Pre-existing issues, unrelated to this PR

* `yarn tsc --noEmit` in `phoenix-event-display` reports `src/tests/helpers/webgl-mock.ts(1,8): error TS1192`. This reproduces on a clean `main`.
* In a full parallel run, `src/tests/managers/session-manager/session-codec.test.ts` can time out on the compression-bomb case. It passes on its own, both with and without this change, so it is contention rather than a regression.

Fixes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)
