### PR TITLE
fix(app): better resizing behaviour of panels

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu-item/phoenix-menu-item.component.scss
@@ -229,17 +229,9 @@
 .phoenix-menu-children {
   margin-left: 0.5rem;
   border-left: 1px solid var(--phoenix-accent);
-  max-height: 35vh;
-  overflow-y: auto;
-
-  /* Custom thin scrollbar to avoid clutter */
-  &::-webkit-scrollbar {
-    width: 4px;
-  }
-  &::-webkit-scrollbar-thumb {
-    background: var(--phoenix-text-color-secondary, #999);
-    border-radius: 4px;
-  }
+  /* No height cap here: every level would get its own scrollbar and several
+     open sections would each be squeezed into a small window. `#phoenixMenu`
+     scrolls the menu as a whole instead. */
 }
 
 .range-slider {

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/phoenix-menu/phoenix-menu.component.scss
@@ -9,10 +9,23 @@
 
 #phoenixMenu {
   background: var(--phoenix-background-color-secondary);
-  max-height: 75vh;
+  /* Grow to whatever the window allows, leaving room for the `top` offset
+     above and the shortcuts button below, and scroll as a single list once
+     there is more than that. Nested levels must not cap themselves, or the
+     menu ends up as a stack of tiny scroll boxes. */
+  max-height: calc(100vh - 8.5rem);
   overflow-y: auto;
   box-shadow: var(--phoenix-box-shadow);
   z-index: 100;
+
+  /* Custom thin scrollbar to avoid clutter */
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--phoenix-text-color-secondary, #999);
+    border-radius: 4px;
+  }
 
   @media screen and (max-width: 768px) {
     top: 4rem;

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.html
@@ -45,7 +45,8 @@
     class="resize-handle corner"
     *ngIf="resizable"
     [hidden]="!showBody"
-    cdkDrag
-    (cdkDragMoved)="onResize()"
+    (pointerdown)="onResizeStart($event)"
+    (mousedown)="$event.stopPropagation()"
+    (touchstart)="$event.stopPropagation()"
   ></span>
 </div>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.scss
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.scss
@@ -85,6 +85,10 @@
     height: 1rem;
     cursor: nwse-resize;
     position: absolute;
+    bottom: 0;
+    right: 0;
+    /* Let the handle receive pointer moves instead of panning the page. */
+    touch-action: none;
 
     &.corner {
       border-right: 0.2rem solid var(--phoenix-text-color);

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.test.ts
@@ -20,6 +20,27 @@ describe('OverlayComponent', () => {
     toggleOrthographicView: jest.fn().mockReturnThis(),
   };
 
+  /**
+   * jsdom does not implement `PointerEvent`, so build a `MouseEvent` carrying
+   * the pointer id the component looks at.
+   */
+  const pointerEvent = (
+    type: string,
+    clientX: number,
+    clientY: number,
+    pointerId = 1,
+  ): PointerEvent => {
+    const event: any = new MouseEvent(type, { clientX, clientY });
+    event.pointerId = pointerId;
+    return event as PointerEvent;
+  };
+
+  const mockRect = (element: HTMLElement, width: number, height: number) => {
+    element.getBoundingClientRect = jest
+      .fn()
+      .mockReturnValue({ width, height, top: 0, left: 0 } as DOMRect);
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [PhoenixUIModule],
@@ -45,55 +66,90 @@ describe('OverlayComponent', () => {
 
   it('should initialize to not be resizable', () => {
     component.resizable = false;
-    component.ngAfterViewInit();
+    fixture.detectChanges();
+
     expect(component.resizeHandleCorner).toBeFalsy();
   });
 
-  it('should initialize to be resizable', async () => {
+  it('should initialize to be resizable', () => {
     component.resizable = true;
     component.showBody = true;
-    const computedStyle = getComputedStyle as any;
-    computedStyle.getPropertyValue = jest.fn().mockReturnValue('10px');
+    fixture.detectChanges();
 
-    // Creating a mock resize handle corner
-    component.resizeHandleCorner = new ElementRef(
-      document.createElement('span'),
-    );
-    component.ngAfterViewInit();
-
-    expect(component.resizeHandleCorner.nativeElement.style.bottom).toBe('0px');
-    expect(component.resizeHandleCorner.nativeElement.style.right).toBe('0px');
+    expect(component.resizeHandleCorner).toBeTruthy();
   });
 
-  describe('OverlayComponent with overlay element', () => {
+  describe('resizing', () => {
+    let card: HTMLElement;
+    let handle: HTMLElement;
+
     beforeEach(() => {
-      // Creating mock elements
       component.resizable = true;
       component.showBody = true;
-      component.resizeHandleCorner = new ElementRef(
-        document.createElement('span'),
-      );
-      component.overlayCard = new ElementRef(document.createElement('div'));
+
+      card = document.createElement('div');
+      handle = document.createElement('span');
+      mockRect(card, 400, 300);
+
+      component.overlayCard = new ElementRef(card);
+      component.resizeHandleCorner = new ElementRef(handle);
     });
 
-    it('should resize', () => {
-      jest.spyOn(component as any, 'setHandleTransform');
-      component.onResize();
+    it('should resize the overlay card as the pointer moves', () => {
+      component.onResizeStart(pointerEvent('pointerdown', 400, 300));
+      handle.dispatchEvent(pointerEvent('pointermove', 450, 360));
 
-      expect((component as any).setHandleTransform).toHaveBeenCalledWith(
-        component.overlayCard.nativeElement.getBoundingClientRect(),
-        component.resizeHandleCorner.nativeElement.getBoundingClientRect(),
-      );
+      expect(card.style.width).toBe('450px');
+      expect(card.style.height).toBe('360px');
     });
 
-    it('should reset resize handle position', () => {
-      jest.spyOn(component as any, 'setHandleTransform');
-      component.resetHandlePosition();
+    it('should not resize below the minimum size', () => {
+      component.onResizeStart(pointerEvent('pointerdown', 400, 300));
+      handle.dispatchEvent(pointerEvent('pointermove', 0, 0));
 
-      expect((component as any).setHandleTransform).toHaveBeenCalledWith(
-        component.overlayCard.nativeElement.getBoundingClientRect(),
-        component.resizeHandleCorner.nativeElement.getBoundingClientRect(),
-      );
+      expect(card.style.width).toBe('300px');
+      expect(card.style.height).toBe('100px');
+    });
+
+    it('should stop resizing once the pointer is released', () => {
+      component.onResizeStart(pointerEvent('pointerdown', 400, 300));
+      handle.dispatchEvent(pointerEvent('pointermove', 450, 360));
+      handle.dispatchEvent(pointerEvent('pointerup', 450, 360));
+
+      // Any further movement must not drag the overlay along with the cursor.
+      handle.dispatchEvent(pointerEvent('pointermove', 800, 800));
+
+      expect(card.style.width).toBe('450px');
+      expect(card.style.height).toBe('360px');
+    });
+
+    it('should stop resizing when the pointer capture is lost', () => {
+      component.onResizeStart(pointerEvent('pointerdown', 400, 300));
+      handle.dispatchEvent(pointerEvent('lostpointercapture', 400, 300));
+      handle.dispatchEvent(pointerEvent('pointermove', 800, 800));
+
+      expect(card.style.width).toBe('');
+    });
+
+    it('should restore the original size on Escape', () => {
+      component.onResizeStart(pointerEvent('pointerdown', 400, 300));
+      handle.dispatchEvent(pointerEvent('pointermove', 600, 500));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+      expect(card.style.width).toBe('400px');
+      expect(card.style.height).toBe('300px');
+
+      handle.dispatchEvent(pointerEvent('pointermove', 800, 800));
+
+      expect(card.style.width).toBe('400px');
+    });
+
+    it('should stop resizing when the component is destroyed', () => {
+      component.onResizeStart(pointerEvent('pointerdown', 400, 300));
+      component.ngOnDestroy();
+      handle.dispatchEvent(pointerEvent('pointermove', 800, 800));
+
+      expect(card.style.width).toBe('');
     });
   });
 });

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/overlay/overlay.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ContentChild,
   Input,
+  NgZone,
   ViewChild,
   type OnInit,
   type AfterViewInit,
@@ -9,11 +10,19 @@ import {
   ViewEncapsulation,
   ElementRef,
 } from '@angular/core';
-import { ResizeSensor } from 'css-element-queries';
 
 import { EventDisplayService } from '../../../services/event-display.service';
 
 let maxZIndex = 100;
+
+/** State of an in-progress resize of the overlay. */
+interface ResizeSession {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startWidth: number;
+  startHeight: number;
+}
 
 /**
  * Component for overlay panel.
@@ -55,9 +64,6 @@ export class OverlayComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Aspect ratio of the overlay view. */
   aspectRatio: number = window.innerWidth / window.innerHeight;
 
-  /** Bound resize handler for cleanup. */
-  private resizeHandler = () => this.resetHandlePosition();
-
   // ********************************************************************************
   // * Below code is specific to the overlay resize feature. (LOOK INTO CSS RESIZE) *
   // ********************************************************************************
@@ -75,9 +81,13 @@ export class OverlayComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Minimum resizable height */
   private MIN_RES_HEIGHT: number = 100;
 
+  /** The resize currently being dragged, or `null` if there is none. */
+  private resizeSession: ResizeSession | null = null;
+
   constructor(
     private eventDisplay: EventDisplayService,
     private elementRef: ElementRef,
+    private ngZone: NgZone,
   ) {}
 
   ngOnInit() {}
@@ -101,108 +111,191 @@ export class OverlayComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  /**
-   * Move the resizable handle to the bottom right after the component is created.
-   */
   ngAfterViewInit() {
     this.bringToFront();
-
-    if (this.resizable) {
-      const resizeHandleElement = this.resizeHandleCorner.nativeElement;
-      resizeHandleElement.style.bottom = '0';
-      resizeHandleElement.style.right = '0';
-
-      new ResizeSensor(this.overlayCard.nativeElement, () => {
-        this.resetHandlePosition();
-      });
-
-      window.addEventListener('resize', this.resizeHandler);
-    }
   }
 
   /**
-   * Clean up event listeners when the component is destroyed.
+   * Clean up any resize still in progress when the component is destroyed.
    */
   ngOnDestroy() {
-    window.removeEventListener('resize', this.resizeHandler);
+    this.stopResize();
   }
 
   /**
-   * Resize the overlay card when the resize handle is dragged.
+   * Start resizing the overlay card.
+   *
+   * The pointer is captured by the handle so that every subsequent move and,
+   * crucially, the closing `pointerup` are delivered to us even if the cursor
+   * leaves the handle or the window. Without the capture a fast drag can end
+   * outside the handle and leave the overlay glued to the cursor.
+   * @param event Pointer event that started the resize.
    */
-  onResize() {
-    const resizeHandleElement = this.resizeHandleCorner.nativeElement;
-    const overlayCardElement = this.overlayCard.nativeElement;
+  onResizeStart(event: PointerEvent) {
+    if (!this.resizable || this.resizeSession) {
+      return;
+    }
 
-    const dragRect = resizeHandleElement.getBoundingClientRect();
-    const overlayRect = overlayCardElement.getBoundingClientRect();
+    event.preventDefault();
+    this.bringToFront();
 
-    const width = dragRect.left - overlayRect.left + dragRect.width;
-    let height = dragRect.top - overlayRect.top + dragRect.height;
+    // The 3D overlay sizes its canvas, everything else sizes the whole card,
+    // so measure whichever one the drag is going to act on.
+    const startRect = (
+      this.overlayWindow?.nativeElement ?? this.overlayCard.nativeElement
+    ).getBoundingClientRect();
+    this.resizeSession = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startWidth: startRect.width,
+      startHeight: startRect.height,
+    };
 
-    this.setHandleTransform(overlayRect, dragRect);
+    const handle = this.resizeHandleCorner.nativeElement as HTMLElement;
+    try {
+      handle.setPointerCapture?.(event.pointerId);
+    } catch {
+      // Capturing is best effort; the listeners below still end the resize.
+    }
 
-    if (width > this.MIN_RES_WIDTH && height > this.MIN_RES_HEIGHT) {
-      if (this.keepAspectRatioFixed) {
-        height = width / this.aspectRatio;
+    // Resizing only writes to the DOM and the renderer, so it does not need to
+    // trigger change detection on every pointer move.
+    this.ngZone.runOutsideAngular(() => {
+      handle.addEventListener('pointermove', this.onResizeMove);
+      handle.addEventListener('pointerup', this.onResizeEnd);
+      handle.addEventListener('pointercancel', this.onResizeEnd);
+      handle.addEventListener('lostpointercapture', this.onResizeEnd);
+      document.addEventListener('keydown', this.onResizeKeyDown);
+    });
+  }
+
+  /** Resize the overlay to follow the pointer. */
+  private onResizeMove = (event: PointerEvent) => {
+    const session = this.resizeSession;
+    if (!session || event.pointerId !== session.pointerId) {
+      return;
+    }
+    // The button can be released where the page never sees it, e.g. outside the
+    // window. Noticing that the button is gone stops the overlay from staying
+    // glued to the cursor.
+    if (event.pointerType === 'mouse' && event.buttons === 0) {
+      this.stopResize();
+      return;
+    }
+    event.preventDefault();
+
+    const width = Math.max(
+      this.MIN_RES_WIDTH,
+      session.startWidth + (event.clientX - session.startX),
+    );
+    const height = Math.max(
+      this.MIN_RES_HEIGHT,
+      session.startHeight + (event.clientY - session.startY),
+    );
+
+    this.applySize(
+      width,
+      this.keepAspectRatioFixed ? width / this.aspectRatio : height,
+    );
+  };
+
+  /** End the resize once the pointer is released, cancelled or lost. */
+  private onResizeEnd = (event: PointerEvent) => {
+    if (
+      this.resizeSession &&
+      event.pointerId !== this.resizeSession.pointerId
+    ) {
+      return;
+    }
+    this.stopResize();
+  };
+
+  /** Abandon the resize and restore the original size on Escape. */
+  private onResizeKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Escape' || !this.resizeSession) {
+      return;
+    }
+    const { startWidth, startHeight } = this.resizeSession;
+    this.stopResize();
+    if (startWidth > 0 && startHeight > 0) {
+      this.applySize(startWidth, startHeight);
+    }
+  };
+
+  /**
+   * Stop the resize in progress, if any, releasing the pointer and detaching
+   * every listener added when it started.
+   */
+  private stopResize() {
+    const session = this.resizeSession;
+    if (!session) {
+      return;
+    }
+    this.resizeSession = null;
+
+    document.removeEventListener('keydown', this.onResizeKeyDown);
+
+    const handle = this.resizeHandleCorner?.nativeElement as HTMLElement;
+    if (!handle) {
+      return;
+    }
+    handle.removeEventListener('pointermove', this.onResizeMove);
+    handle.removeEventListener('pointerup', this.onResizeEnd);
+    handle.removeEventListener('pointercancel', this.onResizeEnd);
+    handle.removeEventListener('lostpointercapture', this.onResizeEnd);
+    try {
+      if (handle.hasPointerCapture?.(session.pointerId)) {
+        handle.releasePointerCapture(session.pointerId);
       }
-
-      if (this.overlayWindow?.nativeElement) {
-        const oldratioW = width / this.overlayWindow.nativeElement.width;
-        const oldratioH = height / this.overlayWindow.nativeElement.height;
-        this.eventDisplay
-          .getThreeManager()
-          .getOverlayRenderer()
-          .setSize(width, height);
-        this.eventDisplay
-          .getThreeManager()
-          .syncOverlayViewPort(oldratioW, oldratioH);
-      } else {
-        // Fallback for generic content that does not have a 3D canvas
-        this.overlayCard.nativeElement.style.width = width + 'px';
-        this.overlayCard.nativeElement.style.height = height + 'px';
-        const contentWrapper = this.overlayCard.nativeElement.querySelector(
-          '.overlay-card-content',
-        );
-        if (contentWrapper) {
-          contentWrapper.style.flex = '1';
-          contentWrapper.style.overflow = 'hidden';
-          contentWrapper.style.maxHeight = 'none';
-          const contentBody = contentWrapper.firstElementChild as HTMLElement;
-          if (contentBody) {
-            contentBody.style.width = '100%';
-            contentBody.style.height = '100%';
-            contentBody.style.maxWidth = 'none';
-            contentBody.style.maxHeight = 'none';
-          }
-        }
-      }
+    } catch {
+      // The pointer may already be gone; nothing left to release.
     }
   }
 
   /**
-   * Reset resize handle position.
+   * Resize the overlay content to the given size.
+   * @param width New width of the overlay content in pixels.
+   * @param height New height of the overlay content in pixels.
    */
-  resetHandlePosition() {
-    const resizeHandleElement = this.resizeHandleCorner.nativeElement;
+  private applySize(width: number, height: number) {
+    const canvas = this.overlayWindow?.nativeElement;
 
-    this.setHandleTransform(
-      this.overlayCard.nativeElement.getBoundingClientRect(),
-      resizeHandleElement.getBoundingClientRect(),
+    if (canvas) {
+      const oldratioW = width / canvas.width;
+      const oldratioH = height / canvas.height;
+      this.eventDisplay
+        .getThreeManager()
+        .getOverlayRenderer()
+        .setSize(width, height);
+      this.eventDisplay
+        .getThreeManager()
+        .syncOverlayViewPort(oldratioW, oldratioH);
+      return;
+    }
+
+    // Fallback for generic content that does not have a 3D canvas
+    const overlayCardElement = this.overlayCard.nativeElement;
+    overlayCardElement.style.width = width + 'px';
+    overlayCardElement.style.height = height + 'px';
+    const contentWrapper = overlayCardElement.querySelector(
+      '.overlay-card-content',
     );
-
-    resizeHandleElement.style.bottom = null;
-    resizeHandleElement.style.right = null;
-  }
-
-  /**
-   * Set the position of the resize handle using transform3d.
-   * @param overlayRect Bounding client rectangle of the overlay card.
-   * @param dragRect Bounding client rectangle of the resize handle.
-   */
-  private setHandleTransform(overlayRect: any, dragRect: any) {
-    const translateX = overlayRect.width - dragRect.width;
-    const translateY = overlayRect.height - dragRect.height;
-    this.resizeHandleCorner.nativeElement.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
+    if (contentWrapper) {
+      contentWrapper.style.flex = '1';
+      contentWrapper.style.overflow = 'auto';
+      contentWrapper.style.maxHeight = 'none';
+      const contentBody = contentWrapper.firstElementChild as HTMLElement;
+      if (contentBody) {
+        // Fill the card when there is room to spare, but keep the natural
+        // height when there is not so the wrapper can scroll instead of
+        // clipping the content.
+        contentBody.style.width = '100%';
+        contentBody.style.height = 'auto';
+        contentBody.style.minHeight = '100%';
+        contentBody.style.maxWidth = 'none';
+        contentBody.style.maxHeight = 'none';
+      }
+    }
   }
 }


### PR DESCRIPTION
I was doing a demo and I had an issue where I could not let the corner of the panel go. I think the diagnosis from claude is correct: I let go of the resize handle outside of the main window and so the mouse up was missed. I have to admit I've not fully understood this fix however.... so I will want to check the logic carefully. In local testing it does seem much better though.

Another issue I noticed was that it was very hard to use the phoenix menu as it was unusably compact. This single scroll window approach seems much better to me