### PR TITLE
fix(event-display): keep a collection's color over a save and load

### DIFF
--- a/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
@@ -2,10 +2,14 @@ import { Color } from 'three';
 import { PrettySymbols } from '../../helpers/pretty-symbols';
 import { ColorManager } from '../three-manager/color-manager';
 import { PhoenixMenuNode } from './phoenix-menu/phoenix-menu-node';
-import { type ConfigSelect } from './phoenix-menu/config-types';
+import {
+  type ConfigColor,
+  type ConfigSelect,
+} from './phoenix-menu/config-types';
 
 /** Keys for options available for coloring event data by. */
 export enum ColorByOptionKeys {
+  COLLECTION = 'collection',
   CHARGE = 'charge',
   MOM = 'mom',
   VERTEX = 'vertex',
@@ -31,9 +35,18 @@ export class ColorOptions {
   private selectedColorByOption: ColorByOptionKeys;
   /** Phoenix menu node containing color configurations. */
   private colorOptionsFolder: PhoenixMenuNode;
+  /** Configuration holding the single color of the whole collection. */
+  private colorConfig: ConfigColor;
+  /** Configuration holding the selected option to color by. */
+  private colorByConfig?: ConfigSelect;
 
   /** All color by options possible. */
   private allColorByOptions: ColorByOption[] = [
+    {
+      key: ColorByOptionKeys.COLLECTION,
+      name: 'Collection color',
+      apply: this.applyCollectionColor.bind(this),
+    },
     {
       key: ColorByOptionKeys.CHARGE,
       name: 'Charge ' + PrettySymbols.getPrettySymbol('charge'),
@@ -94,15 +107,22 @@ export class ColorOptions {
       'color-options',
     );
 
-    this.colorOptionsFolder.addConfig({
+    this.colorConfig = {
       type: 'color',
       label: 'Color',
       color: collectionColor
         ? `#${collectionColor?.getHexString()}`
         : undefined,
-      onChange: (value) =>
-        this.colorManager.collectionColor(this.collectionName, value),
-    });
+      onChange: (value) => {
+        this.colorConfig.color = value;
+        // Giving the collection a single color is itself a choice of how to
+        // color it. Recording it keeps the menu honest, and stops the color
+        // being overwritten by another option when the state is loaded back.
+        this.selectColorByOption(ColorByOptionKeys.COLLECTION);
+        this.colorManager.collectionColor(this.collectionName, value);
+      },
+    };
+    this.colorOptionsFolder.addConfig(this.colorConfig);
 
     this.colorOptionsFolder.addConfig({
       type: 'button',
@@ -120,8 +140,12 @@ export class ColorOptions {
       colorByOptionsToInclude?.length &&
       colorByOptionsToInclude?.length > 0
     ) {
-      this.colorByOptions = this.allColorByOptions.filter((colorByOption) =>
-        colorByOptionsToInclude.includes(colorByOption.key),
+      // The collection color is always an option: without it there is no way
+      // to go back to a single color, or to express one in a saved state.
+      this.colorByOptions = this.allColorByOptions.filter(
+        (colorByOption) =>
+          colorByOption.key === ColorByOptionKeys.COLLECTION ||
+          colorByOptionsToInclude.includes(colorByOption.key),
       );
 
       this.initColorByOptions();
@@ -139,10 +163,6 @@ export class ColorOptions {
     this.selectedColorByOption = this.colorByOptions[0].key;
 
     // Configurations
-
-    // `value` is deliberately not set initially so that applying the config
-    // state on creation does not override the collection color. It is set on
-    // user selection so the choice survives saving/loading the menu state.
     const colorByConfig: ConfigSelect = {
       type: 'select',
       label: 'Color by',
@@ -162,7 +182,52 @@ export class ColorOptions {
       },
     };
 
+    this.colorByConfig = colorByConfig;
     this.colorOptionsFolder.addConfig(colorByConfig);
+
+    // The value is set after the config has been added, as adding it would
+    // otherwise apply the option and re-color a collection which is already
+    // drawn correctly. It is set at all so that the selected option is always
+    // part of the saved state, even if the user never changes it.
+    colorByConfig.value = this.colorByOptions[0].name;
+  }
+
+  /**
+   * Select an option to color by, without applying it. Used for choices which
+   * are made through another config, such as picking a color for the whole
+   * collection.
+   * @param key Key of the option to select.
+   */
+  private selectColorByOption(key: ColorByOptionKeys) {
+    const colorByOption = this.colorByOptions?.find(
+      (option) => option.key === key,
+    );
+    if (!colorByOption) {
+      // This collection has no color by options, so there is nothing to select.
+      return;
+    }
+
+    this.selectedColorByOption = colorByOption.key;
+    if (this.colorByConfig) {
+      this.colorByConfig.value = colorByOption.name;
+    }
+    this.onlySelectedColorByOption();
+  }
+
+  // Collection color options.
+
+  /**
+   * Apply the single color of the whole collection.
+   */
+  private applyCollectionColor() {
+    if (this.colorConfig.color === undefined) {
+      return;
+    }
+
+    this.colorManager.collectionColor(
+      this.collectionName,
+      this.colorConfig.color,
+    );
   }
 
   // Charge options.

--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
@@ -291,11 +291,14 @@ export class PhoenixMenuNode {
       // console.log('nodeConfig', nodeConfig);
       if (nodeConfig) {
         for (const prop in configState) {
-          if (prop === 'options' || prop === 'onChange') {
+          if (prop === 'options' || prop === 'onChange' || prop === 'hidden') {
             // The available options of a `select` are structural (derived from
             // the loaded event data), not user state - a saved state must not
             // overwrite them.
             // The function 'onChange' depends on the available options.
+            // Whether a config is shown is derived from the state which is
+            // being restored here, so it is left to the owner of the config to
+            // work out once everything has been applied.
             continue;
           }
           const key = prop as keyof typeof nodeConfig;

--- a/packages/phoenix-event-display/src/tests/loaders/jivexml-menu-integration.test.ts
+++ b/packages/phoenix-event-display/src/tests/loaders/jivexml-menu-integration.test.ts
@@ -78,12 +78,16 @@ describe('JiveXML to Phoenix menu integration', () => {
       return select?.options;
     };
 
+    // Every collection can be colored with its own single color; only the one
+    // with linked vertices can be colored by vertex.
     expect(getColorByOptions('Tracks_')).toEqual([
+      'Collection color',
       'Charge q',
       'Momentum |p|',
       'Vertex',
     ]);
     expect(getColorByOptions('OtherTracks')).toEqual([
+      'Collection color',
       'Charge q',
       'Momentum |p|',
     ]);

--- a/packages/phoenix-event-display/src/tests/managers/ui-manager/color-options.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/ui-manager/color-options.test.ts
@@ -1,11 +1,27 @@
 import { Color } from 'three';
-import { ColorOptions } from '../../../managers/ui-manager/color-options';
+import {
+  ColorByOptionKeys,
+  ColorOptions,
+} from '../../../managers/ui-manager/color-options';
 import { ColorManager } from '../../../managers/three-manager/color-manager';
 import { PhoenixMenuNode } from '../../../managers/ui-manager/phoenix-menu/phoenix-menu-node';
+
+/** The color by options a track collection is created with. */
+const TRACK_COLOR_BY_OPTIONS = [
+  ColorByOptionKeys.CHARGE,
+  ColorByOptionKeys.MOM,
+  ColorByOptionKeys.VERTEX,
+];
 
 describe('ColorOptions', () => {
   let colorManager: ColorManager;
   let collectionFolder: PhoenixMenuNode;
+
+  /** Get a config of the collection's "Color Options" node by label. */
+  const getConfig = (label: string) =>
+    collectionFolder
+      .findInTree('Color Options')
+      ?.configs.find((config) => config.label === label);
 
   beforeEach(() => {
     colorManager = {
@@ -22,11 +38,7 @@ describe('ColorOptions', () => {
   it('should show the color the collection was built with', () => {
     new ColorOptions(colorManager, collectionFolder, new Color(0xff0000));
 
-    const colorConfig = collectionFolder
-      .findInTree('Color Options')
-      ?.configs.find((config) => config.label === 'Color');
-
-    expect(colorConfig?.['color']).toBe('#ff0000');
+    expect(getConfig('Color')?.['color']).toBe('#ff0000');
   });
 
   it('should not color the collection when the options are created', () => {
@@ -56,5 +68,124 @@ describe('ColorOptions', () => {
       'CombinedMuonTracks',
       '#0adb2d',
     );
+  });
+
+  describe('color by', () => {
+    /** Create color options for a track collection colored `color`. */
+    const createTrackColorOptions = (color = 0xff8000) =>
+      new ColorOptions(
+        colorManager,
+        collectionFolder,
+        new Color(color),
+        TRACK_COLOR_BY_OPTIONS,
+      );
+
+    /** Select an option to color by, as the menu does. */
+    const selectColorBy = (option: string) =>
+      (getConfig('Color by') as any).onChange(option);
+
+    /**
+     * Save the state of the collection the way the state manager does, through
+     * JSON, so that loading it back cannot be affected by the live configs.
+     */
+    const saveState = () =>
+      JSON.parse(JSON.stringify(collectionFolder.getNodeState()));
+
+    it('should offer the collection color as the option selected to begin with', () => {
+      createTrackColorOptions();
+
+      const colorByConfig = getConfig('Color by');
+
+      expect(colorByConfig?.['options'][0]).toBe('Collection color');
+      expect(colorByConfig?.['value']).toBe('Collection color');
+    });
+
+    it('should not color the collection when the options are created', () => {
+      createTrackColorOptions();
+
+      expect(colorManager.collectionColor).not.toHaveBeenCalled();
+      expect(colorManager.colorObjectsByProperty).not.toHaveBeenCalled();
+    });
+
+    it('should select the collection color when one is picked', () => {
+      createTrackColorOptions();
+      selectColorBy('Charge q');
+
+      (getConfig('Color') as any).onChange('#0adb2d');
+
+      expect(getConfig('Color by')?.['value']).toBe('Collection color');
+      expect(colorManager.collectionColor).toHaveBeenLastCalledWith(
+        'CombinedMuonTracks',
+        '#0adb2d',
+      );
+    });
+
+    it('should keep the collection color over a save and load', () => {
+      createTrackColorOptions();
+      (getConfig('Color') as any).onChange('#0adb2d');
+
+      const state = saveState();
+      jest.clearAllMocks();
+      collectionFolder.loadStateFromJSON(state);
+
+      // The charge colors are still in the state, but they are not the way
+      // this collection is colored, so they must not be applied.
+      expect(colorManager.collectionColor).toHaveBeenCalledWith(
+        'CombinedMuonTracks',
+        '#0adb2d',
+      );
+      expect(colorManager.colorObjectsByProperty).not.toHaveBeenCalled();
+    });
+
+    it('should keep the color by option over a save and load', () => {
+      createTrackColorOptions();
+      selectColorBy('Charge q');
+
+      const state = saveState();
+      jest.clearAllMocks();
+      collectionFolder.loadStateFromJSON(state);
+
+      expect(getConfig('Color by')?.['value']).toBe('Charge q');
+      expect(colorManager.colorObjectsByProperty).toHaveBeenCalled();
+    });
+
+    it('should use the collection color of a state saved without one selected', () => {
+      // States saved before there was an option for the collection color hold
+      // the color of the collection, but no option to color by.
+      createTrackColorOptions();
+
+      const state = saveState();
+      const colorOptionsState = state['children'].find(
+        (child: any) => child.name === 'Color Options',
+      );
+      colorOptionsState.configs.find(
+        (config: any) => config.label === 'Color',
+      ).color = '#0adb2d';
+      delete colorOptionsState.configs.find(
+        (config: any) => config.label === 'Color by',
+      ).value;
+
+      collectionFolder.loadStateFromJSON(state);
+
+      expect(colorManager.collectionColor).toHaveBeenCalledWith(
+        'CombinedMuonTracks',
+        '#0adb2d',
+      );
+      expect(colorManager.colorObjectsByProperty).not.toHaveBeenCalled();
+    });
+
+    it('should only show the configs of the selected option after a load', () => {
+      createTrackColorOptions();
+      selectColorBy('Charge q');
+      const state = saveState();
+
+      // Whether a config is hidden is derived from the selected option, so a
+      // state saved with another one selected must not bring its own back.
+      selectColorBy('Collection color');
+      collectionFolder.loadStateFromJSON(state);
+
+      expect(getConfig('q=1')?.hidden).toBe(false);
+      expect(getConfig('|p| min')?.hidden).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Fixes #1023.

### The problem

A collection's **Color** does not survive a save/load round trip. Save a state with a track collection coloured orange, reload the event with it, and the tracks come back coloured by charge while the menu swatch still reads `#ff8000`.

`selectedColorByOption` was initialised to the first colour-by option — charge, for tracks — even though nothing had been coloured by charge and the collection was drawn in its own colour. Loading a state applies the stored configs in order, so `Color` painted the collection, and the `q=…` swatches immediately after it repainted it, because their handlers check `selectedColorByOption === CHARGE` and that was true by default.

There was also no way to express "use one colour for this collection" in a saved state: the select's `value` was only set if the user actively picked an option, and no option meant "the collection colour" anyway.

### The change

- **"Collection color" is now a colour-by option**, first in the list and selected to begin with. `selectedColorByOption` is therefore truthful from the start, and the charge/momentum handlers correctly do nothing until their option is chosen.
- **The selected option is always written to the saved state.** `value` is set after the config is added, so adding it does not re-colour a collection that is already drawn correctly — the reason it was previously left unset.
- **Picking a colour for the collection selects that option**, since choosing a single colour is itself a choice of how to colour the collection.
- **`hidden` is no longer restored from a saved state.** It is derived from the selected option, so restoring it made the menu show the configs of whichever option was selected when the state was written. It joins `options` and `onChange` in the list of config properties `loadStateFromJSON` leaves alone.

### Effect on existing state files

A state saved before this change holds no selected option, so its collection colour is now restored rather than being overwritten by the charge colours the file also holds. This fixes the ATLAS deployment's saved configurations without editing them — the case in #1023 where the tracks were expected to be orange and came out red.

### Tests

`color-options.test.ts` gains cases for the round trip in both directions (collection colour kept; charge kept), for a legacy state with no selected option, and for the derived `hidden` flags. The saved state is round-tripped through JSON, as the state manager does, so that the live config objects cannot mask a failure.

`jivexml-menu-integration.test.ts` asserts the exact list of colour-by options, so its expectations gain the new entry.

Full `phoenix-event-display` suite: 379 passed / 44 suites. ESLint, Prettier and `tsc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
