### PR TITLE
fix(ui-components): unsubscribe from download progress on destroy

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/download-animation-dialog/download-animation-dialog.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/download-animation-dialog/download-animation-dialog.component.test.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { BehaviorSubject } from 'rxjs';
+import { PhoenixUIModule } from 'phoenix-ui-components';
+import { DownloadAnimationDialogComponent } from './download-animation-dialog.component';
+
+describe('DownloadAnimationDialogComponent', () => {
+  let component: DownloadAnimationDialogComponent;
+  let progress$: BehaviorSubject<number>;
+
+  beforeEach(() => {
+    progress$ = new BehaviorSubject<number>(0);
+
+    TestBed.configureTestingModule({
+      imports: [PhoenixUIModule],
+      declarations: [DownloadAnimationDialogComponent],
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: { progress$ },
+        },
+      ],
+    }).compileComponents();
+
+    component = TestBed.createComponent(
+      DownloadAnimationDialogComponent,
+    ).componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should track the reported progress', () => {
+    component.ngOnInit();
+    progress$.next(42);
+
+    expect(component.progress).toBe(42);
+  });
+
+  it('should stop listening to progress once destroyed', () => {
+    component.ngOnInit();
+    progress$.next(30);
+
+    component.ngOnDestroy();
+    progress$.next(90);
+
+    // The dialog is gone, so late progress must not reach it.
+    expect(component.progress).toBe(30);
+    expect(progress$.observed).toBe(false);
+  });
+});

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/download-animation-dialog/download-animation-dialog.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/animate-camera/download-animation-dialog/download-animation-dialog.component.ts
@@ -1,6 +1,6 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 @Component({
   standalone: false,
@@ -8,16 +8,23 @@ import { Observable } from 'rxjs';
   templateUrl: './download-animation-dialog.component.html',
   styleUrls: ['./download-animation-dialog.component.scss'],
 })
-export class DownloadAnimationDialogComponent implements OnInit {
+export class DownloadAnimationDialogComponent implements OnInit, OnDestroy {
   progress = 0;
+  private progressSub?: Subscription;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { progress$: Observable<number> },
   ) {}
 
   ngOnInit(): void {
-    this.data.progress$.subscribe((val) => {
+    this.progressSub = this.data.progress$.subscribe((val) => {
       this.progress = val;
     });
+  }
+
+  ngOnDestroy(): void {
+    // `progress$` is a BehaviorSubject that is never completed, so the
+    // subscription outlives the dialog unless it is dropped here.
+    this.progressSub?.unsubscribe();
   }
 }


### PR DESCRIPTION
## Problem

`DownloadAnimationDialogComponent` subscribed to `progress$` in `ngOnInit` and discarded the returned `Subscription`. The component implemented `OnInit` only, with no `OnDestroy`.

That would be harmless if the source completed, but it does not. `downloadAnimation` creates a `BehaviorSubject` per download, feeds it from an interval, pushes `100` in `onEnd`, and never calls `complete()`. So closing the dialog leaves the subscription open, holding the destroyed component and its closure alive, and still willing to write `this.progress` on a torn-down component.

Because a new subject and dialog are created per download, the leak repeats every time a user downloads an animation.

## Changes

* Implement `OnDestroy` and unsubscribe there.
* Keep the subscription in a `progressSub` field, guarded with optional chaining so destroying before `ngOnInit` is safe.

The fix is confined to the dialog component. It does not touch `animate-camera.component.ts`, so it does not overlap with #1006.

## Tests

Adds `download-animation-dialog.component.test.ts`, which had no test file before. Three cases:

* `should create`
* `should track the reported progress` — confirms emissions still reach the component
* `should stop listening to progress once destroyed` — emits, destroys, emits again, and asserts the late value never lands and `progress$.observed` is `false`

**The teardown test fails before the change:**

```
TypeError: component.ngOnDestroy is not a function
```

All three pass after it. The full `phoenix-ng` suite is green: 213 passed, 7 skipped, 0 failed.

Fixes #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)
