### PR TITLE
fix(event-display): drop pending state changes on cleanup

### DIFF
--- a/packages/phoenix-event-display/src/event-display.ts
+++ b/packages/phoenix-event-display/src/event-display.ts
@@ -152,9 +152,15 @@ export class EventDisplay {
     }
     // Stop any active session recording or playback
     this.sessionManager?.cleanup();
+    // Drop any debounced state change so its callbacks cannot run after teardown
+    if (this.stateChangeTimeout) {
+      clearTimeout(this.stateChangeTimeout);
+      this.stateChangeTimeout = null;
+    }
     // Clear accumulated callbacks
     this.onEventsChange = [];
     this.onDisplayedEventChange = [];
+    this.onStateChange = [];
     this.eventBus.clear();
     this.eventBusWildcard.clear();
     // Reset singletons for clean view transition

--- a/packages/phoenix-event-display/src/tests/event-display.test.ts
+++ b/packages/phoenix-event-display/src/tests/event-display.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import { EventDisplay } from '../event-display';
+
+describe('EventDisplay', () => {
+  describe('cleanup', () => {
+    let eventDisplay: any;
+
+    beforeEach(() => {
+      // `cleanup` is exercised on a bare instance so the test does not need a
+      // WebGL context, a DOM host element or a loaded configuration.
+      eventDisplay = Object.create(EventDisplay.prototype);
+      eventDisplay.onEventsChange = [];
+      eventDisplay.onDisplayedEventChange = [];
+      eventDisplay.onStateChange = [];
+      eventDisplay.eventBus = new Map();
+      eventDisplay.eventBusWildcard = new Set();
+      eventDisplay.stateChangeTimeout = null;
+    });
+
+    it('should not run pending state change callbacks after cleanup', () => {
+      jest.useFakeTimers();
+
+      const callback = jest.fn();
+      eventDisplay.onStateChange.push(callback);
+
+      // A state change is queued, then the display is torn down before the
+      // debounced callbacks get a chance to run.
+      eventDisplay.triggerStateChange();
+      eventDisplay.cleanup();
+
+      jest.runAllTimers();
+
+      expect(callback).not.toHaveBeenCalled();
+
+      jest.useRealTimers();
+    });
+
+    it('should clear the state change callbacks', () => {
+      eventDisplay.onStateChange.push(jest.fn());
+
+      eventDisplay.cleanup();
+
+      expect(eventDisplay.onStateChange).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Two related gaps in `EventDisplay.cleanup`.

**The debounced state change timer was never cancelled.** `triggerStateChange` queues the callbacks behind a `setTimeout`. `cleanup` tears down the graphics library and resets `loadingManager` and `stateManager`, but leaves that timer armed. It fires a tick later and runs every `onStateChange` callback against a display whose managers have just been reset.

**`onStateChange` was never cleared.** `cleanup` empties `onEventsChange` and `onDisplayedEventChange` under a `Clear accumulated callbacks` comment, but `onStateChange` is not in that list. Callbacks from a previous view stay subscribed across a re-initialisation, so after the next view registers its own, both sets fire on every state change and the stale closures keep the old view alive for the rest of the page's life.

Given the two adjacent arrays are handled, the omission looks unintentional.

## Changes

* Clear `stateChangeTimeout` in `cleanup` so a queued state change cannot run after teardown.
* Reset `onStateChange` alongside the other two callback arrays.

## Tests

Adds `src/tests/event-display.test.ts` with two cases:

* `should not run pending state change callbacks after cleanup` — queues a state change, calls `cleanup`, runs all timers, and asserts the callback never fired.
* `should clear the state change callbacks` — asserts `onStateChange` is empty after `cleanup`.

**Both fail before the change.** The first sees the callback invoked; the second finds the array still populated:

```
- Array []
+ Array [
+   [Function mockConstructor],
+ ]
```

`cleanup` is exercised on a bare instance via `Object.create(EventDisplay.prototype)`, so the test needs no WebGL context, host element or loaded configuration.

## Pre-existing issues, unrelated to this PR

* `yarn tsc --noEmit` in `phoenix-event-display` reports `src/tests/helpers/webgl-mock.ts(1,8): error TS1192`, which reproduces on a clean `main`.
* In a full parallel run, `session-codec.test.ts` can time out on the compression-bomb case. It passes on its own both with and without this change, so it is contention rather than a regression. The rest of the suite is green: 362 passed.

Fixes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)
