### PR TITLE
fix(ui-components): guard view options teardown before init

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.test.ts
@@ -182,6 +182,14 @@ describe('ViewOptionsComponent', () => {
     );
   });
 
+  it('should not throw when destroyed before the subscription is created', () => {
+    // A component destroyed before ngOnInit runs has no subscription to drop.
+    const uninitialized =
+      TestBed.createComponent(ViewOptionsComponent).componentInstance;
+
+    expect(() => uninitialized.ngOnDestroy()).not.toThrow();
+  });
+
   it('should unsubscribe the existing subscriptions', () => {
     component.sub = new Subscription();
     const spy = jest.spyOn(component.sub, 'unsubscribe');

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/view-options/view-options.component.ts
@@ -92,6 +92,8 @@ export class ViewOptionsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.sub.unsubscribe();
+    // The component can be destroyed before ngOnInit has created the
+    // subscription, so guard rather than dereferencing it unconditionally.
+    this.sub?.unsubscribe();
   }
 }


### PR DESCRIPTION
## Problem

`ViewOptionsComponent.ngOnDestroy` called `this.sub.unsubscribe()` unconditionally, but `sub` is declared without an initialiser and only assigned in `ngOnInit`.

Angular does not guarantee `ngOnInit` has completed before `ngOnDestroy` runs. A component destroyed in the same change detection pass that created it, or one whose `ngOnInit` threw before reaching the assignment, hits `ngOnDestroy` with `sub` still `undefined` and throws:

```
TypeError: Cannot read properties of undefined (reading 'unsubscribe')
```

The throw happens inside Angular's cleanup, so Angular reports `1 component threw errors during cleanup` and abandons the rest of the teardown for that view. Sibling components can then miss their own `ngOnDestroy` and leak in turn.

`ngOnInit` calls `getPresetViews()` before assigning `sub`, so a failure in that call leaves the component in exactly this state.

## Changes

Use optional chaining in `ngOnDestroy` so destroying an uninitialised component is a no-op.

This matches `CartesianGridConfigComponent`, which was given the same guard in #993 for #989. That component subscribes to the same `originChanged` emitter; `ViewOptionsComponent` was not covered by that change.

## Tests

Adds `should not throw when destroyed before the subscription is created` to the existing `view-options.component.test.ts`. It creates a fresh component without running `ngOnInit` and asserts `ngOnDestroy` does not throw.

**This test fails before the change**, with the `TypeError` above plus Angular's `1 component threw errors during cleanup`.

All 12 tests in the file pass after it, including the existing `should unsubscribe the existing subscriptions`, which confirms a real subscription is still unsubscribed.

The full `phoenix-ng` suite passes: 213 passed, 7 skipped, 0 failed.

Fixes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)
