### PR TITLE
fix(event-display): keep labels visible when an animation cannot run

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/animations-manager.ts
@@ -153,17 +153,17 @@ export class AnimationsManager {
     onEnd?: () => void,
     onAnimationStart?: () => void,
   ) {
+    const eventData = this.scene.getObjectByName(SceneManager.EVENT_DATA_ID);
+    if (!eventData) {
+      return;
+    }
+
     // 🔥 Hide labels at the start of the animation
     const labelsGroup = this.scene.getObjectByName(SceneManager.LABELS_ID);
     if (labelsGroup) labelsGroup.visible = false;
 
     const extraAnimationSphereDuration = tweenDuration * 0.25;
     tweenDuration *= 0.75;
-
-    const eventData = this.scene.getObjectByName(SceneManager.EVENT_DATA_ID);
-    if (!eventData) {
-      return;
-    }
 
     const animationSphere = new Sphere(new Vector3(), 0);
     const objectsToAnimateWithSphere: {

--- a/packages/phoenix-event-display/src/tests/managers/three-manager/animations-manager.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/three-manager/animations-manager.test.ts
@@ -56,6 +56,20 @@ describe('AnimationsManager', () => {
     expect((animationsManager as any).getHitsPositions(hits).length).toBe(2);
   });
 
+  it('should restore the labels when there is no event data to animate', () => {
+    const labelsGroup = new Object3D();
+    labelsGroup.name = SceneManager.LABELS_ID;
+    labelsGroup.visible = true;
+    scene.add(labelsGroup);
+
+    // No event data has been loaded, so the animation cannot run.
+    expect(scene.getObjectByName(SceneManager.EVENT_DATA_ID)).toBeUndefined();
+
+    animationsManager.animateEvent(500);
+
+    expect(labelsGroup.visible).toBe(true);
+  });
+
   describe('It depends on the event data', () => {
     beforeEach(() => {
       const mockEventData = new Object3D();


### PR DESCRIPTION
## Problem

`animateEvent` hid the labels group before checking that there is any event data to animate:

```ts
const labelsGroup = this.scene.getObjectByName(SceneManager.LABELS_ID);
if (labelsGroup) labelsGroup.visible = false;
...
const eventData = this.scene.getObjectByName(SceneManager.EVENT_DATA_ID);
if (!eventData) {
  return;
}
```

Labels are restored in `animationSphereTweenClone.onComplete`, which only exists once the animation is set up. The `!eventData` guard returns between the hide and that `onComplete`, so on that path nothing ever restores them. The labels stay hidden for the rest of the session, and loading event data or toggling labels in the UI does not bring them back.

The sibling `animateEventWithClipping` already looks up the event data and returns before touching the labels.

## Changes

Move the event data lookup above the label hiding in `animateEvent`, so labels are only hidden once the animation is actually going to run. This makes the two animation entrypoints guard in the same order.

The change is a reordering only. No behaviour changes on the path where event data exists.

## Tests

Adds `should restore the labels when there is no event data to animate` to the existing `animations-manager.test.ts`. It is placed outside the `It depends on the event data` describe block, so no event data is present, and asserts the labels group is still visible after `animateEvent` returns.

**This test fails before the change:**

```
expect(received).toBe(expected) // Object.is equality
Expected: true
Received: false
```

All 8 tests in the file pass after it.

## Pre-existing issues, unrelated to this PR

* `yarn tsc --noEmit` in `phoenix-event-display` reports `src/tests/helpers/webgl-mock.ts(1,8): error TS1192`, which reproduces on a clean `main`.
* In a full parallel run, `session-codec.test.ts` can time out on the compression-bomb case. It passes on its own with and without this change.

Fixes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
