### PR TITLE
feat(event-display): put "Color by" first and color at random from seed

### DIFF
--- a/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
+++ b/packages/phoenix-event-display/src/managers/three-manager/color-manager.ts
@@ -9,8 +9,6 @@ import {
   type ShaderMaterial,
 } from 'three';
 import { SceneManager } from './scene-manager';
-import { PhoenixMenuNode } from '../ui-manager/phoenix-menu/phoenix-menu-node';
-import { type ConfigColor } from '../ui-manager/phoenix-menu/config-types';
 
 /**
  * Color manager for three.js functions related to coloring of objects.
@@ -89,12 +87,8 @@ export class ColorManager {
   /**
    * Changes the color of all objects inside an event data collection to some random color.
    * @param collectionName Name of the collection.
-   * @param optionsFolder Reporting random color back to the menu color box.
    */
-  public collectionColorRandom(
-    collectionName: string,
-    optionsFolder?: PhoenixMenuNode,
-  ) {
+  public collectionColorRandom(collectionName: string) {
     if (!this.sceneManager || !this.sceneManager.getScene()) {
       return;
     }
@@ -108,17 +102,6 @@ export class ColorManager {
           child.traverse((object) => {
             const randomColor = Math.floor(Math.random() * 0xffffff);
             setColorForObject(object, randomColor);
-            if (typeof optionsFolder === 'undefined') {
-              return;
-            }
-            if (optionsFolder.configs.length < 1) {
-              return;
-            }
-            if (optionsFolder.configs[0].type !== 'color') {
-              return;
-            }
-            const configColor = optionsFolder.configs[0] as ConfigColor;
-            configColor.color = `#${randomColor.toString(16)}`;
           });
         }
       }

--- a/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/color-options.ts
@@ -10,10 +10,19 @@ import {
 /** Keys for options available for coloring event data by. */
 export enum ColorByOptionKeys {
   COLLECTION = 'collection',
+  RANDOM = 'random',
   CHARGE = 'charge',
   MOM = 'mom',
   VERTEX = 'vertex',
 }
+
+/**
+ * Type for the "Color by" select. It carries the seed of the random colors, so
+ * that the seed is saved and restored with the rest of the menu state - the
+ * seed has to be back in place before the select is applied, and every property
+ * of a config is restored before that config is applied.
+ */
+type ConfigColorBySelect = ConfigSelect & { seed?: number };
 
 /** Type for a single color by option. */
 type ColorByOption = {
@@ -37,15 +46,24 @@ export class ColorOptions {
   private colorOptionsFolder: PhoenixMenuNode;
   /** Configuration holding the single color of the whole collection. */
   private colorConfig: ConfigColor;
+  /** The single color the whole collection is drawn in. */
+  private collectionColor?: string;
   /** Configuration holding the selected option to color by. */
-  private colorByConfig?: ConfigSelect;
+  private colorByConfig: ConfigColorBySelect;
 
   /** All color by options possible. */
   private allColorByOptions: ColorByOption[] = [
     {
       key: ColorByOptionKeys.COLLECTION,
       name: 'Collection color',
+      initialize: this.initCollectionColorOptions.bind(this),
       apply: this.applyCollectionColor.bind(this),
+    },
+    {
+      key: ColorByOptionKeys.RANDOM,
+      name: 'Random',
+      initialize: this.initRandomColorOptions.bind(this),
+      apply: this.applyRandomColorOptions.bind(this),
     },
     {
       key: ColorByOptionKeys.CHARGE,
@@ -107,53 +125,32 @@ export class ColorOptions {
       'color-options',
     );
 
-    this.colorConfig = {
-      type: 'color',
-      label: 'Color',
-      color: collectionColor
-        ? `#${collectionColor?.getHexString()}`
-        : undefined,
-      onChange: (value) => {
-        this.colorConfig.color = value;
-        // Giving the collection a single color is itself a choice of how to
-        // color it. Recording it keeps the menu honest, and stops the color
-        // being overwritten by another option when the state is loaded back.
-        this.selectColorByOption(ColorByOptionKeys.COLLECTION);
-        this.colorManager.collectionColor(this.collectionName, value);
-      },
-    };
-    this.colorOptionsFolder.addConfig(this.colorConfig);
+    this.collectionColor = collectionColor
+      ? `#${collectionColor?.getHexString()}`
+      : undefined;
 
-    this.colorOptionsFolder.addConfig({
-      type: 'button',
-      label: 'Random',
-      onClick: () =>
-        this.colorManager.collectionColorRandom(
-          this.collectionName,
-          this.colorOptionsFolder,
-        ),
-    });
+    // Check which color by options are to be included. The collection color
+    // and a random one need nothing of the event data, so every collection can
+    // be colored by them: without the first there is no way back to a single
+    // color, or to express one in a saved state. The collection color comes
+    // first, as it is what a collection is drawn with to begin with.
+    const alwaysIncluded = [
+      ColorByOptionKeys.COLLECTION,
+      ColorByOptionKeys.RANDOM,
+    ];
+    this.colorByOptions = this.allColorByOptions.filter(
+      (colorByOption) =>
+        alwaysIncluded.includes(colorByOption.key) ||
+        colorByOptionsToInclude?.includes(colorByOption.key),
+    );
 
-    // Check which color by options are to be included.
-
-    if (
-      colorByOptionsToInclude?.length &&
-      colorByOptionsToInclude?.length > 0
-    ) {
-      // The collection color is always an option: without it there is no way
-      // to go back to a single color, or to express one in a saved state.
-      this.colorByOptions = this.allColorByOptions.filter(
-        (colorByOption) =>
-          colorByOption.key === ColorByOptionKeys.COLLECTION ||
-          colorByOptionsToInclude.includes(colorByOption.key),
-      );
-
-      this.initColorByOptions();
-      this.colorByOptions.forEach((colorByOption) =>
-        colorByOption.initialize?.(),
-      );
-      this.onlySelectedColorByOption();
-    }
+    // The selector is added before the configs of any option, so that the
+    // choice sits above the settings it governs.
+    this.initColorByOptions();
+    this.colorByOptions.forEach((colorByOption) =>
+      colorByOption.initialize?.(),
+    );
+    this.onlySelectedColorByOption();
   }
 
   /**
@@ -163,9 +160,10 @@ export class ColorOptions {
     this.selectedColorByOption = this.colorByOptions[0].key;
 
     // Configurations
-    const colorByConfig: ConfigSelect = {
+    const colorByConfig: ConfigColorBySelect = {
       type: 'select',
       label: 'Color by',
+      seed: ColorOptions.newRandomSeed(),
       options: this.colorByOptions.map((colorByOption) => colorByOption.name),
       onChange: (updatedColorByOption) => {
         const newColorByOption = this.colorByOptions.find(
@@ -192,42 +190,101 @@ export class ColorOptions {
     colorByConfig.value = this.colorByOptions[0].name;
   }
 
-  /**
-   * Select an option to color by, without applying it. Used for choices which
-   * are made through another config, such as picking a color for the whole
-   * collection.
-   * @param key Key of the option to select.
-   */
-  private selectColorByOption(key: ColorByOptionKeys) {
-    const colorByOption = this.colorByOptions?.find(
-      (option) => option.key === key,
-    );
-    if (!colorByOption) {
-      // This collection has no color by options, so there is nothing to select.
-      return;
-    }
-
-    this.selectedColorByOption = colorByOption.key;
-    if (this.colorByConfig) {
-      this.colorByConfig.value = colorByOption.name;
-    }
-    this.onlySelectedColorByOption();
-  }
-
   // Collection color options.
+
+  /**
+   * Initialize the options for coloring the whole collection in one color.
+   */
+  private initCollectionColorOptions() {
+    this.colorConfig = {
+      type: 'color',
+      label: 'Color',
+      group: ColorByOptionKeys.COLLECTION,
+      color: this.collectionColor,
+      onChange: (value) => {
+        this.collectionColor = value;
+
+        // A saved state applies every color it holds, including this one when
+        // the collection is colored by something else - which would repaint
+        // over that. The swatch is hidden unless it is the selected option, so
+        // the user cannot reach it out of turn either.
+        if (this.selectedColorByOption === ColorByOptionKeys.COLLECTION) {
+          this.colorManager.collectionColor(this.collectionName, value);
+        }
+      },
+    };
+    this.colorOptionsFolder.addConfig(this.colorConfig);
+  }
 
   /**
    * Apply the single color of the whole collection.
    */
   private applyCollectionColor() {
-    if (this.colorConfig.color === undefined) {
+    if (this.collectionColor === undefined) {
       return;
     }
 
     this.colorManager.collectionColor(
       this.collectionName,
-      this.colorConfig.color,
+      this.collectionColor,
     );
+  }
+
+  // Random options.
+
+  /**
+   * Initialize random color options.
+   */
+  private initRandomColorOptions() {
+    this.colorOptionsFolder.addConfig({
+      type: 'button',
+      label: 'Random',
+      group: ColorByOptionKeys.RANDOM,
+      onClick: () => {
+        this.colorByConfig.seed = ColorOptions.newRandomSeed();
+        this.applyRandomColorOptions();
+      },
+    });
+  }
+
+  /**
+   * Apply random color options, giving each object of the collection its own
+   * color so that objects drawn on top of each other can be told apart.
+   */
+  private applyRandomColorOptions() {
+    // The objects of a collection are always built in the same order, so their
+    // position in it identifies them well enough to color them from the seed.
+    let objectIndex = 0;
+    this.colorManager.colorObjectsByComputedColor(this.collectionName, () =>
+      this.randomColor(objectIndex++),
+    );
+  }
+
+  /**
+   * Get a new seed for the random colors.
+   * @returns A seed for the random colors.
+   */
+  private static newRandomSeed(): number {
+    return Math.floor(Math.random() * 0xffffffff);
+  }
+
+  /**
+   * Get the random color of an object from the seed and the object's position
+   * in the collection, so that the same seed always gives the same colors and
+   * a saved state is restored as it was.
+   * @param objectIndex Position of the object in the collection.
+   * @returns The color for the object.
+   */
+  private randomColor(objectIndex: number): Color {
+    let hash = (this.colorByConfig.seed ?? 0) + objectIndex * 0x9e3779b1;
+    hash = Math.imul(hash ^ (hash >>> 16), 0x21f0aaad);
+    hash = Math.imul(hash ^ (hash >>> 15), 0x735a2d97);
+    hash = (hash ^ (hash >>> 15)) >>> 0;
+
+    // Picking a hue rather than a color keeps every object clearly visible and
+    // clearly different, which coloring at random in RGB does not - that can
+    // land on colors close to the background, or close to each other.
+    return new Color().setHSL((hash % 360) / 360, 0.7, 0.55);
   }
 
   // Charge options.

--- a/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
+++ b/packages/phoenix-event-display/src/managers/ui-manager/phoenix-menu/phoenix-menu-node.ts
@@ -321,14 +321,21 @@ export class PhoenixMenuNode {
       // console.log('nodeConfig', nodeConfig);
       if (nodeConfig) {
         for (const prop in configState) {
-          if (prop === 'options' || prop === 'onChange' || prop === 'hidden') {
+          if (
+            prop === 'options' ||
+            prop === 'onChange' ||
+            prop === 'group' ||
+            prop === 'hidden'
+          ) {
             // The available options of a `select` are structural (derived from
             // the loaded event data), not user state - a saved state must not
             // overwrite them.
             // The function 'onChange' depends on the available options.
             // Whether a config is shown is derived from the state which is
             // being restored here, so it is left to the owner of the config to
-            // work out once everything has been applied.
+            // work out once everything has been applied. The `group` it is
+            // derived from is structural too: a state written by an older
+            // version of Phoenix can group a config differently, or not at all.
             continue;
           }
           const key = prop as keyof typeof nodeConfig;

--- a/packages/phoenix-event-display/src/tests/loaders/jivexml-menu-integration.test.ts
+++ b/packages/phoenix-event-display/src/tests/loaders/jivexml-menu-integration.test.ts
@@ -78,16 +78,18 @@ describe('JiveXML to Phoenix menu integration', () => {
       return select?.options;
     };
 
-    // Every collection can be colored with its own single color; only the one
-    // with linked vertices can be colored by vertex.
+    // Every collection can be colored with its own single color or at random;
+    // only the one with linked vertices can be colored by vertex.
     expect(getColorByOptions('Tracks_')).toEqual([
       'Collection color',
+      'Random',
       'Charge q',
       'Momentum |p|',
       'Vertex',
     ]);
     expect(getColorByOptions('OtherTracks')).toEqual([
       'Collection color',
+      'Random',
       'Charge q',
       'Momentum |p|',
     ]);

--- a/packages/phoenix-event-display/src/tests/managers/ui-manager/color-options.test.ts
+++ b/packages/phoenix-event-display/src/tests/managers/ui-manager/color-options.test.ts
@@ -107,16 +107,53 @@ describe('ColorOptions', () => {
       expect(colorManager.colorObjectsByProperty).not.toHaveBeenCalled();
     });
 
-    it('should select the collection color when one is picked', () => {
+    it('should put the selector above the configs of the selected option', () => {
+      createTrackColorOptions();
+
+      const configs = collectionFolder.findInTree('Color Options')?.configs;
+
+      expect(configs?.[0].label).toBe('Color by');
+      expect(
+        configs
+          ?.filter((config) => !config.hidden)
+          .map((config) => config.label),
+      ).toEqual(['Color by', 'Color']);
+    });
+
+    it('should hide the collection color when coloring by something else', () => {
       createTrackColorOptions();
       selectColorBy('Charge q');
 
+      expect(getConfig('Color')?.hidden).toBe(true);
+      expect(
+        collectionFolder
+          .findInTree('Color Options')
+          ?.configs.filter((config) => !config.hidden)
+          .map((config) => config.label),
+      ).toEqual(['Color by', 'q=-1', 'q=0', 'q=1']);
+    });
+
+    it('should not repaint the collection while coloring by something else', () => {
+      // A saved state applies every color it holds, this one included, and the
+      // selector is restored before it.
+      createTrackColorOptions();
+      selectColorBy('Charge q');
+      jest.clearAllMocks();
+
       (getConfig('Color') as any).onChange('#0adb2d');
 
-      expect(getConfig('Color by')?.['value']).toBe('Collection color');
+      expect(colorManager.collectionColor).not.toHaveBeenCalled();
+      expect(getConfig('Color by')?.['value']).toBe('Charge q');
+    });
+
+    it('should go back to the collection color when it is selected again', () => {
+      createTrackColorOptions();
+      selectColorBy('Charge q');
+      selectColorBy('Collection color');
+
       expect(colorManager.collectionColor).toHaveBeenLastCalledWith(
         'CombinedMuonTracks',
-        '#0adb2d',
+        '#ff8000',
       );
     });
 
@@ -174,6 +211,69 @@ describe('ColorOptions', () => {
       expect(colorManager.colorObjectsByProperty).not.toHaveBeenCalled();
     });
 
+    it('should offer the collection color and a random one to any collection', () => {
+      // Neither needs anything of the event data, so a collection with no
+      // other option - hits, jets - can still be colored by them.
+      new ColorOptions(colorManager, collectionFolder, new Color(0xff8000));
+
+      expect(getConfig('Color by')?.['options']).toEqual([
+        'Collection color',
+        'Random',
+      ]);
+    });
+
+    it('should give each object its own color when coloring at random', () => {
+      createTrackColorOptions();
+      selectColorBy('Random');
+
+      expect(colorManager.colorObjectsByComputedColor).toHaveBeenCalled();
+      expect(
+        collectionFolder
+          .findInTree('Color Options')
+          ?.configs.filter((config) => !config.hidden)
+          .map((config) => config.label),
+      ).toEqual(['Color by', 'Random']);
+    });
+
+    /** Color the first few objects of the collection at random. */
+    const randomColors = () => {
+      (colorManager.colorObjectsByComputedColor as jest.Mock).mockClear();
+      selectColorBy('Random');
+      const getColor = (colorManager.colorObjectsByComputedColor as jest.Mock)
+        .mock.calls[0][1];
+      return [0, 1, 2, 3].map(() => getColor({}).getHexString());
+    };
+
+    it('should give every object a different random color', () => {
+      createTrackColorOptions();
+
+      const colors = randomColors();
+
+      expect(new Set(colors).size).toBe(colors.length);
+    });
+
+    it('should give new random colors only when they are asked for', () => {
+      createTrackColorOptions();
+
+      const colors = randomColors();
+      expect(randomColors()).toEqual(colors);
+
+      (getConfig('Random') as any).onClick();
+      expect(randomColors()).not.toEqual(colors);
+    });
+
+    it('should keep a random coloring over a save and load', () => {
+      createTrackColorOptions();
+      const colors = randomColors();
+
+      const state = saveState();
+      collectionFolder = new PhoenixMenuNode('CombinedMuonTracks');
+      createTrackColorOptions();
+      collectionFolder.loadStateFromJSON(state);
+
+      expect(randomColors()).toEqual(colors);
+    });
+
     it('should only show the configs of the selected option after a load', () => {
       createTrackColorOptions();
       selectColorBy('Charge q');
@@ -186,6 +286,32 @@ describe('ColorOptions', () => {
 
       expect(getConfig('q=1')?.hidden).toBe(false);
       expect(getConfig('|p| min')?.hidden).toBe(true);
+    });
+
+    it('should group its configs itself rather than take the grouping from a state', () => {
+      // States saved before the collection color and the random one were
+      // options hold a "Color" and a "Random" which belonged to no group.
+      createTrackColorOptions();
+
+      const state = saveState();
+      const colorOptionsState = state['children'].find(
+        (child: any) => child.name === 'Color Options',
+      );
+      for (const label of ['Color', 'Random']) {
+        delete colorOptionsState.configs.find(
+          (config: any) => config.label === label,
+        ).group;
+      }
+      delete colorOptionsState.configs.find(
+        (config: any) => config.label === 'Color by',
+      ).value;
+
+      collectionFolder.loadStateFromJSON(state);
+
+      expect(getConfig('Color')?.group).toBe(ColorByOptionKeys.COLLECTION);
+      expect(getConfig('Random')?.group).toBe(ColorByOptionKeys.RANDOM);
+      expect(getConfig('Color')?.hidden).toBe(false);
+      expect(getConfig('Random')?.hidden).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Before:
<img width="251" height="233" alt="image" src="https://github.com/user-attachments/assets/a2efa4fd-6da9-4694-b191-4f14f385d53d" />


The color options menu showed the collection's color swatch and a "Random" button above the "Color by" selector, so the controls for a single color sat outside the mechanism which shows only the configs of the selected option. The selector now comes first, and the collection color is grouped under its own option, so it appears only when it is chosen - as the charge and momentum controls already did.

Picking a color no longer selects the collection color option. That was safe only while the swatch sat above the selector, as a saved state applies its configs in file order and the selector, coming after, had the last word. With the selector first, restoring a state colored by charge would have applied charge and then had the stored swatch flip the option back and repaint the collection, which is the fault in #1023 the other way round. The swatch instead repaints only while its option is selected, and is hidden otherwise, so it cannot be reached out of turn.

Coloring at random is now an option to color by rather than a button which painted over whatever was selected. It is seeded, with the seed kept on the selector so that it is restored before the option is applied: the same seed gives the same colors, so a saved random coloring comes back as it was, and the "Random" button re-rolls it. It previously wrote one arbitrary object's color into the swatch, which was then all that was saved, so reloading painted the whole collection that single color. Colors are picked by hue rather than in RGB, which keeps objects distinguishable from each other and from the background.

Both options are offered for every collection, as neither needs anything of the event data.

`group` is no longer restored from a saved state, joining `hidden` which it is derived from. A state written by an older version of Phoenix groups the collection color and "Random" differently, or not at all.