### PR TITLE
fix(app): make histogram panel addition configurable

### DIFF
--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas-masterclass/atlas-masterclass.component.test.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas-masterclass/atlas-masterclass.component.test.ts
@@ -58,6 +58,10 @@ describe('AtlasMasterclassComponent', () => {
     expect(component.uiConfig.showMasterclassPanel).toBe(true);
   });
 
+  it('should enable the histogram panel', () => {
+    expect(component.uiConfig.showHistogramPanel).toBe(true);
+  });
+
   it('should use the ATLAS masterclass config', () => {
     expect(component.masterclassConfig.title).toContain('Masterclass');
     expect(component.masterclassConfig.particleTags.length).toBeGreaterThan(0);

--- a/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas-masterclass/atlas-masterclass.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-app/src/app/sections/atlas-masterclass/atlas-masterclass.component.ts
@@ -59,6 +59,7 @@ export class AtlasMasterclassComponent implements OnInit, OnDestroy {
     showCollectionsInfo: false,
     showGeometryBrowser: false,
     showMasterclassPanel: true,
+    showHistogramPanel: true,
   };
 
   /** ATLAS Z-path masterclass config (electron, muon, photon tags). */

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.html
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.html
@@ -72,7 +72,10 @@
   <app-share-link *ngIf="uiConfig.showShareLink"></app-share-link>
 
   <!-- Histogram panel -->
-  <app-histogram-panel [config]="histogramConfig"></app-histogram-panel>
+  <app-histogram-panel
+    *ngIf="uiConfig?.showHistogramPanel"
+    [config]="histogramConfig"
+  ></app-histogram-panel>
 
   <!-- Extra options -->
   <ng-content></ng-content>

--- a/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.ts
+++ b/packages/phoenix-ng/projects/phoenix-ui-components/lib/components/ui-menu/ui-menu.component.ts
@@ -28,6 +28,7 @@ export interface UIMenuConfig {
   showEtaPhiPanel?: boolean;
   showKinematicsPanel?: boolean;
   showMasterclassPanel?: boolean;
+  showHistogramPanel?: boolean;
 }
 
 export const defaultUIMenuConfig: UIMenuConfig = {
@@ -48,6 +49,7 @@ export const defaultUIMenuConfig: UIMenuConfig = {
   showEtaPhiPanel: true,
   showKinematicsPanel: true,
   showMasterclassPanel: false,
+  showHistogramPanel: false,
 };
 
 @Component({


### PR DESCRIPTION
As of #843 the histogram panel was appearing on all examples. This makes it off by default, and only enabled for the Masterclass example.