### PR TITLE
fix(ui-components,event-display): declare imported deps, drop dead ones

### DIFF
--- a/packages/phoenix-event-display/package.json
+++ b/packages/phoenix-event-display/package.json
@@ -38,18 +38,15 @@
     "eslint:fix": "yarn eslint --fix"
   },
   "dependencies": {
-    "@babel/core": "^8.0.0",
     "@tweenjs/tween.js": "^25.0.0",
     "dat.gui": "^0.7.9",
     "html2canvas": "^1.4.1",
     "jsroot": "^7.11.0",
     "jszip": "^3.10.1",
-    "stats-js": "^1.0.1",
     "three": "~0.184.0"
   },
   "devDependencies": {
     "@babel/helper-string-parser": "^7.27.1",
-    "@babel/plugin-transform-runtime": "^7.28.5",
     "@compodoc/compodoc": "^1.2.1",
     "@types/dat.gui": "^0.7.13",
     "@types/three": "~0.184.1",

--- a/packages/phoenix-ng/projects/phoenix-ui-components/package.json
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/package.json
@@ -21,6 +21,7 @@
     "@angular/compiler": "*",
     "@angular/core": "*",
     "@angular/platform-browser-dynamic": "*",
+    "@angular/router": "*",
     "phoenix-event-display": "*",
     "zone.js": "*"
   },
@@ -31,12 +32,15 @@
     "@angular/material": "^20.2.14",
     "@angular/platform-browser": "^20.3.28",
     "css-element-queries": "^1.2.3",
+    "jszip": "^3.10.1",
     "qrcode": "1.5.4",
+    "recordrtc": "^5.6.2",
     "rxjs": "^7.8.2",
     "three": "~0.184.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
+    "@types/recordrtc": "^5.6.15",
     "node-fetch": "^3.3.2",
     "rimraf": "^6.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,16 +743,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/code-frame@npm:8.0.0"
-  dependencies:
-    "@babel/helper-validator-identifier": ^8.0.0
-    js-tokens: ^10.0.0
-  checksum: b0cab876cd938f3e5101ada3f1708b9a84c22bdcb6a9497ad4db17fc0600e1d32e0a3a159ecf53562c92720a714bc5275a171bcfeabeeb1b3247cd8afb757b9c
-  languageName: node
-  linkType: hard
-
 "@babel/compat-data@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/compat-data@npm:7.27.2"
@@ -778,13 +768,6 @@ __metadata:
   version: 7.29.7
   resolution: "@babel/compat-data@npm:7.29.7"
   checksum: 4424f8fb72f61657c8e811bdf7e5c69af212a15fe362711162b2e00b82f0e0588fb8259ecd9a70c5490562bf51d408b0cb92f277ead71a2390ddddfe7283b35d
-  languageName: node
-  linkType: hard
-
-"@babel/compat-data@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/compat-data@npm:8.0.0"
-  checksum: 058468d5296443a59d3bef98eaaa6a80adbfbb39e42d30bcdf64463bfa23b78fb84e90c60a5a20ced746f9de4f6094a8201e894f2155b9ea52ea89714d2700b3
   languageName: node
   linkType: hard
 
@@ -854,30 +837,6 @@ __metadata:
     json5: ^2.2.3
     semver: ^6.3.1
   checksum: 95149e98ffde5b9d903459c284fbcf1f9ad8b3a833d69fdfe1aa7185821a102af1925324fe2892caf4b643b151c1dc948510d1e25a5e3c6c6c6f17f6712eb38e
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^8.0.0":
-  version: 8.0.1
-  resolution: "@babel/core@npm:8.0.1"
-  dependencies:
-    "@babel/code-frame": ^8.0.0
-    "@babel/generator": ^8.0.0
-    "@babel/helper-compilation-targets": ^8.0.0
-    "@babel/helpers": ^8.0.0
-    "@babel/parser": ^8.0.0
-    "@babel/template": ^8.0.0
-    "@babel/traverse": ^8.0.0
-    "@babel/types": ^8.0.0
-    "@types/gensync": ^1.0.5
-    convert-source-map: ^2.0.0
-    empathic: ^2.0.1
-    gensync: ^1.0.0-beta.2
-    import-meta-resolve: ^4.2.0
-    json5: ^2.2.3
-    obug: ^2.1.1
-    semver: ^7.7.3
-  checksum: 567910df2a92707fb5c87ce424d58ab47515b75703509b6e42fff0ac443d93a16fe2472ad365aa798b88b5d82fa866348ebbfc4223bade51ba341528667b06b9
   languageName: node
   linkType: hard
 
@@ -971,20 +930,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/generator@npm:8.0.0"
-  dependencies:
-    "@babel/parser": ^8.0.0
-    "@babel/types": ^8.0.0
-    "@jridgewell/gen-mapping": ^0.3.12
-    "@jridgewell/trace-mapping": ^0.3.28
-    "@types/jsesc": ^2.5.0
-    jsesc: ^3.0.2
-  checksum: 9b8e5d67cf78640fa50659540646129fc980ed1d9f5f92266cec14365106508cd4595e34df261d486fdf4f55ecc4b397841fa261e727f864c80578e58aabb8aa
-  languageName: node
-  linkType: hard
-
 "@babel/helper-annotate-as-pure@npm:7.27.3, @babel/helper-annotate-as-pure@npm:^7.27.3":
   version: 7.27.3
   resolution: "@babel/helper-annotate-as-pure@npm:7.27.3"
@@ -1044,19 +989,6 @@ __metadata:
     lru-cache: ^5.1.1
     semver: ^6.3.1
   checksum: f60a943937f4eba0e671aa28551cb45569fd081c1e30a52ede167860475dc0417f3dbdf2a0fa3f086965595c7070aa76308da60cc0319860de05db4ed2a431f7
-  languageName: node
-  linkType: hard
-
-"@babel/helper-compilation-targets@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/helper-compilation-targets@npm:8.0.0"
-  dependencies:
-    "@babel/compat-data": ^8.0.0
-    "@babel/helper-validator-option": ^8.0.0
-    browserslist: ^4.24.0
-    lru-cache: ^11.0.0
-    semver: ^7.7.3
-  checksum: 08fc8cbc00716f6688f90981492ec8255ccf51909a485b85de3839c6b578b818b4ffd7fb46b7d695ac77ed90832a9b189b4dbe35c814c1d449a211eab3134749
   languageName: node
   linkType: hard
 
@@ -1176,13 +1108,6 @@ __metadata:
   version: 7.29.7
   resolution: "@babel/helper-globals@npm:7.29.7"
   checksum: 6deaf9846a415c7f110ac153e8c3d81e3543c9b685aa9fd9a59b4235f402e2b760129d3df49466daea9162f0cf73ff98a0ec7f180448a3449ca14ae5e1117b42
-  languageName: node
-  linkType: hard
-
-"@babel/helper-globals@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/helper-globals@npm:8.0.0"
-  checksum: c18299171739cf7ed1ce5c406d0ca2bbb34c8f580f75ccc718b1a771306d7db69182a39dc9b479c811197e0e45ae33bbc1bb0c6b352bdba857cdd68c0c2da4a8
   languageName: node
   linkType: hard
 
@@ -1446,13 +1371,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/helper-string-parser@npm:8.0.0"
-  checksum: 796a8b1e6c598f73c2ab98d3ea192374587cfdea6ec36e43fac428e119d9467c43eb97b48aef678994a80acccac2afac9cab32b74e774790212c9f885bc2d25f
-  languageName: node
-  linkType: hard
-
 "@babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
@@ -1481,13 +1399,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^8.0.0":
-  version: 8.0.2
-  resolution: "@babel/helper-validator-identifier@npm:8.0.2"
-  checksum: 2613625704f52bb5a1d639e0d5ee174053b4ce689144edbefc94038e73101ec466d9defa1275dd17da5d6702657e150beccbb805be7dcae6265fae3c340d2b5c
-  languageName: node
-  linkType: hard
-
 "@babel/helper-validator-option@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
@@ -1499,13 +1410,6 @@ __metadata:
   version: 7.29.7
   resolution: "@babel/helper-validator-option@npm:7.29.7"
   checksum: aeb6aa966f59300d3cc2fea7c68e1dfd7ad011fc10e535c8e2b2de3094b27c859428dc7220f16420350f8b1cde99da120b673be04bcb0c2f37b56258c96bed58
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/helper-validator-option@npm:8.0.0"
-  checksum: 12c2bf5457fbe1ff0701321b4e471420d46a94a2b10858042c7a96134894212ba04224021345c8572ed3eb7b536890deb842ccd7e5f655aa56de594529ec64d0
   languageName: node
   linkType: hard
 
@@ -1548,16 +1452,6 @@ __metadata:
     "@babel/template": ^7.29.7
     "@babel/types": ^7.29.7
   checksum: b5c4ed0ce5983c5599cd01b3948444b77ba2fa47bf6282a82afdcbe45eb8cc5b7986194e3920ef2760f533c6a775504e6b00a66960c0a3bc52909920b8433908
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/helpers@npm:8.0.0"
-  dependencies:
-    "@babel/template": ^8.0.0
-    "@babel/types": ^8.0.0
-  checksum: caf6ecd8ec34c9f5fa6ac57b92b13700726c0d2b04f77b251b64ce1e0a5bd3641bf435450116c5a607eb7fe0a3a00329a406a6ec0b725d3b3baa70205940a617
   languageName: node
   linkType: hard
 
@@ -1647,17 +1541,6 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 56f4c32a371004d3becd0a960a85a3bba4ec4df73d5e202aa3fe6473328b243162c6be9a510be1c12ed1825f5ce9ff1ea5cc357298631e8acf2e5b8da9f5a961
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/parser@npm:8.0.0"
-  dependencies:
-    "@babel/types": ^8.0.0
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 4b565527fa53f980e50c4e97d440b1296f2f44f9b67b6820c1dc7e45cb53af4e9f2c845d6a8831443f2a9976800c3f3e4993fd3c28057b8d7b3fb11e2e50da41
   languageName: node
   linkType: hard
 
@@ -2837,22 +2720,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-runtime@npm:7.28.5"
-  dependencies:
-    "@babel/helper-module-imports": ^7.27.1
-    "@babel/helper-plugin-utils": ^7.27.1
-    babel-plugin-polyfill-corejs2: ^0.4.14
-    babel-plugin-polyfill-corejs3: ^0.13.0
-    babel-plugin-polyfill-regenerator: ^0.6.5
-    semver: ^6.3.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 5bb66f366c5bb22d0c890667ecd0f1fde9db86ac04df62b21fc2bbf58531eb84068bb0bf38fb1c496c8f78a917c59a884f6c1f8b205b8689d155e72fcf1d442d
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-transform-shorthand-properties@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.27.1"
@@ -3230,17 +3097,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/template@npm:8.0.0"
-  dependencies:
-    "@babel/code-frame": ^8.0.0
-    "@babel/parser": ^8.0.0
-    "@babel/types": ^8.0.0
-  checksum: a243ac9b658ffc890fd283510b03b234390237430ff9777a4f7fc9046def3e62dd83824098b9958e127e1f09d1657531b5833218c7440df188e16bf7de0736b3
-  languageName: node
-  linkType: hard
-
 "@babel/traverse@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/traverse@npm:7.27.1"
@@ -3316,21 +3172,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/traverse@npm:8.0.0"
-  dependencies:
-    "@babel/code-frame": ^8.0.0
-    "@babel/generator": ^8.0.0
-    "@babel/helper-globals": ^8.0.0
-    "@babel/parser": ^8.0.0
-    "@babel/template": ^8.0.0
-    "@babel/types": ^8.0.0
-    obug: ^2.1.1
-  checksum: b047d7c55427de48919d3948d2dea973747eb32f2fee1154bb8eed38a8c5c39d0c4bab589911ab9228c9d0d50377a5aef7e55bb4e8e27b71071f1e6792114886
-  languageName: node
-  linkType: hard
-
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.7, @babel/types@npm:^7.25.0, @babel/types@npm:^7.25.6, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.25.6
   resolution: "@babel/types@npm:7.25.6"
@@ -3389,16 +3230,6 @@ __metadata:
     "@babel/helper-string-parser": ^7.29.7
     "@babel/helper-validator-identifier": ^7.29.7
   checksum: 71c46837d22c5c63a5ed571f3b68b4261ecabfc3d4be7251b336ccbd26bc52752ae68ae6d16d24ea512311b78b6f54efdfb00dde87a81a4dc3d19e4a45f05b20
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/types@npm:8.0.0"
-  dependencies:
-    "@babel/helper-string-parser": ^8.0.0
-    "@babel/helper-validator-identifier": ^8.0.0
-  checksum: 9f03e85dd1e803d5b2f860fb46ed5ccb04fddf47e053ce826e42a52b5d59fec7d2a01265bbda2eb5f25c3a9eaa761cba1b3e6264a2ead22410891a675fdd4a42
   languageName: node
   linkType: hard
 
@@ -7210,13 +7041,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/gensync@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "@types/gensync@npm:1.0.5"
-  checksum: 1b417012a1249c60d2a5d3a646c208710473f31ab91ee702d4a0bf742d4d20a04c4296efcf6f42b7c1b38536ff732c3aa00dd5afc8fa138c70d1905a0521a5c3
-  languageName: node
-  linkType: hard
-
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.9
   resolution: "@types/graceful-fs@npm:4.1.9"
@@ -7285,13 +7109,6 @@ __metadata:
     "@types/tough-cookie": "*"
     parse5: ^7.0.0
   checksum: d55402c5256ef451f93a6e3d3881f98339fe73a5ac2030588df056d6835df8367b5a857b48d27528289057e26dcdd3f502edc00cb877c79174cb3a4c7f2198c1
-  languageName: node
-  linkType: hard
-
-"@types/jsesc@npm:^2.5.0":
-  version: 2.5.1
-  resolution: "@types/jsesc@npm:2.5.1"
-  checksum: fb4303b059df0b6834f26446712d890a93fa7c446347b61505a925e07c7fab3aaab083940bca0be8d521779a2a6a5c16a75136f6de753f4a65c1f24fd7c6aee6
   languageName: node
   linkType: hard
 
@@ -10890,13 +10707,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"empathic@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "empathic@npm:2.0.1"
-  checksum: c5a37b78926e722c38779e5026342350098771fa1cacb52cb808e5329896ab39abb88cd2f1374671d6e5c98aa24cba2534f00da2938d04f11de1a2d012ee75c3
-  languageName: node
-  linkType: hard
-
 "encodeurl@npm:^2.0.0, encodeurl@npm:~2.0.0":
   version: 2.0.0
   resolution: "encodeurl@npm:2.0.0"
@@ -13381,13 +13191,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-meta-resolve@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "import-meta-resolve@npm:4.2.0"
-  checksum: fe5ca3258f22dc3dd4e2f2e8f6b54324c1cf0261216c7d9aae801b2eadf664bbd61e26cfb907a1238761285a3e9c8c23403321d52ca0e579c341b8d90c97fa52
-  languageName: node
-  linkType: hard
-
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -14527,13 +14330,6 @@ __metadata:
   version: 6.2.0
   resolution: "jose@npm:6.2.0"
   checksum: 6ca6c238b10a3317640c122393d5c52d7fdd3e6c5d2beb7347f091571ba4ade621dc9882264afe583bfc700f4b736d07e06e2c1f6f459951d545cbb5d4c56277
-  languageName: node
-  linkType: hard
-
-"js-tokens@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "js-tokens@npm:10.0.0"
-  checksum: 1bc804299157b0a81543f9975d380aaf9e4bd57853e41623a10ebd364dad30682d2f194d1b0485832cd85a59a0bef21fbfc7a063a95575b782ddecaa804647fb
   languageName: node
   linkType: hard
 
@@ -16880,13 +16676,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"obug@npm:^2.1.1":
-  version: 2.1.3
-  resolution: "obug@npm:2.1.3"
-  checksum: e177b2ce8e2215b602fdc5206a717027ad6dba6c7c7a783f90ad4c5b601d2cd630c80a15b15123ceb218fbb3cfdca58005daaadbe60a9c9e3e9de8923dc4ba54
-  languageName: node
-  linkType: hard
-
 "on-finished@npm:2.4.1, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -17583,9 +17372,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "phoenix-event-display@workspace:packages/phoenix-event-display"
   dependencies:
-    "@babel/core": ^8.0.0
     "@babel/helper-string-parser": ^7.27.1
-    "@babel/plugin-transform-runtime": ^7.28.5
     "@compodoc/compodoc": ^1.2.1
     "@tweenjs/tween.js": ^25.0.0
     "@types/dat.gui": ^0.7.13
@@ -17596,7 +17383,6 @@ __metadata:
     jest: ^29.7.0
     jsroot: ^7.11.0
     jszip: ^3.10.1
-    stats-js: ^1.0.1
     three: ~0.184.0
     ts-jest: ^29.3.4
     typescript: ~5.8.2
@@ -17660,9 +17446,12 @@ __metadata:
     "@angular/forms": ^20.3.28
     "@angular/material": ^20.2.14
     "@angular/platform-browser": ^20.3.28
+    "@types/recordrtc": ^5.6.15
     css-element-queries: ^1.2.3
+    jszip: ^3.10.1
     node-fetch: ^3.3.2
     qrcode: 1.5.4
+    recordrtc: ^5.6.2
     rimraf: ^6.1.2
     rxjs: ^7.8.2
     three: ~0.184.0
@@ -17672,6 +17461,7 @@ __metadata:
     "@angular/compiler": "*"
     "@angular/core": "*"
     "@angular/platform-browser-dynamic": "*"
+    "@angular/router": "*"
     phoenix-event-display: "*"
     zone.js: "*"
   languageName: unknown
@@ -19864,13 +19654,6 @@ __metadata:
   version: 2.7.0
   resolution: "stackblur-canvas@npm:2.7.0"
   checksum: 05b37ef9f1ba3aac2a1dda2f2c078cacd0668426ef689dbbfac7e90c79ef05e8dfad8e0d8474a1cc52776c5810e224ef163cbee2ec52f0a320dec8352ab2dece
-  languageName: node
-  linkType: hard
-
-"stats-js@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "stats-js@npm:1.0.1"
-  checksum: ded4c72874e04ea78da121ceb0a6821079b1485d91f86701b85c1d0c6c250da23960ad76be7d3fb665602571071b040203aa250e6dd875a191a0bdd132a90dc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1017, plus two more instances of the same bug and some dead weight.

## The reported bug

`phoenix-ui-components` imports `recordrtc` in `animate-camera.component.ts` but never declared it, so it survives as an unresolvable bare import in the shipped `dist/fesm2022/phoenix-ui-components.mjs`. It was only ever declared in the *app's* `package.json` and at the repo root, which is why it builds here but not for consumers.

## Two more of exactly the same kind

Diffing every bare import in the built fesm bundle against the declared deps turned up two others:

| Package | Imported at | Was declared? |
|---|---|---|
| `recordrtc` | `animate-camera.component.ts` | no — #1017 |
| `jszip` | `services/file-loader.service.ts` | no |
| `@angular/router` | `components/phoenix-ui.module.ts` | no |

All three are runtime value imports, not type-only.

**Why only `recordrtc` got reported:** the other two normally resolve by luck. `jszip` is a dependency of `phoenix-event-display` (a peer of this package), so it lands in `node_modules` transitively; `@angular/router` is present in virtually every Angular app. Under strict resolution (pnpm, Yarn PnP), or in an app without the router, both fail identically. `recordrtc` is just the one nobody happens to already have.

`@angular/router` is declared as a **peer** dependency alongside the other Angular packages, to avoid a duplicate router instance. `jszip` and `recordrtc` are runtime **dependencies**. `@types/recordrtc` is added as a devDependency because `recordrtc` ships no types.

## Dead runtime dependencies removed

`phoenix-event-display` declared `@babel/core` (`^8.0.0`) and `stats-js` as runtime `dependencies`, but neither is imported anywhere in `src/` or `configs/` — the bundle is built with `esbuild-loader` and the tests run under `ts-jest`. `@babel/core` appeared in no file except `package.json` itself. Every consumer was installing Babel for nothing.

`@babel/plugin-transform-runtime` is removed along with them: it is equally unused, and was the only remaining thing requesting `@babel/core` as a peer.

## Verification

- Every bare import in the rebuilt fesm bundle now resolves from declared deps (checked programmatically).
- `phoenix-event-display`: `yarn build` + `yarn build:bundle` clean; **372 tests pass**.
- `phoenix-ng` / `phoenix-ui-components`: production `ng build` clean; **216 tests pass**.
- `yarn install` no longer emits the `@babel/core` unmet-peer warning.

## Not addressed here

`phoenix-event-display` also imports `EventEmitter` from `@angular/core` in `managers/three-manager/index.ts`, and declares `@angular/core` in *no* dependency section at all — it reaches both `dist/index.js` and `dist/index.d.ts`. That makes the framework-independent package silently require Angular for one utility class. Fixing it is a design call (declare it as a peer, or drop the coupling for an rxjs `Subject`/local emitter — the latter changes the public type of `originChanged`/`stopShifting`), so it is left for a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
