### PR TITLE
fix(event-display): menu node undefined toggle state

### DIFF
--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
@@ -125,12 +125,22 @@ export class PhoenixMenuNode {
    * @param value If the node itself and descendants are to be made true or false.
    */
   toggleSelfAndDescendants(value: boolean) {
+    // Whether this node is actually going from on to off, as opposed to being
+    // switched off again while already off - which happens whenever an
+    // ancestor is toggled off.
+    const isBeingSwitchedOff = !value && (this.toggleState ?? true);
+
     this.onToggle?.(value);
     this.toggleState = value;
     for (const child of this.children) {
       if (!value) {
-        // Save previous toggle state of children and toggle them false
-        this.childrenToggleState[child.name] = child.toggleState;
+        // Save previous toggle state of children and toggle them false. Only
+        // on the way from on to off: an already off node has children it has
+        // itself forced to false, and saving those would overwrite what they
+        // were before with the states this node imposed on them.
+        if (isBeingSwitchedOff) {
+          this.childrenToggleState[child.name] = child.toggleState;
+        }
         child.toggleSelfAndDescendants(value);
       } else {
         // Restore previous toggle state of children. There is no saved entry

--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
@@ -133,8 +133,13 @@ export class PhoenixMenuNode {
         this.childrenToggleState[child.name] = child.toggleState;
         child.toggleSelfAndDescendants(value);
       } else {
-        // Restore previous toggle state of children
-        child.toggleState = this.childrenToggleState[child.name];
+        // Restore previous toggle state of children. There is no saved entry
+        // for a child which was never toggled off through this node - for
+        // instance when this node was switched off by a loaded state rather
+        // than by its own toggle - so fall back to the child's current state
+        // instead of propagating `undefined` down the tree.
+        child.toggleState =
+          this.childrenToggleState[child.name] ?? child.toggleState ?? true;
         child.toggleSelfAndDescendants(child.toggleState);
       }
     }
@@ -229,7 +234,10 @@ export class PhoenixMenuNode {
 
     phoenixNodeJSON['name'] = this.name;
     phoenixNodeJSON['nodeLevel'] = this.nodeLevel;
-    phoenixNodeJSON['toggleState'] = this.toggleState;
+    // `?? true` so that a node whose toggle state was somehow lost is still
+    // serialised with one - `JSON.stringify` drops an `undefined` value
+    // entirely, and a state file missing the key cannot restore visibility.
+    phoenixNodeJSON['toggleState'] = this.toggleState ?? true;
     phoenixNodeJSON['childrenActive'] = this.childrenActive;
     phoenixNodeJSON['configs'] = this.configs;
     phoenixNodeJSON['children'] = [];
@@ -260,6 +268,18 @@ export class PhoenixMenuNode {
     if (jsonObject['toggleState'] !== undefined) {
       this.toggleState = jsonObject['toggleState'];
       this.onToggle?.(this.toggleState);
+    } else if (this.onToggle) {
+      // A node which can hide something is expected to carry a toggle state.
+      // Missing it means the scene can end up disagreeing with the file - the
+      // menu shows one thing, the state file says nothing - so say so rather
+      // than leaving the mismatch to be found on screen. Nodes without a
+      // toggle handler (the "Cut Options" style folders) are left alone, as
+      // hand-written configs routinely omit their toggle state.
+      console.warn(
+        `No toggle state for "${this.name}" in the saved state, so its ` +
+          'visibility is left as it is. The state was likely written by a ' +
+          'version of Phoenix which could drop the toggle state of a node.',
+      );
     }
 
     for (const configState of jsonObject['configs'] ?? []) {

--- a/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-node.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-node.test.ts
@@ -230,5 +230,72 @@ describe('PhoenixMenuNode', () => {
 
       expect(onChange).toHaveBeenCalledWith('#a8a8a8');
     });
+
+    it('should warn when a node which can be toggled has no toggle state', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const node = new PhoenixMenuNode('Pixel', undefined, jest.fn());
+
+      node.loadStateFromJSON({ name: 'Pixel' });
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Pixel'));
+      warn.mockRestore();
+    });
+
+    it('should not warn about a node which has nothing to toggle', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const node = new PhoenixMenuNode('Cut Options');
+
+      node.loadStateFromJSON({ name: 'Cut Options' });
+
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+  });
+
+  describe('toggleSelfAndDescendants', () => {
+    /** A group with two collections under it, as the event data menu is built. */
+    const eventDataGroup = () => {
+      const group = new PhoenixMenuNode('Hits', undefined, jest.fn());
+      group.addChild('Pixel', jest.fn());
+      group.addChild('SCT', jest.fn());
+      return group;
+    };
+
+    it('should restore the previous state of children toggled off through it', () => {
+      const group = eventDataGroup();
+      group.children[1].toggleSelfAndDescendants(false);
+
+      group.toggleSelfAndDescendants(false);
+      group.toggleSelfAndDescendants(true);
+
+      expect(group.children[0].toggleState).toBe(true);
+      expect(group.children[1].toggleState).toBe(false);
+    });
+
+    it('should not leave children without a toggle state when switched on first', () => {
+      const group = eventDataGroup();
+      // A loaded state switches the group off without descending into it, so
+      // nothing is remembered about the children.
+      group.loadStateFromJSON({ name: 'Hits', toggleState: false });
+
+      group.toggleSelfAndDescendants(true);
+
+      for (const child of group.children) {
+        expect(child.toggleState).toBe(true);
+        expect(child.onToggle).toHaveBeenCalledWith(true);
+      }
+    });
+
+    it('should save a toggle state for every node', () => {
+      const group = eventDataGroup();
+      group.loadStateFromJSON({ name: 'Hits', toggleState: false });
+      group.toggleSelfAndDescendants(true);
+      group.children[0].toggleSelfAndDescendants(false);
+
+      const state = savedState(group);
+
+      expect(state['children'][0]).toHaveProperty('toggleState', false);
+      expect(state['children'][1]).toHaveProperty('toggleState', true);
+    });
   });
 });

--- a/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-node.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/ui-manager/phoenix-menu/phoenix-menu-node.test.ts
@@ -286,6 +286,26 @@ describe('PhoenixMenuNode', () => {
       }
     });
 
+    it('should keep what children were before, when an ancestor is toggled off too', () => {
+      const root = new PhoenixMenuNode('Event Data', undefined, jest.fn());
+      const group = root.addChild('Hits', jest.fn());
+      group.addChild('Pixel', jest.fn());
+      group.addChild('SCT', jest.fn());
+
+      group.children[1].toggleSelfAndDescendants(false); // SCT off
+      group.toggleSelfAndDescendants(false); // the group off
+      root.toggleSelfAndDescendants(false); // and all of Event Data off
+
+      root.toggleSelfAndDescendants(true);
+      group.toggleSelfAndDescendants(true);
+
+      // Pixel was on before any of this, so it comes back on. Switching the
+      // group off through Event Data must not have overwritten that with the
+      // false the group had already imposed on it.
+      expect(group.children[0].toggleState).toBe(true);
+      expect(group.children[1].toggleState).toBe(false);
+    });
+
     it('should save a toggle state for every node', () => {
       const group = eventDataGroup();
       group.loadStateFromJSON({ name: 'Hits', toggleState: false });


### PR DESCRIPTION
Fixes #1022 (see that for details)

A second bug related to toggle memory being lost when a node is switch off when already off, was also fixed.